### PR TITLE
Fix current timeline for times between 11:45 pm and 11:59 pm

### DIFF
--- a/library/Notifications/Widget/Timeline.php
+++ b/library/Notifications/Widget/Timeline.php
@@ -370,17 +370,13 @@ class Timeline extends BaseHtmlElement implements EntryProvider
                 )
             );
 
-            $beforeHour = $now->format('H');
             $now = Util::roundToNearestThirtyMinute($now);
-
-            if ($beforeHour === '23' && $now->format('H') === '00') {
-                $now->sub(new DateInterval('PT30M'));
-            }
+            $diff = $this->start->diff($now);
 
             $this->getStyle()->addFor($currentTime, [
                 '--timeStartColumn' =>
-                    $now->format('G') * 2 // 2 columns per hour
-                    + ($now->format('i') >= 30 ? 1 : 0) // 1 column for the half hour
+                    ($diff->d * 24 + $diff->h) * 2 // 2 columns per hour
+                    + ($diff->i >= 30 ? 1 : 0) // 1 column for the half hour
                     + 1 // CSS starts counting columns from 1, not zero
             ]);
 


### PR DESCRIPTION
Use the current timestamp rounded to the nearest thirty minutes to take a diff to the day's start at 12 am. Use the `past hours * 2` plus 1 if the half hour is past to align the clock correctly. If the rounded current time is 12 am at the next day the diff will return **0 past hours**, but **1 past day**. For this case we will multiply the past days by **24**.

Fix #367 