### PR TITLE
IncidentsController: Use `severity` as default sort and fix `Opened On`

### DIFF
--- a/application/controllers/IncidentsController.php
+++ b/application/controllers/IncidentsController.php
@@ -36,9 +36,9 @@ class IncidentsController extends CompatController
         $sortControl = $this->createSortControl(
             $incidents,
             [
-                'incident.started_at'                         => t('Opened On'),
+                'incident.severity desc, incident.started_at' => t('Severity'),
+                'incident.started_at desc'                    => t('Opened On'),
                 'incident.recovered_at'                       => t('Recovered At'),
-                'incident.severity desc, incident.started_at' => t('Severity')
             ]
         );
 


### PR DESCRIPTION
The default sort of `Incident` model and controller must match.