### PR TITLE
EventRulesController: Do not update col1 upon adding a rule

### DIFF
--- a/application/controllers/EventRulesController.php
+++ b/application/controllers/EventRulesController.php
@@ -102,8 +102,7 @@ class EventRulesController extends CompatController
             ->populate(['id' => -1])
             ->setCsrfCounterMeasureId(Session::getSession()->getId())
             ->setAction(Url::fromRequest()->getAbsoluteUrl())
-            ->on(Form::ON_SUCCESS, function ($form) {
-                $this->sendExtraUpdates(['#col1']);
+            ->on(Form::ON_SUBMIT, function ($form) {
                 $this->getResponse()->setHeader('X-Icinga-Container', 'col2');
                 $this->redirectNow(Links::eventRule(-1)->addParams(['name' => $form->getValue('name')]));
             })->handleRequest($this->getServerRequest());


### PR DESCRIPTION
That's a remnant of a previous implementation. It causes two parallel requests, both access and update the session. The last request updating the session overrides the changes of the other and in case of xDebug being disabled or inactive the timing of the requests is different, hence I did not notice this prior. So the actual problem is not solved…

fixes #355