### PR TITLE
ContactGroup: Fix contact deletion

### DIFF
--- a/application/forms/ContactGroupForm.php
+++ b/application/forms/ContactGroupForm.php
@@ -235,7 +235,13 @@ class ContactGroupForm extends CompatForm
         $toAdd = array_diff($newContacts, $storedContacts);
 
         if (! empty($toDelete)) {
-            $this->db->delete('contactgroup_member', ['contact_id IN (?)' => $toDelete]);
+            $this->db->delete(
+                'contactgroup_member',
+                [
+                    'contactgroup_id = ?' => $this->contactgroupId,
+                    'contact_id IN (?)'   => $toDelete
+                ]
+            );
 
             $isUpdated = true;
         }


### PR DESCRIPTION
The `ContactGroupForm` was missing a required condition to ensure that only memberships of the given group are going to get deleted.

Fixes: https://github.com/Icinga/icinga-notifications-web/issues/217