### PR TITLE
Add data base target `_main` to controller index action tabs

### DIFF
--- a/application/controllers/ContactsController.php
+++ b/application/controllers/ContactsController.php
@@ -182,11 +182,13 @@ class ContactsController extends CompatController
                     'url'           => Url::fromPath('notifications/schedules'),
                     'baseTarget'    => '_main'
                 ])->add('event-rules', [
-                    'label' => $this->translate('Event Rules'),
-                    'url'   => Url::fromPath('notifications/event-rules')
+                    'label'      => $this->translate('Event Rules'),
+                    'url'        => Url::fromPath('notifications/event-rules'),
+                    'baseTarget' => '_main'
                 ])->add('contacts', [
-                    'label' => $this->translate('Contacts'),
-                    'url'   => Url::fromRequest()
+                    'label'      => $this->translate('Contacts'),
+                    'url'        => Url::fromRequest(),
+                    'baseTarget' => '_main'
                 ]);
         }
 

--- a/application/controllers/EventRulesController.php
+++ b/application/controllers/EventRulesController.php
@@ -243,11 +243,13 @@ class EventRulesController extends CompatController
                     'url'           => Url::fromPath('notifications/schedules'),
                     'baseTarget'    => '_main'
                 ])->add('event-rules', [
-                    'label' => $this->translate('Event Rules'),
-                    'url'   => Url::fromPath('notifications/event-rules')
+                    'label'      => $this->translate('Event Rules'),
+                    'url'        => Url::fromPath('notifications/event-rules'),
+                    'baseTarget' => '_main'
                 ])->add('contacts', [
-                    'label' => $this->translate('Contacts'),
-                    'url'   => Url::fromPath('notifications/contacts')
+                    'label'      => $this->translate('Contacts'),
+                    'url'        => Url::fromPath('notifications/contacts'),
+                    'baseTarget' => '_main'
                 ]);
         }
 


### PR DESCRIPTION
When switching to another tab in `col1` while `col2` is active, `col2` must also be closed, as it is not related to the currently active tab in `col1`.

<img width="1247" alt="Bildschirmfoto 2023-09-19 um 11 02 59" src="https://github.com/Icinga/icinga-notifications-web/assets/57616252/1562498d-359a-40ab-9986-8174219b047b">
