### PR TITLE
Remove tests for PHP versions below 8.2

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3']
+        php: ['8.2', '8.3']
         os: ['ubuntu-latest']
 
     steps:
@@ -51,17 +51,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3']
+        php: ['8.2', '8.3']
         os: ['ubuntu-latest']
-        include:
-          - php: '7.2'
-            phpunit-version: 8.5
-          - php: '7.3'
-            phpunit-version: 9.6
-          - php: '7.4'
-            phpunit-version: 9.6
-          - php: '8.0'
-            phpunit-version: 9.6
 
     steps:
       - name: Checkout code base


### PR DESCRIPTION
Because we have set PHP 8.2 as a new basic version for new modules.