### PR TITLE
Change default search columns for `Incident`

### DIFF
--- a/library/Noma/Model/Incident.php
+++ b/library/Noma/Model/Incident.php
@@ -44,7 +44,7 @@ class Incident extends Model
 
     public function getSearchColumns()
     {
-        return ['severity'];
+        return ['object.host', 'object.service'];
     }
 
     public function getDefaultSort()


### PR DESCRIPTION
The default search columns for incident list must be either `object.host` or `object.service`.

fix #83 