### PR TITLE
css: Do not "cut through" a recipient's name too much

### DIFF
--- a/public/css/calendar.less
+++ b/public/css/calendar.less
@@ -385,6 +385,6 @@
 
 @light-mode: {
   .time-grid .entry {
-    mix-blend-mode: revert;
+    mix-blend-mode: darken;
   }
 };

--- a/public/css/timeline.less
+++ b/public/css/timeline.less
@@ -187,7 +187,7 @@
           display: flex;
           align-items: flex-end;
           width: 1px;
-          border-left: 1px solid red;
+          border-left: 1px solid rgba(255, 0, 0, 0.5);
           z-index: 1;
 
           .now {


### PR DESCRIPTION
This is an attempt to solve the problem of the now indicator to cut through a recipient's name. In dark mode this isn't too obvious, but in light mode the line makes characters hard to read if they overlap.