### PR TITLE
Database: Use module name as default backend name

### DIFF
--- a/library/Notifications/Common/Database.php
+++ b/library/Notifications/Common/Database.php
@@ -47,7 +47,7 @@ final class Database
     private static function getConnection(): Connection
     {
         $config = new SqlConfig(ResourceFactory::getResourceConfig(
-            AppConfig::module('notifications')->get('database', 'resource')
+            AppConfig::module('notifications')->get('database', 'resource', 'notifications')
         ));
 
         $config->options = [PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_OBJ];


### PR DESCRIPTION
This should determine automatically if the backend resource is named after the module name.