### PR TITLE
Handle config decoding errors from DB charset issues

### DIFF
--- a/application/forms/ChannelForm.php
+++ b/application/forms/ChannelForm.php
@@ -6,14 +6,16 @@ namespace Icinga\Module\Notifications\Forms;
 
 use DateTime;
 use Icinga\Exception\Http\HttpNotFoundException;
-use Icinga\Module\Notifications\Model\Channel;
 use Icinga\Module\Notifications\Model\AvailableChannelType;
+use Icinga\Module\Notifications\Model\Channel;
 use Icinga\Module\Notifications\Model\Contact;
 use Icinga\Module\Notifications\Model\RuleEscalationRecipient;
 use Icinga\Web\Session;
+use ipl\Html\Attributes;
 use ipl\Html\Contract\FormSubmitElement;
 use ipl\Html\FormElement\BaseFormElement;
 use ipl\Html\FormElement\FieldsetElement;
+use ipl\Html\HtmlElement;
 use ipl\I18n\GettextTranslator;
 use ipl\I18n\StaticTranslator;
 use ipl\Sql\Connection;
@@ -267,6 +269,24 @@ class ChannelForm extends CompatForm
         $elementsConfig = json_decode($config, true);
 
         if (empty($elementsConfig)) {
+            $this->prependHtml(
+                HtmlElement::create(
+                    'ul',
+                    Attributes::create(['class' => 'errors']),
+                    HtmlElement::create(
+                        'li',
+                        null,
+                        sprintf(
+                            $this->translate(
+                                'Could not decode options for type \'%s\'.'
+                                . ' Check if your database\'s character set is correctly configured.'
+                            ),
+                            $type
+                        )
+                    )
+                )
+            );
+
             return;
         }
 
@@ -448,5 +468,21 @@ class ChannelForm extends CompatForm
             'type'      => $channel->type,
             'config'    => json_decode($channel->config, true) ?? []
         ];
+    }
+
+    /**
+     * Validate all elements
+     *
+     * @return $this
+     */
+    public function validate(): self
+    {
+        parent::validate();
+
+        if (! $this->hasElement('config')) {
+            $this->isValid = false;
+        }
+
+        return $this;
     }
 }

--- a/library/Notifications/Common/Database.php
+++ b/library/Notifications/Common/Database.php
@@ -82,6 +82,13 @@ final class Database
                 . ",NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION'";
         }
 
+        if (empty($config->charset)) {
+            $config->charset = match ($config->db) {
+                'mysql' => 'utf8mb4',
+                default => 'utf8',
+            };
+        }
+
         $db = new Connection($config);
 
         $adapter = $db->getAdapter();


### PR DESCRIPTION
If the database's character set is not set correctly, the decoding of the config attributes may fail. For that case an error message will be rendered in the form. There will also be a docs entry to prevent that.

Closes #271 