### PR TITLE
ObjectTags: Remove superfluous table name prefix from the column definition

### DIFF
--- a/library/Notifications/Model/Behavior/ObjectTags.php
+++ b/library/Notifications/Model/Behavior/ObjectTags.php
@@ -68,12 +68,7 @@ class ObjectTags implements RewriteColumnBehavior, QueryAwareBehavior
 
     public function rewriteColumnDefinition(ColumnDefinition $def, string $relation): void
     {
-        $parts = explode('.', substr($relation, 0, -4));
-        $objectType = array_pop($parts);
-
-        $name = $def->getName();
-        // Programmatically translated since the full definition is available in class ObjectSuggestions
-        $def->setLabel(sprintf(t(ucfirst($objectType) . ' %s', '..<tag-name>'), $name));
+        $def->setLabel(ucfirst($def->getName()));
     }
 
     public function isSelectableColumn(string $name): bool

--- a/library/Notifications/Model/ObjectExtraTag.php
+++ b/library/Notifications/Model/ObjectExtraTag.php
@@ -9,6 +9,13 @@ use ipl\Orm\Behaviors;
 use ipl\Orm\Model;
 use ipl\Orm\Relations;
 
+/**
+ * ObjectExtraTag database model
+ *
+ * @property int $object_id
+ * @property string $tag
+ * @property string $value
+ */
 class ObjectExtraTag extends Model
 {
     public function getTableName()

--- a/library/Notifications/Model/ObjectIdTag.php
+++ b/library/Notifications/Model/ObjectIdTag.php
@@ -9,6 +9,13 @@ use ipl\Orm\Behaviors;
 use ipl\Orm\Model;
 use ipl\Orm\Relations;
 
+/**
+ * ObjectIdTag database model
+ *
+ * @property int $object_id
+ * @property string $tag
+ * @property string $value
+ */
 class ObjectIdTag extends Model
 {
     public function getTableName(): string

--- a/library/Notifications/Web/Control/SearchBar/ObjectSuggestions.php
+++ b/library/Notifications/Web/Control/SearchBar/ObjectSuggestions.php
@@ -185,7 +185,7 @@ class ObjectSuggestions extends Suggestions
         // Custom variables only after the columns are exhausted and there's actually a chance the user sees them
         foreach ([new ObjectIdTag(), new ObjectExtraTag()] as $model) {
             $titleAdded = false;
-            /** @var Model $tag */
+            /** @var ObjectIdTag|ObjectExtraTag $tag */
             foreach ($this->queryTags($model, $searchTerm) as $tag) {
                 $isIdTag = $tag instanceof ObjectIdTag;
 
@@ -199,10 +199,8 @@ class ObjectSuggestions extends Suggestions
                 }
 
                 $relation = $isIdTag ? 'object.tag' : 'object.extra_tag';
-                /** @var string $tagName */
-                $tagName = $tag->tag;
 
-                yield $relation . '.' . $tagName => ucfirst($tagName);
+                yield $relation . '.' . $tag->tag => ucfirst($tag->tag);
             }
         }
     }

--- a/library/Notifications/Web/Control/SearchBar/ObjectSuggestions.php
+++ b/library/Notifications/Web/Control/SearchBar/ObjectSuggestions.php
@@ -199,9 +199,10 @@ class ObjectSuggestions extends Suggestions
                 }
 
                 $relation = $isIdTag ? 'object.tag' : 'object.extra_tag';
+                /** @var string $tagName */
                 $tagName = $tag->tag;
 
-                yield $relation . '.' . $tagName => $tagName;
+                yield $relation . '.' . $tagName => ucfirst($tagName);
             }
         }
     }

--- a/library/Notifications/Web/Control/SearchBar/ObjectSuggestions.php
+++ b/library/Notifications/Web/Control/SearchBar/ObjectSuggestions.php
@@ -104,7 +104,8 @@ class ObjectSuggestions extends Suggestions
 
         if (strpos($column, ' ') !== false) {
             // $column may be a label
-            list($path, $_) = Seq::find(
+            /** @var string $path */
+            [$path, $_] = Seq::find(
                 self::collectFilterColumns($query->getModel(), $query->getResolver()),
                 $column,
                 false

--- a/phpstan-baseline-standard.neon
+++ b/phpstan-baseline-standard.neon
@@ -1026,11 +1026,6 @@ parameters:
 			path: library/Notifications/Web/Control/SearchBar/ObjectSuggestions.php
 
 		-
-			message: "#^Parameter \\#1 \\$path of method ipl\\\\Orm\\\\Resolver\\:\\:qualifyPath\\(\\) expects string, mixed given\\.$#"
-			count: 1
-			path: library/Notifications/Web/Control/SearchBar/ObjectSuggestions.php
-
-		-
 			message: "#^Property Icinga\\\\Module\\\\Notifications\\\\Web\\\\Control\\\\SearchBar\\\\ObjectSuggestions\\:\\:\\$model \\(ipl\\\\Orm\\\\Model\\) does not accept object\\.$#"
 			count: 1
 			path: library/Notifications/Web/Control/SearchBar/ObjectSuggestions.php


### PR DESCRIPTION
resolves #150 