### PR TITLE
ObjectsRendererHook: Always use `_next` as `data-base-target`

### DIFF
--- a/library/Notifications/Hook/ObjectsRendererHook.php
+++ b/library/Notifications/Hook/ObjectsRendererHook.php
@@ -283,6 +283,7 @@ abstract class ObjectsRendererHook
                     }
 
                     return $objectLink->addAttributes([
+                        'data-base-target' => '_next',
                         'class' => [
                             'icinga-module',
                             'module-' . ($sourceType === 'icinga2' ? 'icingadb' : $sourceType)


### PR DESCRIPTION
Otherwise, the link is opened in the same container (_self).