### PR TITLE
Handle unicode in contact and contact group names

### DIFF
--- a/library/Notifications/Widget/ItemList/ContactGroupListItem.php
+++ b/library/Notifications/Widget/ItemList/ContactGroupListItem.php
@@ -31,7 +31,7 @@ class ContactGroupListItem extends BaseListItem
         $visual->addHtml(new HtmlElement(
             'div',
             Attributes::create(['class' => 'contact-ball']),
-            Text::create($this->item->name[0])
+            Text::create(grapheme_substr($this->item->name, 0, 1))
         ));
     }
 

--- a/library/Notifications/Widget/ItemList/ContactListItem.php
+++ b/library/Notifications/Widget/ItemList/ContactListItem.php
@@ -35,7 +35,7 @@ class ContactListItem extends BaseListItem
         $visual->addHtml(new HtmlElement(
             'div',
             Attributes::create(['class' => 'contact-ball']),
-            Text::create($this->item->full_name[0])
+            Text::create(grapheme_substr($this->item->full_name, 0, 1))
         ));
     }
 


### PR DESCRIPTION
Accessing `$string[0]` returns the first byte, which may be only part of a UTF-8 encoded character. In that case, that byte on its own is invalid UTF-8 and will be replaced with the unicode replacement character which is then shown as the contact or contact group icon.

This commit fixes it by using `grapheme_substr()` instead which handles this properly. Note that `mb_substr()` also exists, but that wouldn't handle even more complex characters composed of multiple code points (like some emojis) correctly.

<details>
<summary>Quick demonstration how <code>[0]</code>, <code>substr()</code>, <code>mb_substr()</code>, <code>grapheme_substr()</code> handle different characters</summary>

```php
<?php

foreach (['ASCII is boring', 'Ähm was?', '💩', '👩‍👩‍👧‍👧'] as $input) {
	echo '                $input       : '; var_dump($input);
	echo '                $input[0]    : '; var_dump($input[0]);
	echo '         substr($input, 0, 1): '; var_dump(substr($input, 0, 1));
	echo '      mb_substr($input, 0, 1): '; var_dump(mb_substr($input, 0, 1));
	echo 'grapheme_substr($input, 0, 1): '; var_dump(grapheme_substr($input, 0, 1));
	echo "\n";
}
```

```
                $input       : string(15) "ASCII is boring"
                $input[0]    : string(1) "A"
         substr($input, 0, 1): string(1) "A"
      mb_substr($input, 0, 1): string(1) "A"
grapheme_substr($input, 0, 1): string(1) "A"

                $input       : string(9) "Ähm was?"
                $input[0]    : string(1) "�"
         substr($input, 0, 1): string(1) "�"
      mb_substr($input, 0, 1): string(2) "Ä"
grapheme_substr($input, 0, 1): string(2) "Ä"

                $input       : string(4) "💩"
                $input[0]    : string(1) "�"
         substr($input, 0, 1): string(1) "�"
      mb_substr($input, 0, 1): string(4) "💩"
grapheme_substr($input, 0, 1): string(4) "💩"

                $input       : string(25) "👩‍👩‍👧‍👧"
                $input[0]    : string(1) "�"
         substr($input, 0, 1): string(1) "�"
      mb_substr($input, 0, 1): string(4) "👩"
grapheme_substr($input, 0, 1): string(25) "👩‍👩‍👧‍👧"
```

`grapheme_substr()` is provided by PHP's `intl` extension, but this [is already required by Icinga Web](https://icinga.com/docs/icinga-web/latest/doc/02-Installation/#installing-requirements-from-source), so that doesn't introduce new dependencies.

</details>

### Tests

#### main (d69b33367eeeabd0de77994b55925ea0ef822ce3)

![20250422_14h44m26s_grim](https://github.com/user-attachments/assets/03c92ee8-0cab-4975-95d6-e33851d161fe)

#### This PR (ab647ef4375b472773186907784edf8239e46d27)

![20250422_14h44m49s_grim](https://github.com/user-attachments/assets/18ba605a-1181-47c6-9ade-28c09a9e2aea)

fixes #261