### PR TITLE
Ensure new/updated rows having a changed_at greater than all previous ones

### DIFF
--- a/application/forms/ChannelForm.php
+++ b/application/forms/ChannelForm.php
@@ -203,7 +203,9 @@ class ChannelForm extends CompatForm
         $channel['config'] = json_encode($this->filterConfig($channel['config']));
         $channel['changed_at'] = (int) (new DateTime())->format("Uv");
 
-        $this->db->insert('channel', $channel);
+        $this->db->transaction(function (Connection $db) use ($channel): void {
+            $db->insert('channel', $channel);
+        });
     }
 
     /**
@@ -235,11 +237,13 @@ class ChannelForm extends CompatForm
      */
     public function removeChannel(): void
     {
-        $this->db->update(
-            'channel',
-            ['changed_at' => (int) (new DateTime())->format("Uv"), 'deleted' => 'y'],
-            ['id = ?' => $this->channelId]
-        );
+        $this->db->transaction(function (Connection $db): void {
+            $db->update(
+                'channel',
+                ['changed_at' => (int) (new DateTime())->format("Uv"), 'deleted' => 'y'],
+                ['id = ?' => $this->channelId]
+            );
+        });
     }
 
     /**

--- a/application/forms/ScheduleForm.php
+++ b/application/forms/ScheduleForm.php
@@ -72,12 +72,14 @@ class ScheduleForm extends CompatForm
 
     public function addSchedule(): int
     {
-        $this->db->insert('schedule', [
-            'name' => $this->getValue('name'),
-            'changed_at' => (int) (new DateTime())->format("Uv")
-        ]);
+        return $this->db->transaction(function (Connection $db) {
+            $db->insert('schedule', [
+                'name' => $this->getValue('name'),
+                'changed_at' => (int) (new DateTime())->format("Uv")
+            ]);
 
-        return $this->db->lastInsertId();
+            return $db->lastInsertId();
+        });
     }
 
     public function editSchedule(int $id): void

--- a/application/forms/SourceForm.php
+++ b/application/forms/SourceForm.php
@@ -297,7 +297,9 @@ class SourceForm extends CompatForm
 
         $source['changed_at'] = (int) (new DateTime())->format("Uv");
 
-        $this->db->insert('source', $source);
+        $this->db->transaction(function (Connection $db) use ($source): void {
+            $db->insert('source', $source);
+        });
     }
 
     /**
@@ -334,11 +336,13 @@ class SourceForm extends CompatForm
      */
     public function removeSource(): void
     {
-        $this->db->update(
-            'source',
-            ['changed_at' => (int) (new DateTime())->format("Uv"), 'deleted' => 'y'],
-            ['id = ?' => $this->sourceId]
-        );
+        $this->db->transaction(function (Connection $db): void {
+            $db->update(
+                'source',
+                ['changed_at' => (int) (new DateTime())->format("Uv"), 'deleted' => 'y'],
+                ['id = ?' => $this->sourceId]
+            );
+        });
     }
 
     /**

--- a/library/Notifications/Common/Database.php
+++ b/library/Notifications/Common/Database.php
@@ -85,6 +85,13 @@ final class Database
         $db = new Connection($config);
 
         $adapter = $db->getAdapter();
+
+        $db->prepexec(
+            $adapter instanceof Pgsql
+                ? 'SET SESSION CHARACTERISTICS AS TRANSACTION ISOLATION LEVEL SERIALIZABLE'
+                : 'SET SESSION TRANSACTION ISOLATION LEVEL SERIALIZABLE'
+        );
+
         if ($adapter instanceof Pgsql) {
             $db->getQueryBuilder()
                 ->on(QueryBuilder::ON_ASSEMBLE_SELECT, function (Select $select) {


### PR DESCRIPTION
The Go daemon's incremental config update mechanism regularily selects only config updates newer than the last known one.

This change ensures config rows having ascending changed_at, so nothing gets lost even if two users click during the same few ms. (E.g. CockroachDB allows nodes' clocks to differ by 7ms.)

closes https://github.com/Icinga/icinga-notifications/pull/288
closes https://github.com/Icinga/icinga-notifications/pull/237

## Tests

```
mysql> -- create in web
mysql> select changed_at from source;
ERROR 2013 (HY000): Lost connection to MySQL server during query
No connection. Trying to reconnect...
Connection id:    7
Current database: notifications

+---------------+
| changed_at    |
+---------------+
| 1742577440317 |
+---------------+
1 row in set (0,07 sec)

mysql> update source set changed_at=1742999000000;
Query OK, 1 row affected (0,01 sec)
Rows matched: 1  Changed: 1  Warnings: 0

mysql> select changed_at from source;
+---------------+
| changed_at    |
+---------------+
| 1742999000000 |
+---------------+
1 row in set (0,00 sec)

mysql> -- update in web
mysql> select changed_at from source;
+---------------+
| changed_at    |
+---------------+
| 1742999000001 |
+---------------+
1 row in set (0,00 sec)

mysql> -- insert in web again
mysql> select changed_at from source;
+---------------+
| changed_at    |
+---------------+
| 1742999000001 |
| 1742999000002 |
+---------------+
2 rows in set (0,00 sec)

mysql> -- create in web
mysql> select changed_at from source;
+---------------+
| changed_at    |
+---------------+
| 1742999000001 |
| 1742999000002 |
| 1742999000003 |
+---------------+
3 rows in set (0,01 sec)

mysql> -- rm * in web
mysql> select changed_at from source;
+---------------+
| changed_at    |
+---------------+
| 1742999000004 |
| 1742999000005 |
| 1742999000006 |
+---------------+
3 rows in set (0,00 sec)

mysql> -- create in web
mysql> select changed_at from source;
+---------------+
| changed_at    |
+---------------+
| 1742999000004 |
| 1742999000005 |
| 1742999000006 |
| 1742999000007 |
+---------------+
4 rows in set (0,01 sec)

mysql>
```

# 👍