### PR TITLE
Fix copyright message format

### DIFF
--- a/application/controllers/ChannelController.php
+++ b/application/controllers/ChannelController.php
@@ -1,6 +1,8 @@
 <?php
 
-/* Icinga Notifications Web | (c) 2023 Icinga GmbH | GPLv2 */
+/*
+ * Icinga Notifications Web | (c) 2023-2024 Icinga GmbH | GPLv2
+ */
 
 namespace Icinga\Module\Notifications\Controllers;
 

--- a/application/controllers/ChannelsController.php
+++ b/application/controllers/ChannelsController.php
@@ -1,6 +1,8 @@
 <?php
 
-/* Icinga Notifications Web | (c) 2023 Icinga GmbH | GPLv2 */
+/*
+ * Icinga Notifications Web | (c) 2023-2024 Icinga GmbH | GPLv2
+ */
 
 namespace Icinga\Module\Notifications\Controllers;
 

--- a/application/controllers/ConfigController.php
+++ b/application/controllers/ConfigController.php
@@ -1,6 +1,8 @@
 <?php
 
-/* Icinga Notifications Web | (c) 2023 Icinga GmbH | GPLv2 */
+/*
+ * Icinga Notifications Web | (c) 2023-2024 Icinga GmbH | GPLv2
+ */
 
 namespace Icinga\Module\Notifications\Controllers;
 

--- a/application/controllers/ContactController.php
+++ b/application/controllers/ContactController.php
@@ -1,6 +1,8 @@
 <?php
 
-/* Icinga Notifications Web | (c) 2023 Icinga GmbH | GPLv2 */
+/*
+ * Icinga Notifications Web | (c) 2023-2024 Icinga GmbH | GPLv2
+ */
 
 namespace Icinga\Module\Notifications\Controllers;
 

--- a/application/controllers/ContactsController.php
+++ b/application/controllers/ContactsController.php
@@ -1,6 +1,8 @@
 <?php
 
-/* Icinga Notifications Web | (c) 2023 Icinga GmbH | GPLv2 */
+/*
+ * Icinga Notifications Web | (c) 2023-2024 Icinga GmbH | GPLv2
+ */
 
 namespace Icinga\Module\Notifications\Controllers;
 

--- a/application/controllers/EventController.php
+++ b/application/controllers/EventController.php
@@ -1,6 +1,8 @@
 <?php
 
-/* Icinga Notifications Web | (c) 2023 Icinga GmbH | GPLv2 */
+/*
+ * Icinga Notifications Web | (c) 2023-2024 Icinga GmbH | GPLv2
+ */
 
 namespace Icinga\Module\Notifications\Controllers;
 

--- a/application/controllers/EventRuleController.php
+++ b/application/controllers/EventRuleController.php
@@ -1,6 +1,8 @@
 <?php
 
-/* Icinga Notifications Web | (c) 2023 Icinga GmbH | GPLv2 */
+/*
+ * Icinga Notifications Web | (c) 2023-2024 Icinga GmbH | GPLv2
+ */
 
 namespace Icinga\Module\Notifications\Controllers;
 

--- a/application/controllers/EventRulesController.php
+++ b/application/controllers/EventRulesController.php
@@ -1,6 +1,8 @@
 <?php
 
-/* Icinga Notifications Web | (c) 2023 Icinga GmbH | GPLv2 */
+/*
+ * Icinga Notifications Web | (c) 2023-2024 Icinga GmbH | GPLv2
+ */
 
 namespace Icinga\Module\Notifications\Controllers;
 

--- a/application/controllers/EventsController.php
+++ b/application/controllers/EventsController.php
@@ -1,6 +1,8 @@
 <?php
 
-/* Icinga Notifications Web | (c) 2023 Icinga GmbH | GPLv2 */
+/*
+ * Icinga Notifications Web | (c) 2023-2024 Icinga GmbH | GPLv2
+ */
 
 namespace Icinga\Module\Notifications\Controllers;
 

--- a/application/controllers/IncidentController.php
+++ b/application/controllers/IncidentController.php
@@ -1,6 +1,8 @@
 <?php
 
-/* Icinga Notifications Web | (c) 2023 Icinga GmbH | GPLv2 */
+/*
+ * Icinga Notifications Web | (c) 2023-2024 Icinga GmbH | GPLv2
+ */
 
 namespace Icinga\Module\Notifications\Controllers;
 

--- a/application/controllers/IncidentsController.php
+++ b/application/controllers/IncidentsController.php
@@ -1,6 +1,8 @@
 <?php
 
-/* Icinga Notifications Web | (c) 2023 Icinga GmbH | GPLv2 */
+/*
+ * Icinga Notifications Web | (c) 2023-2024 Icinga GmbH | GPLv2
+ */
 
 namespace Icinga\Module\Notifications\Controllers;
 

--- a/application/controllers/ScheduleController.php
+++ b/application/controllers/ScheduleController.php
@@ -1,6 +1,8 @@
 <?php
 
-/* Icinga Notifications Web | (c) 2023 Icinga GmbH | GPLv2 */
+/*
+ * Icinga Notifications Web | (c) 2023-2024 Icinga GmbH | GPLv2
+ */
 
 namespace Icinga\Module\Notifications\Controllers;
 

--- a/application/controllers/SchedulesController.php
+++ b/application/controllers/SchedulesController.php
@@ -1,6 +1,8 @@
 <?php
 
-/* Icinga Notifications Web | (c) 2023 Icinga GmbH | GPLv2 */
+/*
+ * Icinga Notifications Web | (c) 2023-2024 Icinga GmbH | GPLv2
+ */
 
 namespace Icinga\Module\Notifications\Controllers;
 

--- a/application/forms/AddEscalationForm.php
+++ b/application/forms/AddEscalationForm.php
@@ -1,6 +1,8 @@
 <?php
 
-/* Icinga Notifications Web | (c) 2023 Icinga GmbH | GPLv2 */
+/*
+ * Icinga Notifications Web | (c) 2023-2024 Icinga GmbH | GPLv2
+ */
 
 namespace Icinga\Module\Notifications\Forms;
 

--- a/application/forms/AddFilterForm.php
+++ b/application/forms/AddFilterForm.php
@@ -1,6 +1,8 @@
 <?php
 
-/* Icinga Notifications Web | (c) 2023 Icinga GmbH | GPLv2 */
+/*
+ * Icinga Notifications Web | (c) 2023-2024 Icinga GmbH | GPLv2
+ */
 
 namespace Icinga\Module\Notifications\Forms;
 

--- a/application/forms/BaseEscalationForm.php
+++ b/application/forms/BaseEscalationForm.php
@@ -1,6 +1,8 @@
 <?php
 
-/* Icinga Notifications Web | (c) 2023 Icinga GmbH | GPLv2 */
+/*
+ * Icinga Notifications Web | (c) 2023-2024 Icinga GmbH | GPLv2
+ */
 
 namespace Icinga\Module\Notifications\Forms;
 

--- a/application/forms/ChannelForm.php
+++ b/application/forms/ChannelForm.php
@@ -1,6 +1,8 @@
 <?php
 
-/* Icinga Notifications Web | (c) 2023 Icinga GmbH | GPLv2 */
+/*
+ * Icinga Notifications Web | (c) 2023-2024 Icinga GmbH | GPLv2
+ */
 
 namespace Icinga\Module\Notifications\Forms;
 

--- a/application/forms/DatabaseConfigForm.php
+++ b/application/forms/DatabaseConfigForm.php
@@ -1,6 +1,8 @@
 <?php
 
-/* Icinga Notifications Web | (c) 2023 Icinga GmbH | GPLv2 */
+/*
+ * Icinga Notifications Web | (c) 2023-2024 Icinga GmbH | GPLv2
+ */
 
 namespace Icinga\Module\Notifications\Forms;
 

--- a/application/forms/EntryForm.php
+++ b/application/forms/EntryForm.php
@@ -1,6 +1,8 @@
 <?php
 
-/* Icinga Notifications Web | (c) 2023 Icinga GmbH | GPLv2 */
+/*
+ * Icinga Notifications Web | (c) 2023-2024 Icinga GmbH | GPLv2
+ */
 
 namespace Icinga\Module\Notifications\Forms;
 

--- a/application/forms/EscalationConditionForm.php
+++ b/application/forms/EscalationConditionForm.php
@@ -1,6 +1,8 @@
 <?php
 
-/* Icinga Notifications Web | (c) 2023 Icinga GmbH | GPLv2 */
+/*
+ * Icinga Notifications Web | (c) 2023-2024 Icinga GmbH | GPLv2
+ */
 
 namespace Icinga\Module\Notifications\Forms;
 

--- a/application/forms/EscalationRecipientForm.php
+++ b/application/forms/EscalationRecipientForm.php
@@ -1,6 +1,8 @@
 <?php
 
-/* Icinga Notifications Web | (c) 2023 Icinga GmbH | GPLv2 */
+/*
+ * Icinga Notifications Web | (c) 2023-2024 Icinga GmbH | GPLv2
+ */
 
 namespace Icinga\Module\Notifications\Forms;
 

--- a/application/forms/EventRuleForm.php
+++ b/application/forms/EventRuleForm.php
@@ -1,6 +1,8 @@
 <?php
 
-/* Icinga Notifications Web | (c) 2023 Icinga GmbH | GPLv2 */
+/*
+ * Icinga Notifications Web | (c) 2023-2024 Icinga GmbH | GPLv2
+ */
 
 namespace Icinga\Module\Notifications\Forms;
 

--- a/application/forms/RemoveEscalationForm.php
+++ b/application/forms/RemoveEscalationForm.php
@@ -1,6 +1,8 @@
 <?php
 
-/* Icinga Notifications Web | (c) 2023 Icinga GmbH | GPLv2 */
+/*
+ * Icinga Notifications Web | (c) 2023-2024 Icinga GmbH | GPLv2
+ */
 
 namespace Icinga\Module\Notifications\Forms;
 

--- a/application/forms/SaveEventRuleForm.php
+++ b/application/forms/SaveEventRuleForm.php
@@ -1,6 +1,8 @@
 <?php
 
-/* Icinga Notifications Web | (c) 2023 Icinga GmbH | GPLv2 */
+/*
+ * Icinga Notifications Web | (c) 2023-2024 Icinga GmbH | GPLv2
+ */
 
 namespace Icinga\Module\Notifications\Forms;
 

--- a/application/forms/ScheduleForm.php
+++ b/application/forms/ScheduleForm.php
@@ -1,6 +1,8 @@
 <?php
 
-/* Icinga Notifications Web | (c) 2023 Icinga GmbH | GPLv2 */
+/*
+ * Icinga Notifications Web | (c) 2023-2024 Icinga GmbH | GPLv2
+ */
 
 namespace Icinga\Module\Notifications\Forms;
 

--- a/configuration.php
+++ b/configuration.php
@@ -1,6 +1,8 @@
 <?php
 
-/* Icinga Notifications Web | (c) 2023 Icinga GmbH | GPLv2 */
+/*
+ * Icinga Notifications Web | (c) 2023-2024 Icinga GmbH | GPLv2
+ */
 
 /** @var \Icinga\Application\Modules\Module $this */
 

--- a/library/Notifications/Common/Auth.php
+++ b/library/Notifications/Common/Auth.php
@@ -1,6 +1,8 @@
 <?php
 
-/* Icinga Notifications Web | (c) 2023 Icinga GmbH | GPLv2 */
+/*
+ * Icinga Notifications Web | (c) 2023-2024 Icinga GmbH | GPLv2
+ */
 
 namespace Icinga\Module\Notifications\Common;
 

--- a/library/Notifications/Common/BaseItemList.php
+++ b/library/Notifications/Common/BaseItemList.php
@@ -1,6 +1,8 @@
 <?php
 
-/* Icinga Notifications Web | (c) 2023 Icinga GmbH | GPLv2 */
+/*
+ * Icinga Notifications Web | (c) 2023-2024 Icinga GmbH | GPLv2
+ */
 
 namespace Icinga\Module\Notifications\Common;
 

--- a/library/Notifications/Common/BaseListItem.php
+++ b/library/Notifications/Common/BaseListItem.php
@@ -1,6 +1,8 @@
 <?php
 
-/* Icinga Notifications Web | (c) 2023 Icinga GmbH | GPLv2 */
+/*
+ * Icinga Notifications Web | (c) 2023-2024 Icinga GmbH | GPLv2
+ */
 
 namespace Icinga\Module\Notifications\Common;
 

--- a/library/Notifications/Common/Database.php
+++ b/library/Notifications/Common/Database.php
@@ -1,6 +1,8 @@
 <?php
 
-/* Icinga Notifications Web | (c) 2023 Icinga GmbH | GPLv2 */
+/*
+ * Icinga Notifications Web | (c) 2023-2024 Icinga GmbH | GPLv2
+ */
 
 namespace Icinga\Module\Notifications\Common;
 

--- a/library/Notifications/Common/Icons.php
+++ b/library/Notifications/Common/Icons.php
@@ -1,6 +1,8 @@
 <?php
 
-/* Icinga Notifications Web | (c) 2023 Icinga GmbH | GPLv2 */
+/*
+ * Icinga Notifications Web | (c) 2023-2024 Icinga GmbH | GPLv2
+ */
 
 namespace Icinga\Module\Notifications\Common;
 

--- a/library/Notifications/Common/Links.php
+++ b/library/Notifications/Common/Links.php
@@ -1,6 +1,8 @@
 <?php
 
-/* Icinga Notifications Web | (c) 2023 Icinga GmbH | GPLv2 */
+/*
+ * Icinga Notifications Web | (c) 2023-2024 Icinga GmbH | GPLv2
+ */
 
 namespace Icinga\Module\Notifications\Common;
 

--- a/library/Notifications/Common/LoadMore.php
+++ b/library/Notifications/Common/LoadMore.php
@@ -1,6 +1,8 @@
 <?php
 
-/* Icinga Notifications Web | (c) 2023 Icinga GmbH | GPLv2 */
+/*
+ * Icinga Notifications Web | (c) 2023-2024 Icinga GmbH | GPLv2
+ */
 
 namespace Icinga\Module\Notifications\Common;
 

--- a/library/Notifications/Common/NoSubjectLink.php
+++ b/library/Notifications/Common/NoSubjectLink.php
@@ -1,6 +1,8 @@
 <?php
 
-/* Icinga Notifications Web | (c) 2023 Icinga GmbH | GPLv2 */
+/*
+ * Icinga Notifications Web | (c) 2023-2024 Icinga GmbH | GPLv2
+ */
 
 namespace Icinga\Module\Notifications\Common;
 

--- a/library/Notifications/Model/AvailableChannelType.php
+++ b/library/Notifications/Model/AvailableChannelType.php
@@ -1,6 +1,8 @@
 <?php
 
-/* Icinga Notifications Web | (c) 2023 Icinga GmbH | GPLv2 */
+/*
+ * Icinga Notifications Web | (c) 2023-2024 Icinga GmbH | GPLv2
+ */
 
 namespace Icinga\Module\Notifications\Model;
 

--- a/library/Notifications/Model/Behavior/HasAddress.php
+++ b/library/Notifications/Model/Behavior/HasAddress.php
@@ -1,6 +1,8 @@
 <?php
 
-/* Icinga Notifications Web | (c) 2023 Icinga GmbH | GPLv2 */
+/*
+ * Icinga Notifications Web | (c) 2023-2024 Icinga GmbH | GPLv2
+ */
 
 namespace Icinga\Module\Notifications\Model\Behavior;
 

--- a/library/Notifications/Model/Behavior/ObjectTags.php
+++ b/library/Notifications/Model/Behavior/ObjectTags.php
@@ -1,5 +1,9 @@
 <?php
 
+/*
+ * Icinga Notifications Web | (c) 2024 Icinga GmbH | GPLv2
+ */
+
 namespace Icinga\Module\Notifications\Model\Behavior;
 
 use Icinga\Module\Notifications\Common\Auth;

--- a/library/Notifications/Model/Channel.php
+++ b/library/Notifications/Model/Channel.php
@@ -1,6 +1,8 @@
 <?php
 
-/* Icinga Notifications Web | (c) 2023 Icinga GmbH | GPLv2 */
+/*
+ * Icinga Notifications Web | (c) 2023-2024 Icinga GmbH | GPLv2
+ */
 
 namespace Icinga\Module\Notifications\Model;
 

--- a/library/Notifications/Model/Contact.php
+++ b/library/Notifications/Model/Contact.php
@@ -1,6 +1,8 @@
 <?php
 
-/* Icinga Notifications Web | (c) 2023 Icinga GmbH | GPLv2 */
+/*
+ * Icinga Notifications Web | (c) 2023-2024 Icinga GmbH | GPLv2
+ */
 
 namespace Icinga\Module\Notifications\Model;
 

--- a/library/Notifications/Model/ContactAddress.php
+++ b/library/Notifications/Model/ContactAddress.php
@@ -1,6 +1,8 @@
 <?php
 
-/* Icinga Notifications Web | (c) 2023 Icinga GmbH | GPLv2 */
+/*
+ * Icinga Notifications Web | (c) 2023-2024 Icinga GmbH | GPLv2
+ */
 
 namespace Icinga\Module\Notifications\Model;
 

--- a/library/Notifications/Model/Contactgroup.php
+++ b/library/Notifications/Model/Contactgroup.php
@@ -1,6 +1,8 @@
 <?php
 
-/* Icinga Notifications Web | (c) 2023 Icinga GmbH | GPLv2 */
+/*
+ * Icinga Notifications Web | (c) 2023-2024 Icinga GmbH | GPLv2
+ */
 
 namespace Icinga\Module\Notifications\Model;
 

--- a/library/Notifications/Model/Event.php
+++ b/library/Notifications/Model/Event.php
@@ -1,6 +1,8 @@
 <?php
 
-/* Icinga Notifications Web | (c) 2023 Icinga GmbH | GPLv2 */
+/*
+ * Icinga Notifications Web | (c) 2023-2024 Icinga GmbH | GPLv2
+ */
 
 namespace Icinga\Module\Notifications\Model;
 

--- a/library/Notifications/Model/ExtraTag.php
+++ b/library/Notifications/Model/ExtraTag.php
@@ -1,6 +1,8 @@
 <?php
 
-/* Icinga Notifications Web | (c) 2023 Icinga GmbH | GPLv2 */
+/*
+ * Icinga Notifications Web | (c) 2023-2024 Icinga GmbH | GPLv2
+ */
 
 namespace Icinga\Module\Notifications\Model;
 

--- a/library/Notifications/Model/Incident.php
+++ b/library/Notifications/Model/Incident.php
@@ -1,6 +1,8 @@
 <?php
 
-/* Icinga Notifications Web | (c) 2023 Icinga GmbH | GPLv2 */
+/*
+ * Icinga Notifications Web | (c) 2023-2024 Icinga GmbH | GPLv2
+ */
 
 namespace Icinga\Module\Notifications\Model;
 

--- a/library/Notifications/Model/IncidentContact.php
+++ b/library/Notifications/Model/IncidentContact.php
@@ -1,6 +1,8 @@
 <?php
 
-/* Icinga Notifications Web | (c) 2023 Icinga GmbH | GPLv2 */
+/*
+ * Icinga Notifications Web | (c) 2023-2024 Icinga GmbH | GPLv2
+ */
 
 namespace Icinga\Module\Notifications\Model;
 

--- a/library/Notifications/Model/IncidentHistory.php
+++ b/library/Notifications/Model/IncidentHistory.php
@@ -1,6 +1,8 @@
 <?php
 
-/* Icinga Notifications Web | (c) 2023 Icinga GmbH | GPLv2 */
+/*
+ * Icinga Notifications Web | (c) 2023-2024 Icinga GmbH | GPLv2
+ */
 
 namespace Icinga\Module\Notifications\Model;
 

--- a/library/Notifications/Model/ObjectExtraTag.php
+++ b/library/Notifications/Model/ObjectExtraTag.php
@@ -1,6 +1,8 @@
 <?php
 
-/* Icinga Notifications Web | (c) 2023 Icinga GmbH | GPLv2 */
+/*
+ * Icinga Notifications Web | (c) 2023-2024 Icinga GmbH | GPLv2
+ */
 
 namespace Icinga\Module\Notifications\Model;
 

--- a/library/Notifications/Model/ObjectIdTag.php
+++ b/library/Notifications/Model/ObjectIdTag.php
@@ -1,6 +1,8 @@
 <?php
 
-/* Icinga Notifications Web | (c) 2023 Icinga GmbH | GPLv2 */
+/*
+ * Icinga Notifications Web | (c) 2023-2024 Icinga GmbH | GPLv2
+ */
 
 namespace Icinga\Module\Notifications\Model;
 

--- a/library/Notifications/Model/Objects.php
+++ b/library/Notifications/Model/Objects.php
@@ -1,6 +1,8 @@
 <?php
 
-/* Icinga Notifications Web | (c) 2023 Icinga GmbH | GPLv2 */
+/*
+ * Icinga Notifications Web | (c) 2023-2024 Icinga GmbH | GPLv2
+ */
 
 namespace Icinga\Module\Notifications\Model;
 

--- a/library/Notifications/Model/Rule.php
+++ b/library/Notifications/Model/Rule.php
@@ -1,6 +1,8 @@
 <?php
 
-/* Icinga Notifications Web | (c) 2023 Icinga GmbH | GPLv2 */
+/*
+ * Icinga Notifications Web | (c) 2023-2024 Icinga GmbH | GPLv2
+ */
 
 namespace Icinga\Module\Notifications\Model;
 

--- a/library/Notifications/Model/RuleEscalation.php
+++ b/library/Notifications/Model/RuleEscalation.php
@@ -1,6 +1,8 @@
 <?php
 
-/* Icinga Notifications Web | (c) 2023 Icinga GmbH | GPLv2 */
+/*
+ * Icinga Notifications Web | (c) 2023-2024 Icinga GmbH | GPLv2
+ */
 
 namespace Icinga\Module\Notifications\Model;
 

--- a/library/Notifications/Model/RuleEscalationRecipient.php
+++ b/library/Notifications/Model/RuleEscalationRecipient.php
@@ -1,6 +1,8 @@
 <?php
 
-/* Icinga Notifications Web | (c) 2023 Icinga GmbH | GPLv2 */
+/*
+ * Icinga Notifications Web | (c) 2023-2024 Icinga GmbH | GPLv2
+ */
 
 namespace Icinga\Module\Notifications\Model;
 

--- a/library/Notifications/Model/Schedule.php
+++ b/library/Notifications/Model/Schedule.php
@@ -1,6 +1,8 @@
 <?php
 
-/* Icinga Notifications Web | (c) 2023 Icinga GmbH | GPLv2 */
+/*
+ * Icinga Notifications Web | (c) 2023-2024 Icinga GmbH | GPLv2
+ */
 
 namespace Icinga\Module\Notifications\Model;
 

--- a/library/Notifications/Model/ScheduleMember.php
+++ b/library/Notifications/Model/ScheduleMember.php
@@ -1,6 +1,8 @@
 <?php
 
-/* Icinga Notifications Web | (c) 2023 Icinga GmbH | GPLv2 */
+/*
+ * Icinga Notifications Web | (c) 2023-2024 Icinga GmbH | GPLv2
+ */
 
 namespace Icinga\Module\Notifications\Model;
 

--- a/library/Notifications/Model/Source.php
+++ b/library/Notifications/Model/Source.php
@@ -1,6 +1,8 @@
 <?php
 
-/* Icinga Notifications Web | (c) 2023 Icinga GmbH | GPLv2 */
+/*
+ * Icinga Notifications Web | (c) 2023-2024 Icinga GmbH | GPLv2
+ */
 
 namespace Icinga\Module\Notifications\Model;
 

--- a/library/Notifications/Model/Tag.php
+++ b/library/Notifications/Model/Tag.php
@@ -1,6 +1,8 @@
 <?php
 
-/* Icinga Notifications Web | (c) 2023 Icinga GmbH | GPLv2 */
+/*
+ * Icinga Notifications Web | (c) 2023-2024 Icinga GmbH | GPLv2
+ */
 
 namespace Icinga\Module\Notifications\Model;
 

--- a/library/Notifications/Model/Timeperiod.php
+++ b/library/Notifications/Model/Timeperiod.php
@@ -1,6 +1,8 @@
 <?php
 
-/* Icinga Notifications Web | (c) 2023 Icinga GmbH | GPLv2 */
+/*
+ * Icinga Notifications Web | (c) 2023-2024 Icinga GmbH | GPLv2
+ */
 
 namespace Icinga\Module\Notifications\Model;
 

--- a/library/Notifications/Model/TimeperiodEntry.php
+++ b/library/Notifications/Model/TimeperiodEntry.php
@@ -1,6 +1,8 @@
 <?php
 
-/* Icinga Notifications Web | (c) 2023 Icinga GmbH | GPLv2 */
+/*
+ * Icinga Notifications Web | (c) 2023-2024 Icinga GmbH | GPLv2
+ */
 
 namespace Icinga\Module\Notifications\Model;
 

--- a/library/Notifications/Util/ObjectSuggestionsCursor.php
+++ b/library/Notifications/Util/ObjectSuggestionsCursor.php
@@ -1,6 +1,8 @@
 <?php
 
-/* Icinga Notifications Web | (c) 2023 Icinga GmbH | GPLv2 */
+/*
+ * Icinga Notifications Web | (c) 2023-2024 Icinga GmbH | GPLv2
+ */
 
 namespace Icinga\Module\Notifications\Util;
 

--- a/library/Notifications/Web/Control/SearchBar/ExtraTagSuggestions.php
+++ b/library/Notifications/Web/Control/SearchBar/ExtraTagSuggestions.php
@@ -1,6 +1,8 @@
 <?php
 
-/* Icinga Notifications Web | (c) 2023 Icinga GmbH | GPLv2 */
+/*
+ * Icinga Notifications Web | (c) 2023-2024 Icinga GmbH | GPLv2
+ */
 
 namespace Icinga\Module\Notifications\Web\Control\SearchBar;
 

--- a/library/Notifications/Web/Control/SearchBar/ObjectSuggestions.php
+++ b/library/Notifications/Web/Control/SearchBar/ObjectSuggestions.php
@@ -1,6 +1,8 @@
 <?php
 
-/* Icinga Notifications Web | (c) 2023 Icinga GmbH | GPLv2 */
+/*
+ * Icinga Notifications Web | (c) 2023-2024 Icinga GmbH | GPLv2
+ */
 
 namespace Icinga\Module\Notifications\Web\Control\SearchBar;
 

--- a/library/Notifications/Web/FilterRenderer.php
+++ b/library/Notifications/Web/FilterRenderer.php
@@ -1,6 +1,8 @@
 <?php
 
-/* Icinga Notifications Web | (c) 2023 Icinga GmbH | GPLv2 */
+/*
+ * Icinga Notifications Web | (c) 2023-2024 Icinga GmbH | GPLv2
+ */
 
 namespace Icinga\Module\Notifications\Web;
 

--- a/library/Notifications/Web/Form/ContactForm.php
+++ b/library/Notifications/Web/Form/ContactForm.php
@@ -1,6 +1,8 @@
 <?php
 
-/* Icinga Notifications Web | (c) 2023 Icinga GmbH | GPLv2 */
+/*
+ * Icinga Notifications Web | (c) 2023-2024 Icinga GmbH | GPLv2
+ */
 
 namespace Icinga\Module\Notifications\Web\Form;
 

--- a/library/Notifications/Web/Form/EventRuleDecorator.php
+++ b/library/Notifications/Web/Form/EventRuleDecorator.php
@@ -1,6 +1,8 @@
 <?php
 
-/* Icinga Notifications Web | (c) 2023 Icinga GmbH | GPLv2 */
+/*
+ * Icinga Notifications Web | (c) 2023-2024 Icinga GmbH | GPLv2
+ */
 
 namespace Icinga\Module\Notifications\Web\Form;
 

--- a/library/Notifications/Widget/Calendar.php
+++ b/library/Notifications/Widget/Calendar.php
@@ -1,6 +1,8 @@
 <?php
 
-/* Icinga Notifications Web | (c) 2023 Icinga GmbH | GPLv2 */
+/*
+ * Icinga Notifications Web | (c) 2023-2024 Icinga GmbH | GPLv2
+ */
 
 namespace Icinga\Module\Notifications\Widget;
 

--- a/library/Notifications/Widget/Calendar/Attendee.php
+++ b/library/Notifications/Widget/Calendar/Attendee.php
@@ -1,6 +1,8 @@
 <?php
 
-/* Icinga Notifications Web | (c) 2023 Icinga GmbH | GPLv2 */
+/*
+ * Icinga Notifications Web | (c) 2023-2024 Icinga GmbH | GPLv2
+ */
 
 namespace Icinga\Module\Notifications\Widget\Calendar;
 

--- a/library/Notifications/Widget/Calendar/BaseGrid.php
+++ b/library/Notifications/Widget/Calendar/BaseGrid.php
@@ -1,6 +1,8 @@
 <?php
 
-/* Icinga Notifications Web | (c) 2023 Icinga GmbH | GPLv2 */
+/*
+ * Icinga Notifications Web | (c) 2023-2024 Icinga GmbH | GPLv2
+ */
 
 namespace Icinga\Module\Notifications\Widget\Calendar;
 

--- a/library/Notifications/Widget/Calendar/Controls.php
+++ b/library/Notifications/Widget/Calendar/Controls.php
@@ -1,6 +1,8 @@
 <?php
 
-/* Icinga Notifications Web | (c) 2023 Icinga GmbH | GPLv2 */
+/*
+ * Icinga Notifications Web | (c) 2023-2024 Icinga GmbH | GPLv2
+ */
 
 namespace Icinga\Module\Notifications\Widget\Calendar;
 

--- a/library/Notifications/Widget/Calendar/DayGrid.php
+++ b/library/Notifications/Widget/Calendar/DayGrid.php
@@ -1,6 +1,8 @@
 <?php
 
-/* Icinga Notifications Web | (c) 2023 Icinga GmbH | GPLv2 */
+/*
+ * Icinga Notifications Web | (c) 2023-2024 Icinga GmbH | GPLv2
+ */
 
 namespace Icinga\Module\Notifications\Widget\Calendar;
 

--- a/library/Notifications/Widget/Calendar/Entry.php
+++ b/library/Notifications/Widget/Calendar/Entry.php
@@ -1,6 +1,8 @@
 <?php
 
-/* Icinga Notifications Web | (c) 2023 Icinga GmbH | GPLv2 */
+/*
+ * Icinga Notifications Web | (c) 2023-2024 Icinga GmbH | GPLv2
+ */
 
 namespace Icinga\Module\Notifications\Widget\Calendar;
 

--- a/library/Notifications/Widget/Calendar/ExtraEntryCount.php
+++ b/library/Notifications/Widget/Calendar/ExtraEntryCount.php
@@ -1,5 +1,9 @@
 <?php
 
+/*
+ * Icinga Notifications Web | (c) 2024 Icinga GmbH | GPLv2
+ */
+
 namespace Icinga\Module\Notifications\Widget\Calendar;
 
 use DateTime;

--- a/library/Notifications/Widget/Calendar/MonthGrid.php
+++ b/library/Notifications/Widget/Calendar/MonthGrid.php
@@ -1,6 +1,8 @@
 <?php
 
-/* Icinga Notifications Web | (c) 2023 Icinga GmbH | GPLv2 */
+/*
+ * Icinga Notifications Web | (c) 2023-2024 Icinga GmbH | GPLv2
+ */
 
 namespace Icinga\Module\Notifications\Widget\Calendar;
 

--- a/library/Notifications/Widget/Calendar/Util.php
+++ b/library/Notifications/Widget/Calendar/Util.php
@@ -1,6 +1,8 @@
 <?php
 
-/* Icinga Notifications Web | (c) 2023 Icinga GmbH | GPLv2 */
+/*
+ * Icinga Notifications Web | (c) 2023-2024 Icinga GmbH | GPLv2
+ */
 
 namespace Icinga\Module\Notifications\Widget\Calendar;
 

--- a/library/Notifications/Widget/Calendar/WeekGrid.php
+++ b/library/Notifications/Widget/Calendar/WeekGrid.php
@@ -1,6 +1,8 @@
 <?php
 
-/* Icinga Notifications Web | (c) 2023 Icinga GmbH | GPLv2 */
+/*
+ * Icinga Notifications Web | (c) 2023-2024 Icinga GmbH | GPLv2
+ */
 
 namespace Icinga\Module\Notifications\Widget\Calendar;
 

--- a/library/Notifications/Widget/CheckboxIcon.php
+++ b/library/Notifications/Widget/CheckboxIcon.php
@@ -1,6 +1,8 @@
 <?php
 
-/* Icinga Notifications Web | (c) 2023 Icinga GmbH | GPLv2 */
+/*
+ * Icinga Notifications Web | (c) 2023-2024 Icinga GmbH | GPLv2
+ */
 
 namespace Icinga\Module\Notifications\Widget;
 

--- a/library/Notifications/Widget/Detail/EventDetail.php
+++ b/library/Notifications/Widget/Detail/EventDetail.php
@@ -1,6 +1,8 @@
 <?php
 
-/* Icinga Notifications Web | (c) 2023 Icinga GmbH | GPLv2 */
+/*
+ * Icinga Notifications Web | (c) 2023-2024 Icinga GmbH | GPLv2
+ */
 
 namespace Icinga\Module\Notifications\Widget\Detail;
 

--- a/library/Notifications/Widget/Detail/IncidentDetail.php
+++ b/library/Notifications/Widget/Detail/IncidentDetail.php
@@ -1,6 +1,8 @@
 <?php
 
-/* Icinga Notifications Web | (c) 2023 Icinga GmbH | GPLv2 */
+/*
+ * Icinga Notifications Web | (c) 2023-2024 Icinga GmbH | GPLv2
+ */
 
 namespace Icinga\Module\Notifications\Widget\Detail;
 

--- a/library/Notifications/Widget/Detail/IncidentQuickActions.php
+++ b/library/Notifications/Widget/Detail/IncidentQuickActions.php
@@ -1,6 +1,8 @@
 <?php
 
-/* Icinga Notifications Web | (c) 2023 Icinga GmbH | GPLv2 */
+/*
+ * Icinga Notifications Web | (c) 2023-2024 Icinga GmbH | GPLv2
+ */
 
 namespace Icinga\Module\Notifications\Widget\Detail;
 

--- a/library/Notifications/Widget/EmptyState.php
+++ b/library/Notifications/Widget/EmptyState.php
@@ -1,6 +1,8 @@
 <?php
 
-/* Icinga Notifications Web | (c) 2023 Icinga GmbH | GPLv2 */
+/*
+ * Icinga Notifications Web | (c) 2023-2024 Icinga GmbH | GPLv2
+ */
 
 namespace Icinga\Module\Notifications\Widget;
 

--- a/library/Notifications/Widget/Escalations.php
+++ b/library/Notifications/Widget/Escalations.php
@@ -1,6 +1,8 @@
 <?php
 
-/* Icinga Notifications Web | (c) 2023 Icinga GmbH | GPLv2 */
+/*
+ * Icinga Notifications Web | (c) 2023-2024 Icinga GmbH | GPLv2
+ */
 
 namespace Icinga\Module\Notifications\Widget;
 

--- a/library/Notifications/Widget/EventRuleConfig.php
+++ b/library/Notifications/Widget/EventRuleConfig.php
@@ -1,6 +1,8 @@
 <?php
 
-/* Icinga Notifications Web | (c) 2023 Icinga GmbH | GPLv2 */
+/*
+ * Icinga Notifications Web | (c) 2023-2024 Icinga GmbH | GPLv2
+ */
 
 namespace Icinga\Module\Notifications\Widget;
 

--- a/library/Notifications/Widget/EventSourceBadge.php
+++ b/library/Notifications/Widget/EventSourceBadge.php
@@ -1,6 +1,8 @@
 <?php
 
-/* Icinga Notifications Web | (c) 2023 Icinga GmbH | GPLv2 */
+/*
+ * Icinga Notifications Web | (c) 2023-2024 Icinga GmbH | GPLv2
+ */
 
 namespace Icinga\Module\Notifications\Widget;
 

--- a/library/Notifications/Widget/FlowLine.php
+++ b/library/Notifications/Widget/FlowLine.php
@@ -1,6 +1,8 @@
 <?php
 
-/* Icinga Notifications Web | (c) 2023 Icinga GmbH | GPLv2 */
+/*
+ * Icinga Notifications Web | (c) 2023-2024 Icinga GmbH | GPLv2
+ */
 
 namespace Icinga\Module\Notifications\Widget;
 

--- a/library/Notifications/Widget/ItemList/ChannelList.php
+++ b/library/Notifications/Widget/ItemList/ChannelList.php
@@ -1,6 +1,8 @@
 <?php
 
-/* Icinga Notifications Web | (c) 2023 Icinga GmbH | GPLv2 */
+/*
+ * Icinga Notifications Web | (c) 2023-2024 Icinga GmbH | GPLv2
+ */
 
 namespace Icinga\Module\Notifications\Widget\ItemList;
 

--- a/library/Notifications/Widget/ItemList/ChannelListItem.php
+++ b/library/Notifications/Widget/ItemList/ChannelListItem.php
@@ -1,6 +1,8 @@
 <?php
 
-/* Icinga Notifications Web | (c) 2023 Icinga GmbH | GPLv2 */
+/*
+ * Icinga Notifications Web | (c) 2023-2024 Icinga GmbH | GPLv2
+ */
 
 namespace Icinga\Module\Notifications\Widget\ItemList;
 

--- a/library/Notifications/Widget/ItemList/ContactList.php
+++ b/library/Notifications/Widget/ItemList/ContactList.php
@@ -1,6 +1,8 @@
 <?php
 
-/* Icinga Notifications Web | (c) 2023 Icinga GmbH | GPLv2 */
+/*
+ * Icinga Notifications Web | (c) 2023-2024 Icinga GmbH | GPLv2
+ */
 
 namespace Icinga\Module\Notifications\Widget\ItemList;
 

--- a/library/Notifications/Widget/ItemList/ContactListItem.php
+++ b/library/Notifications/Widget/ItemList/ContactListItem.php
@@ -1,6 +1,8 @@
 <?php
 
-/* Icinga Notifications Web | (c) 2023 Icinga GmbH | GPLv2 */
+/*
+ * Icinga Notifications Web | (c) 2023-2024 Icinga GmbH | GPLv2
+ */
 
 namespace Icinga\Module\Notifications\Widget\ItemList;
 

--- a/library/Notifications/Widget/ItemList/EventList.php
+++ b/library/Notifications/Widget/ItemList/EventList.php
@@ -1,6 +1,8 @@
 <?php
 
-/* Icinga Notifications Web | (c) 2023 Icinga GmbH | GPLv2 */
+/*
+ * Icinga Notifications Web | (c) 2023-2024 Icinga GmbH | GPLv2
+ */
 
 namespace Icinga\Module\Notifications\Widget\ItemList;
 

--- a/library/Notifications/Widget/ItemList/EventListItem.php
+++ b/library/Notifications/Widget/ItemList/EventListItem.php
@@ -1,6 +1,8 @@
 <?php
 
-/* Icinga Notifications Web | (c) 2023 Icinga GmbH | GPLv2 */
+/*
+ * Icinga Notifications Web | (c) 2023-2024 Icinga GmbH | GPLv2
+ */
 
 namespace Icinga\Module\Notifications\Widget\ItemList;
 

--- a/library/Notifications/Widget/ItemList/EventRuleList.php
+++ b/library/Notifications/Widget/ItemList/EventRuleList.php
@@ -1,6 +1,8 @@
 <?php
 
-/* Icinga Notifications Web | (c) 2023 Icinga GmbH | GPLv2 */
+/*
+ * Icinga Notifications Web | (c) 2023-2024 Icinga GmbH | GPLv2
+ */
 
 namespace Icinga\Module\Notifications\Widget\ItemList;
 

--- a/library/Notifications/Widget/ItemList/EventRuleListItem.php
+++ b/library/Notifications/Widget/ItemList/EventRuleListItem.php
@@ -1,6 +1,8 @@
 <?php
 
-/* Icinga Notifications Web | (c) 2023 Icinga GmbH | GPLv2 */
+/*
+ * Icinga Notifications Web | (c) 2023-2024 Icinga GmbH | GPLv2
+ */
 
 namespace Icinga\Module\Notifications\Widget\ItemList;
 

--- a/library/Notifications/Widget/ItemList/IncidentContactList.php
+++ b/library/Notifications/Widget/ItemList/IncidentContactList.php
@@ -1,6 +1,8 @@
 <?php
 
-/* Icinga Notifications Web | (c) 2023 Icinga GmbH | GPLv2 */
+/*
+ * Icinga Notifications Web | (c) 2023-2024 Icinga GmbH | GPLv2
+ */
 
 namespace Icinga\Module\Notifications\Widget\ItemList;
 

--- a/library/Notifications/Widget/ItemList/IncidentContactListItem.php
+++ b/library/Notifications/Widget/ItemList/IncidentContactListItem.php
@@ -1,6 +1,8 @@
 <?php
 
-/* Icinga Notifications Web | (c) 2023 Icinga GmbH | GPLv2 */
+/*
+ * Icinga Notifications Web | (c) 2023-2024 Icinga GmbH | GPLv2
+ */
 
 namespace Icinga\Module\Notifications\Widget\ItemList;
 

--- a/library/Notifications/Widget/ItemList/IncidentHistoryList.php
+++ b/library/Notifications/Widget/ItemList/IncidentHistoryList.php
@@ -1,6 +1,8 @@
 <?php
 
-/* Icinga Notifications Web | (c) 2023 Icinga GmbH | GPLv2 */
+/*
+ * Icinga Notifications Web | (c) 2023-2024 Icinga GmbH | GPLv2
+ */
 
 namespace Icinga\Module\Notifications\Widget\ItemList;
 

--- a/library/Notifications/Widget/ItemList/IncidentHistoryListItem.php
+++ b/library/Notifications/Widget/ItemList/IncidentHistoryListItem.php
@@ -1,6 +1,8 @@
 <?php
 
-/* Icinga Notifications Web | (c) 2023 Icinga GmbH | GPLv2 */
+/*
+ * Icinga Notifications Web | (c) 2023-2024 Icinga GmbH | GPLv2
+ */
 
 namespace Icinga\Module\Notifications\Widget\ItemList;
 

--- a/library/Notifications/Widget/ItemList/IncidentList.php
+++ b/library/Notifications/Widget/ItemList/IncidentList.php
@@ -1,6 +1,8 @@
 <?php
 
-/* Icinga Notifications Web | (c) 2023 Icinga GmbH | GPLv2 */
+/*
+ * Icinga Notifications Web | (c) 2023-2024 Icinga GmbH | GPLv2
+ */
 
 namespace Icinga\Module\Notifications\Widget\ItemList;
 

--- a/library/Notifications/Widget/ItemList/IncidentListItem.php
+++ b/library/Notifications/Widget/ItemList/IncidentListItem.php
@@ -1,6 +1,8 @@
 <?php
 
-/* Icinga Notifications Web | (c) 2023 Icinga GmbH | GPLv2 */
+/*
+ * Icinga Notifications Web | (c) 2023-2024 Icinga GmbH | GPLv2
+ */
 
 namespace Icinga\Module\Notifications\Widget\ItemList;
 

--- a/library/Notifications/Widget/ItemList/PageSeparatorItem.php
+++ b/library/Notifications/Widget/ItemList/PageSeparatorItem.php
@@ -1,6 +1,8 @@
 <?php
 
-/* Icinga Notifications Web | (c) 2023 Icinga GmbH | GPLv2 */
+/*
+ * Icinga Notifications Web | (c) 2023-2024 Icinga GmbH | GPLv2
+ */
 
 namespace Icinga\Module\Notifications\Widget\ItemList;
 

--- a/library/Notifications/Widget/RecipientSuggestions.php
+++ b/library/Notifications/Widget/RecipientSuggestions.php
@@ -1,6 +1,8 @@
 <?php
 
-/* Icinga Notifications Web | (c) 2023 Icinga GmbH | GPLv2 */
+/*
+ * Icinga Notifications Web | (c) 2023-2024 Icinga GmbH | GPLv2
+ */
 
 namespace Icinga\Module\Notifications\Widget;
 

--- a/library/Notifications/Widget/RightArrow.php
+++ b/library/Notifications/Widget/RightArrow.php
@@ -1,6 +1,8 @@
 <?php
 
-/* Icinga Notifications Web | (c) 2023 Icinga GmbH | GPLv2 */
+/*
+ * Icinga Notifications Web | (c) 2023-2024 Icinga GmbH | GPLv2
+ */
 
 namespace Icinga\Module\Notifications\Widget;
 

--- a/library/Notifications/Widget/RuleEscalationRecipientBadge.php
+++ b/library/Notifications/Widget/RuleEscalationRecipientBadge.php
@@ -1,6 +1,8 @@
 <?php
 
-/* Icinga Notifications Web | (c) 2023 Icinga GmbH | GPLv2 */
+/*
+ * Icinga Notifications Web | (c) 2023-2024 Icinga GmbH | GPLv2
+ */
 
 namespace Icinga\Module\Notifications\Widget;
 

--- a/library/Notifications/Widget/Schedule.php
+++ b/library/Notifications/Widget/Schedule.php
@@ -1,6 +1,8 @@
 <?php
 
-/* Icinga Notifications Web | (c) 2023 Icinga GmbH | GPLv2 */
+/*
+ * Icinga Notifications Web | (c) 2023-2024 Icinga GmbH | GPLv2
+ */
 
 namespace Icinga\Module\Notifications\Widget;
 

--- a/library/Notifications/Widget/ShowMore.php
+++ b/library/Notifications/Widget/ShowMore.php
@@ -1,6 +1,8 @@
 <?php
 
-/* Icinga Notifications Web | (c) 2023 Icinga GmbH | GPLv2 */
+/*
+ * Icinga Notifications Web | (c) 2023-2024 Icinga GmbH | GPLv2
+ */
 
 namespace Icinga\Module\Notifications\Widget;
 

--- a/library/Notifications/Widget/SourceIcon.php
+++ b/library/Notifications/Widget/SourceIcon.php
@@ -1,6 +1,8 @@
 <?php
 
-/* Icinga Notifications Web | (c) 2023 Icinga GmbH | GPLv2 */
+/*
+ * Icinga Notifications Web | (c) 2023-2024 Icinga GmbH | GPLv2
+ */
 
 namespace Icinga\Module\Notifications\Widget;
 

--- a/test/php/library/Notifications/Widget/CalendarTest.php
+++ b/test/php/library/Notifications/Widget/CalendarTest.php
@@ -1,6 +1,8 @@
 <?php
 
-/* Icinga Notifications Web | (c) 2023 Icinga GmbH | GPLv2 */
+/*
+ * Icinga Notifications Web | (c) 2023-2024 Icinga GmbH | GPLv2
+ */
 
 namespace Tests\Icinga\Module\Notifications\Widget;
 


### PR DESCRIPTION
### What's the reason behind this pr?
We are inconsistent with our copyright notices. We either forget adding them while working on new features or implement them much later (example: https://github.com/Icinga/icinga-notifications-web/pull/98/commits/db809d29c9d6e037d73fae989c18e214a38be5bd).
This kind of task can be automated by all of the major integrated development environments like the JetBrains suite, Visual Studio, Eclipse, Emacs, ... and it makes a lot of sense to use those features.
That way no copyright notice goes unseen and all of them are kept up to date if there are any changes made to the format.
As the copyright integrations either support one-line or multiline comments, we should stick to one of those formats. We previously used the multiline syntax but kept it on a single line. This syntax is not supported by such tools as it makes not much sense to define a multiline comment when there's no need to use more than one line.
The pull request changes the format to reflect a multiline comment, which then can be parsed and updated by the copyright tools of the afromentioned major IDE's.