### PR TITLE
events: Pass filters to urls using `Url::setFilter()`

### DIFF
--- a/application/controllers/EventsController.php
+++ b/application/controllers/EventsController.php
@@ -83,8 +83,9 @@ class EventsController extends CompatController
         $this->addControl($limitControl);
         $this->addControl($searchBar);
 
-        $url = Url::fromRequest()->onlyWith($preserveParams);
-        $url->setQueryString(QueryString::render($filter) . '&' . $url->getParams()->toString());
+        $url = Url::fromRequest()
+            ->onlyWith($preserveParams)
+            ->setFilter($filter);
 
         $eventList = (new LoadMoreObjectList($events->execute()))
             ->setPageSize($limitControl->getLimit())


### PR DESCRIPTION
A small change I found in my stash.