### PR TITLE
Change default search columns for event list

### DIFF
--- a/library/Noma/Model/Event.php
+++ b/library/Noma/Model/Event.php
@@ -50,7 +50,7 @@ class Event extends Model
 
     public function getSearchColumns()
     {
-        return ['time'];
+        return ['object.host', 'object.service'];
     }
 
     public function getDefaultSort()


### PR DESCRIPTION
The default search columns for event list must be either `object.host` or `object.service`.

fix #84 