### PR TITLE
ObjectSuggestions: Fix exotic columns match

### DIFF
--- a/library/Notifications/Web/Control/SearchBar/ObjectSuggestions.php
+++ b/library/Notifications/Web/Control/SearchBar/ObjectSuggestions.php
@@ -232,9 +232,8 @@ class ObjectSuggestions extends Suggestions
     protected function matchSuggestion($path, $label, $searchTerm)
     {
         if (preg_match('/[_.](id)$/', $path)) {
-            // Only suggest exotic columns if the user knows about them
-            $trimmedSearch = trim($searchTerm, ' *');
-            return substr($path, -strlen($trimmedSearch)) === $trimmedSearch;
+            // Only suggest exotic columns if the user knows the full column path
+            return substr($path, strrpos($path, '.') + 1) === trim($searchTerm, ' *');
         }
 
         return parent::matchSuggestion($path, $label, $searchTerm);


### PR DESCRIPTION
These columns should only be shown if explicitly given by user. Previously, columns with a similar suffix were also found, e.g. the search for `id` also showed `uuid` as search suggestion.