### PR TITLE
Don't cut off milliseconds from current-time-in-milliseconds

### DIFF
--- a/application/forms/ChannelForm.php
+++ b/application/forms/ChannelForm.php
@@ -4,6 +4,7 @@
 
 namespace Icinga\Module\Notifications\Forms;
 
+use DateTime;
 use Icinga\Exception\Http\HttpNotFoundException;
 use Icinga\Module\Notifications\Model\Channel;
 use Icinga\Module\Notifications\Model\AvailableChannelType;
@@ -200,7 +201,7 @@ class ChannelForm extends CompatForm
         $channel = $this->getValues();
 
         $channel['config'] = json_encode($this->filterConfig($channel['config']));
-        $channel['changed_at'] = time() * 1000;
+        $channel['changed_at'] = (int) (new DateTime())->format("Uv");
 
         $this->db->insert('channel', $channel);
     }
@@ -221,7 +222,7 @@ class ChannelForm extends CompatForm
         $storedValues['config'] = json_encode($storedValues['config']);
 
         if (! empty(array_diff_assoc($channel, $storedValues))) {
-            $channel['changed_at'] = time() * 1000;
+            $channel['changed_at'] = (int) (new DateTime())->format("Uv");
 
             $this->db->update('channel', $channel, ['id = ?' => $this->channelId]);
         }
@@ -236,7 +237,7 @@ class ChannelForm extends CompatForm
     {
         $this->db->update(
             'channel',
-            ['changed_at' => time() * 1000, 'deleted' => 'y'],
+            ['changed_at' => (int) (new DateTime())->format("Uv"), 'deleted' => 'y'],
             ['id = ?' => $this->channelId]
         );
     }

--- a/application/forms/ContactGroupForm.php
+++ b/application/forms/ContactGroupForm.php
@@ -4,6 +4,7 @@
 
 namespace Icinga\Module\Notifications\Forms;
 
+use DateTime;
 use Icinga\Exception\Http\HttpNotFoundException;
 use Icinga\Module\Notifications\Common\Links;
 use Icinga\Module\Notifications\Model\Contact;
@@ -179,7 +180,7 @@ class ContactGroupForm extends CompatForm
 
         $this->db->beginTransaction();
 
-        $changedAt = time() * 1000;
+        $changedAt = (int) (new DateTime())->format("Uv");
         $this->db->insert('contactgroup', ['name' => trim($data['group_name']), 'changed_at' => $changedAt]);
 
         $groupIdentifier = $this->db->lastInsertId();
@@ -218,7 +219,7 @@ class ContactGroupForm extends CompatForm
 
         $storedValues = $this->fetchDbValues();
 
-        $changedAt = time() * 1000;
+        $changedAt = (int) (new DateTime())->format("Uv");
         if ($values['group_name'] !== $storedValues['group_name']) {
             $this->db->update(
                 'contactgroup',
@@ -298,7 +299,7 @@ class ContactGroupForm extends CompatForm
     {
         $this->db->beginTransaction();
 
-        $markAsDeleted = ['changed_at' => time() * 1000, 'deleted' => 'y'];
+        $markAsDeleted = ['changed_at' => (int) (new DateTime())->format("Uv"), 'deleted' => 'y'];
         $updateCondition = ['contactgroup_id = ?' => $this->contactgroupId, 'deleted = ?' => 'n'];
 
         $rotationAndMemberIds = $this->db->fetchPairs(

--- a/application/forms/MoveRotationForm.php
+++ b/application/forms/MoveRotationForm.php
@@ -4,6 +4,7 @@
 
 namespace Icinga\Module\Notifications\Forms;
 
+use DateTime;
 use Icinga\Exception\Http\HttpNotFoundException;
 use Icinga\Module\Notifications\Model\Rotation;
 use Icinga\Web\Session;
@@ -100,7 +101,7 @@ class MoveRotationForm extends Form
 
         $this->scheduleId = $rotation->schedule_id;
 
-        $changedAt = time() * 1000;
+        $changedAt = (int) (new DateTime())->format("Uv");
         // Free up the current priority used by the rotation in question
         $this->db->update('rotation', ['priority' => null, 'deleted' => 'y'], ['id = ?' => $rotationId]);
 

--- a/application/forms/RotationConfigForm.php
+++ b/application/forms/RotationConfigForm.php
@@ -310,7 +310,7 @@ class RotationConfigForm extends CompatForm
             $data['actual_handoff'] = $firstHandoff->format('U.u') * 1000.0;
         }
 
-        $changedAt = time() * 1000;
+        $changedAt = (int) (new DateTime())->format("Uv");
 
         $rotationsToMove = Rotation::on($this->db)
             ->columns('id')
@@ -429,7 +429,7 @@ class RotationConfigForm extends CompatForm
         $createStmt = $this->createRotation((int) $priority);
 
         $allEntriesRemoved = true;
-        $changedAt = time() * 1000;
+        $changedAt = (int) (new DateTime())->format("Uv");
         $markAsDeleted = ['changed_at' => $changedAt, 'deleted' => 'y'];
         if (self::EXPERIMENTAL_OVERRIDES) {
             // We only show a single name, even in case of multiple versions of a rotation.

--- a/application/forms/SaveEventRuleForm.php
+++ b/application/forms/SaveEventRuleForm.php
@@ -4,6 +4,7 @@
 
 namespace Icinga\Module\Notifications\Forms;
 
+use DateTime;
 use Exception;
 use Icinga\Exception\Http\HttpNotFoundException;
 use Icinga\Module\Notifications\Common\Database;
@@ -212,7 +213,7 @@ class SaveEventRuleForm extends Form
 
         $db->beginTransaction();
 
-        $changedAt = time() * 1000;
+        $changedAt = (int) (new DateTime())->format("Uv");
         $db->insert('rule', [
             'name' => $config['name'],
             'timeperiod_id' => $config['timeperiod_id'] ?? null,
@@ -272,7 +273,7 @@ class SaveEventRuleForm extends Form
      */
     private function insertOrUpdateEscalations($ruleId, array $escalations, Connection $db, bool $insert = false): void
     {
-        $changedAt = time() * 1000;
+        $changedAt = (int) (new DateTime())->format("Uv");
         foreach ($escalations as $position => $escalationConfig) {
             if ($insert) {
                 $db->insert('rule_escalation', [
@@ -390,7 +391,7 @@ class SaveEventRuleForm extends Form
             $data['object_filter'] = $values['object_filter'];
         }
 
-        $changedAt = time() * 1000;
+        $changedAt = (int) (new DateTime())->format("Uv");
         if (! empty($data)) {
             $db->update('rule', $data + ['changed_at' => $changedAt], ['id = ?' => $id]);
         }
@@ -472,7 +473,7 @@ class SaveEventRuleForm extends Form
                 ->assembleSelect()
         );
 
-        $markAsDeleted = ['changed_at' => time() * 1000, 'deleted' => 'y'];
+        $markAsDeleted = ['changed_at' => (int) (new DateTime())->format("Uv"), 'deleted' => 'y'];
         if (! empty($escalationsToRemove)) {
             $db->update(
                 'rule_escalation_recipient',

--- a/application/forms/ScheduleForm.php
+++ b/application/forms/ScheduleForm.php
@@ -4,6 +4,7 @@
 
 namespace Icinga\Module\Notifications\Forms;
 
+use DateTime;
 use Icinga\Exception\Http\HttpNotFoundException;
 use Icinga\Module\Notifications\Model\Rotation;
 use Icinga\Module\Notifications\Model\RuleEscalationRecipient;
@@ -73,7 +74,7 @@ class ScheduleForm extends CompatForm
     {
         $this->db->insert('schedule', [
             'name' => $this->getValue('name'),
-            'changed_at' => time() * 1000
+            'changed_at' => (int) (new DateTime())->format("Uv")
         ]);
 
         return $this->db->lastInsertId();
@@ -92,7 +93,7 @@ class ScheduleForm extends CompatForm
 
         $this->db->update('schedule', [
             'name'          => $values['name'],
-            'changed_at'    => time() * 1000
+            'changed_at'    => (int) (new DateTime())->format("Uv")
         ], ['id = ?' => $id]);
 
         $this->db->commitTransaction();
@@ -112,7 +113,7 @@ class ScheduleForm extends CompatForm
             $rotation->delete();
         }
 
-        $markAsDeleted = ['changed_at' => time() * 1000, 'deleted' => 'y'];
+        $markAsDeleted = ['changed_at' => (int) (new DateTime())->format("Uv"), 'deleted' => 'y'];
 
         $escalationIds = $this->db->fetchCol(
             RuleEscalationRecipient::on($this->db)

--- a/application/forms/SourceForm.php
+++ b/application/forms/SourceForm.php
@@ -4,6 +4,7 @@
 
 namespace Icinga\Module\Notifications\Forms;
 
+use DateTime;
 use Icinga\Exception\Http\HttpNotFoundException;
 use Icinga\Module\Notifications\Model\Source;
 use Icinga\Web\Session;
@@ -294,7 +295,7 @@ class SourceForm extends CompatForm
             self::HASH_ALGORITHM
         );
 
-        $source['changed_at'] = time() * 1000;
+        $source['changed_at'] = (int) (new DateTime())->format("Uv");
 
         $this->db->insert('source', $source);
     }
@@ -322,7 +323,7 @@ class SourceForm extends CompatForm
             $source['listener_password_hash'] = password_hash($listenerPassword, self::HASH_ALGORITHM);
         }
 
-        $source['changed_at'] = time() * 1000;
+        $source['changed_at'] = (int) (new DateTime())->format("Uv");
         $this->db->update('source', $source, ['id = ?' => $this->sourceId]);
 
         $this->db->commitTransaction();
@@ -335,7 +336,7 @@ class SourceForm extends CompatForm
     {
         $this->db->update(
             'source',
-            ['changed_at' => time() * 1000, 'deleted' => 'y'],
+            ['changed_at' => (int) (new DateTime())->format("Uv"), 'deleted' => 'y'],
             ['id = ?' => $this->sourceId]
         );
     }

--- a/library/Notifications/Model/Rotation.php
+++ b/library/Notifications/Model/Rotation.php
@@ -124,7 +124,7 @@ class Rotation extends Model
             $timeperiodId = $this->timeperiod->columns('id')->first()->id;
         }
 
-        $changedAt = time() * 1000;
+        $changedAt = (int) (new DateTime())->format("Uv");
         $markAsDeleted = ['changed_at' => $changedAt, 'deleted' => 'y'];
 
         $db->update('timeperiod_entry', $markAsDeleted, ['timeperiod_id = ?' => $timeperiodId,  'deleted = ?' => 'n']);

--- a/library/Notifications/Web/Form/ContactForm.php
+++ b/library/Notifications/Web/Form/ContactForm.php
@@ -4,6 +4,7 @@
 
 namespace Icinga\Module\Notifications\Web\Form;
 
+use DateTime;
 use Icinga\Exception\Http\HttpNotFoundException;
 use Icinga\Module\Notifications\Model\AvailableChannelType;
 use Icinga\Module\Notifications\Model\Channel;
@@ -183,7 +184,7 @@ class ContactForm extends CompatForm
     public function addContact(): void
     {
         $contactInfo = $this->getValues();
-        $changedAt = time() * 1000;
+        $changedAt = (int) (new DateTime())->format("Uv");
         $this->db->beginTransaction();
         $this->db->insert('contact', $contactInfo['contact'] + ['changed_at' => $changedAt]);
         $this->contactId = $this->db->lastInsertId();
@@ -214,7 +215,7 @@ class ContactForm extends CompatForm
         $values = $this->getValues();
         $storedValues = $this->fetchDbValues();
 
-        $changedAt = time() * 1000;
+        $changedAt = (int) (new DateTime())->format("Uv");
         if ($storedValues['contact'] !== $values['contact']) {
             $this->db->update(
                 'contact',
@@ -264,7 +265,7 @@ class ContactForm extends CompatForm
     {
         $this->db->beginTransaction();
 
-        $markAsDeleted = ['changed_at' => time() * 1000, 'deleted' => 'y'];
+        $markAsDeleted = ['changed_at' => (int) (new DateTime())->format("Uv"), 'deleted' => 'y'];
         $updateCondition = ['contact_id = ?' => $this->contactId, 'deleted = ?' => 'n'];
 
         $rotationAndMemberIds = $this->db->fetchPairs(

--- a/library/Notifications/Widget/Detail/IncidentQuickActions.php
+++ b/library/Notifications/Widget/Detail/IncidentQuickActions.php
@@ -4,6 +4,7 @@
 
 namespace Icinga\Module\Notifications\Widget\Detail;
 
+use DateTime;
 use Exception;
 use Icinga\Module\Notifications\Common\Database;
 use Icinga\Module\Notifications\Common\Icons;
@@ -233,7 +234,7 @@ class IncidentQuickActions extends Form
                 'type'                  => 'recipient_role_changed',
                 'new_recipient_role'    => $newRole,
                 'old_recipient_role'    => $oldRole,
-                'time'                  => time() * 1000.0
+                'time'                  => (int) (new DateTime())->format("Uv")
             ]
         );
     }


### PR DESCRIPTION
* Re: https://github.com/Icinga/icinga-notifications-web/issues/226#issuecomment-2695054673

The more precisely we write our timestamps, the less race conditions happen to the Go daemon's incremental config update mechanism if two users change something during the same second.

php > var_dump((int) (new DateTime())->format("Uv"));
int(1741607923054)
php > var_dump(time() * 1000);
int(1741607928000)
php >