### PR TITLE
Fix button margins

### DIFF
--- a/application/controllers/EventRulesController.php
+++ b/application/controllers/EventRulesController.php
@@ -14,7 +14,9 @@ use Icinga\Module\Notifications\Widget\ItemList\EventRuleList;
 use Icinga\Web\Notification;
 use Icinga\Web\Session;
 use ipl\Html\Html;
+use ipl\Html\ValidHtml;
 use ipl\Stdlib\Filter;
+use ipl\Web\Common\BaseItemList;
 use ipl\Web\Compat\CompatController;
 use ipl\Web\Compat\SearchControls;
 use ipl\Web\Control\LimitControl;
@@ -166,6 +168,22 @@ class EventRulesController extends CompatController
 
         $this->addControl($eventRuleFormAndSave);
         $this->addContent($eventRuleConfig);
+    }
+
+    /**
+     * Add attribute 'class' => 'full-width' if the content is an instance of BaseItemList
+     *
+     * @param ValidHtml $content
+     *
+     * @return EventRulesController
+     */
+    protected function addContent(ValidHtml $content)
+    {
+        if ($content instanceof BaseItemList) {
+            $this->content->getAttributes()->add('class', 'full-width');
+        }
+
+        return parent::addContent($content);
     }
 
     public function completeAction(): void

--- a/application/controllers/EventRulesController.php
+++ b/application/controllers/EventRulesController.php
@@ -90,7 +90,7 @@ class EventRulesController extends CompatController
                 Url::fromPath('notifications/event-rule/edit', ['id' => -1, 'clearCache' => true]),
                 'plus'
             ))->openInModal()
-            ->addAttributes(['class' => 'new-event-rule'])
+            ->addAttributes(['class' => 'add-new-component'])
         );
 
         $this->addContent(new EventRuleList($eventRules));

--- a/application/controllers/SchedulesController.php
+++ b/application/controllers/SchedulesController.php
@@ -70,7 +70,7 @@ class SchedulesController extends CompatController
                 Links::scheduleAdd(),
                 'plus',
                 [
-                    'class' => 'add-schedule-control'
+                    'class' => 'add-new-component'
                 ]
             ))->openInModal()
         );

--- a/application/controllers/SchedulesController.php
+++ b/application/controllers/SchedulesController.php
@@ -9,7 +9,9 @@ use Icinga\Module\Notifications\Common\Links;
 use Icinga\Module\Notifications\Model\Schedule;
 use Icinga\Module\Notifications\Web\Control\SearchBar\ObjectSuggestions;
 use Icinga\Module\Notifications\Widget\ItemList\ScheduleList;
+use ipl\Html\ValidHtml;
 use ipl\Stdlib\Filter;
+use ipl\Web\Common\BaseItemList;
 use ipl\Web\Compat\CompatController;
 use ipl\Web\Compat\SearchControls;
 use ipl\Web\Control\LimitControl;
@@ -80,6 +82,22 @@ class SchedulesController extends CompatController
         }
 
         $this->getTabs()->activate('schedules');
+    }
+
+    /**
+     * Add attribute 'class' => 'full-width' if the content is an instance of BaseItemList
+     *
+     * @param ValidHtml $content
+     *
+     * @return SchedulesController
+     */
+    protected function addContent(ValidHtml $content)
+    {
+        if ($content instanceof BaseItemList) {
+            $this->content->getAttributes()->add('class', 'full-width');
+        }
+
+        return parent::addContent($content);
     }
 
     public function completeAction(): void


### PR DESCRIPTION
Fix the missing button margins by adding the full-width class to the contents and set the button's classes to `.add-new-component`.

Fixes #330 