### PR TITLE
Update/create time period entries efficiently

### DIFF
--- a/library/Notifications/Model/ScheduleMember.php
+++ b/library/Notifications/Model/ScheduleMember.php
@@ -4,6 +4,8 @@
 
 namespace Icinga\Module\Notifications\Model;
 
+use ipl\Orm\Behavior\Binary;
+use ipl\Orm\Behaviors;
 use ipl\Orm\Model;
 use ipl\Orm\Relations;
 
@@ -26,8 +28,16 @@ class ScheduleMember extends Model
     {
         return [
             'contact_id',
-            'contactgroup_id'
+            'contactgroup_id',
+            'membership_hash'
         ];
+    }
+
+    public function createBehaviors(Behaviors $behaviors)
+    {
+        $behaviors->add(new Binary([
+            'membership_hash'
+        ]));
     }
 
     public function createRelations(Relations $relations)


### PR DESCRIPTION
Currently a new time period gets created whenever a time period entry with the same group of contacts and/or contact groups for a given schedule. This nullifies the reason for existence of time periods.

Time periods should act as a bridge between the time period entries and the schedules.

Hence, time periods for a group of contacts and/or contact groups should be same across all time period entries for in a given schedule.

A new time period for a new time period entry should be generated only if there is no existing time period for the given schedule and the group of contacts and/contact groups. If another time period entry is created for the same group of contacts and/or contact groups in the same schedule, existing time period or these entries should be used.