### PR TITLE
Don't limit browser_session.user_agent to 4096 chars

### DIFF
--- a/library/Notifications/Daemon/Server.php
+++ b/library/Notifications/Daemon/Server.php
@@ -406,8 +406,7 @@ class Server
 
             if ($browserSession !== null) {
                 if (isset($headers['User-Agent'][0])) {
-                    // limit user-agent to 4k chars
-                    $userAgent = substr(trim($headers['User-Agent'][0]), 0, 4096);
+                    $userAgent = trim($headers['User-Agent'][0]);
                 } else {
                     $userAgent = 'default';
                 }

--- a/library/Notifications/ProvidedHook/SessionStorage.php
+++ b/library/Notifications/ProvidedHook/SessionStorage.php
@@ -39,8 +39,7 @@ class SessionStorage extends AuthenticationHook
             // user successfully authenticated
             $rawUserAgent = (new UserAgent())->getAgent();
             if ($rawUserAgent) {
-                // limit user-agent to 4k chars
-                $userAgent = substr(trim($rawUserAgent), 0, 4096);
+                $userAgent = trim($rawUserAgent);
             } else {
                 $userAgent = 'default';
             }
@@ -124,8 +123,7 @@ class SessionStorage extends AuthenticationHook
 
             $rawUserAgent = (new UserAgent())->getAgent();
             if ($rawUserAgent) {
-                // limit user-agent to 4k chars
-                $userAgent = substr(trim($rawUserAgent), 0, 4096);
+                $userAgent = trim($rawUserAgent);
             } else {
                 $userAgent = 'default';
             }


### PR DESCRIPTION
* This isn't necessary anymore due to https://github.com/Icinga/icinga-notifications/pull/239