### PR TITLE
IncidentDetail: Use relation `incindent.object` instead of `event.object`

### DIFF
--- a/library/Notifications/Widget/Detail/IncidentDetail.php
+++ b/library/Notifications/Widget/Detail/IncidentDetail.php
@@ -96,8 +96,8 @@ class IncidentDetail extends BaseHtmlElement
         $history = $this->incident->incident_history
             ->with([
                 'event',
-                'event.object',
-                'event.object.source',
+                'incident.object',
+                'incident.object.source',
                 'contact',
                 'rule',
                 'rule_escalation',
@@ -107,7 +107,7 @@ class IncidentDetail extends BaseHtmlElement
             ]);
 
         $history
-            ->withColumns('event.object.id_tags')
+            ->withColumns('incident.object.id_tags')
             ->on(Query::ON_SELECT_ASSEMBLED, function (Select $select) use ($history) {
                 Database::registerGroupBy($history, $select);
             });

--- a/library/Notifications/Widget/ItemList/IncidentHistoryListItem.php
+++ b/library/Notifications/Widget/ItemList/IncidentHistoryListItem.php
@@ -56,7 +56,7 @@ class IncidentHistoryListItem extends BaseListItem
                 ->set('data-action-item', true);
 
             /** @var Objects $obj */
-            $obj = $this->item->event->object;
+            $obj = $this->item->incident->object;
             $content = new Link($obj->getName(), Links::event($this->item->event_id), ['class' => 'subject']);
 
             $title->addHtml($content);
@@ -78,7 +78,7 @@ class IncidentHistoryListItem extends BaseListItem
         $header->addHtml($this->createCaption());
         if ($this->item->type === 'opened' || $this->item->type === 'incident_severity_changed') {
             $header->add(
-                (new SourceIcon(SourceIcon::SIZE_BIG))->addHtml($this->item->event->object->source->getIcon())
+                (new SourceIcon(SourceIcon::SIZE_BIG))->addHtml($this->item->incident->object->source->getIcon())
             );
         }
 


### PR DESCRIPTION
fixes #184