### PR TITLE
Revert "Ensure new/updated rows having a changed_at greater than all previous ones"

### DIFF
--- a/library/Notifications/Common/Database.php
+++ b/library/Notifications/Common/Database.php
@@ -14,6 +14,7 @@ use ipl\Sql\Connection;
 use ipl\Sql\Expression;
 use ipl\Sql\QueryBuilder;
 use ipl\Sql\Select;
+use ipl\Sql\Update;
 use PDO;
 
 final class Database
@@ -155,6 +156,16 @@ final class Database
                 }
 
                 $select->where([$baseTableAlias . '.' . $condition => 'n']);
+            })
+            ->on(QueryBuilder::ON_ASSEMBLE_UPDATE, function (Update $update) use ($db): void {
+                $set = $update->getSet();
+
+                if (! isset($set['changed_at'])) {
+                    return;
+                }
+
+                $set['changed_at'] = new Expression('GREATEST(?, 1 + changed_at)', null, $set['changed_at']);
+                $update->set($set);
             });
 
         return $db;

--- a/library/Notifications/Common/Database.php
+++ b/library/Notifications/Common/Database.php
@@ -4,7 +4,6 @@
 
 namespace Icinga\Module\Notifications\Common;
 
-use DateTime;
 use Icinga\Application\Config as AppConfig;
 use Icinga\Data\ResourceFactory;
 use Icinga\Exception\ConfigurationError;
@@ -13,10 +12,8 @@ use ipl\Sql\Adapter\Pgsql;
 use ipl\Sql\Config as SqlConfig;
 use ipl\Sql\Connection;
 use ipl\Sql\Expression;
-use ipl\Sql\Insert;
 use ipl\Sql\QueryBuilder;
 use ipl\Sql\Select;
-use ipl\Sql\Update;
 use PDO;
 
 final class Database
@@ -157,63 +154,10 @@ final class Database
                     return;
                 }
 
-                // getNextChangedAt() wants MAX(changed_at) of all rows, deleted or not
-                foreach ($select->getColumns() as $column) {
-                    if ($column instanceof Expression && strpos($column->getStatement(), 'MAX(changed_at)') !== false) {
-                        return;
-                    }
-                }
-
                 $select->where([$baseTableAlias . '.' . $condition => 'n']);
-            })
-            ->on(QueryBuilder::ON_ASSEMBLE_INSERT, function (Insert $insert) use ($db): void {
-                $columns = $insert->getColumns();
-                $pos = array_search('changed_at', $columns);
-
-                if ($pos === false) {
-                    return;
-                }
-
-                $values = $insert->getValues();
-                $values[$pos] = self::getNextChangedAt($db, $insert->getInto(), $values[$pos]);
-                $insert->values(array_combine($columns, $values));
-            })
-            ->on(QueryBuilder::ON_ASSEMBLE_UPDATE, function (Update $update) use ($db): void {
-                $set = $update->getSet();
-
-                if (! isset($set['changed_at'])) {
-                    return;
-                }
-
-                $set['changed_at'] = self::getNextChangedAt($db, $update->getTable()[0], $set['changed_at']);
-                $update->set($set);
             });
 
         return $db;
-    }
-
-    /**
-     * Return the next changed_at value for the given database and table
-     *
-     * @param Connection $db
-     * @param string $table
-     * @param mixed $nowUnixMilli
-     *
-     * @return int The given timestamp or 1 + the maximum changed_at value in the table, whichever is greater
-     */
-    private static function getNextChangedAt(Connection $db, string $table, $nowUnixMilli)
-    {
-        return $db->select(
-            (new Select())
-                ->from($table)
-                ->columns(
-                    ['changed_at' => new Expression(
-                        'GREATEST(?, 1 + COALESCE(MAX(changed_at), 0))',
-                        null,
-                        $nowUnixMilli
-                    )]
-                )
-        )->fetchColumn();
     }
 
     /**


### PR DESCRIPTION
This reverts commit 5ddc751f4e05ec9fecc851dd57bf314c983381c4.

As you requested, now completely different channels won't conflict (40001) w/ each other, as they don't SELECT a common MAX(changed_at) in a serializable tx.

But one and the same e.g channel would still conflict (40001) if updated by two users which is good.