### PR TITLE
Select a proper expression when performing exists queries

### DIFF
--- a/application/controllers/ContactGroupsController.php
+++ b/application/controllers/ContactGroupsController.php
@@ -18,6 +18,7 @@ use Icinga\Web\Notification;
 use ipl\Html\Form;
 use ipl\Html\HtmlString;
 use ipl\Html\TemplateString;
+use ipl\Sql\Expression;
 use ipl\Stdlib\Filter;
 use ipl\Web\Compat\CompatController;
 use ipl\Web\Compat\SearchControls;
@@ -91,8 +92,8 @@ class ContactGroupsController extends CompatController
         );
 
         $emptyStateMessage = null;
-        if (Contact::on(Database::get())->columns('1')->limit(1)->first() === null) {
-            if (Channel::on(Database::get())->columns('1')->limit(1)->first() === null) {
+        if (Contact::on(Database::get())->columns([new Expression('1')])->limit(1)->first() === null) {
+            if (Channel::on(Database::get())->columns([new Expression('1')])->limit(1)->first() === null) {
                 $addButton->disable($this->translate('A channel is required to add a contact group'));
 
                 $emptyStateMessage = TemplateString::create(

--- a/application/forms/ChannelForm.php
+++ b/application/forms/ChannelForm.php
@@ -20,6 +20,7 @@ use ipl\Html\HtmlElement;
 use ipl\I18n\GettextTranslator;
 use ipl\I18n\StaticTranslator;
 use ipl\Sql\Connection;
+use ipl\Sql\Expression;
 use ipl\Stdlib\Filter;
 use ipl\Validator\EmailAddressValidator;
 use ipl\Web\Common\CsrfCounterMeasure;
@@ -128,13 +129,13 @@ class ChannelForm extends CompatForm
 
         if ($this->channelId !== null) {
             $isInUse = Contact::on($this->db)
-                ->columns('1')
+                ->columns([new Expression('1')])
                 ->filter(Filter::equal('default_channel_id', $this->channelId))
                 ->first();
 
             if ($isInUse === null) {
                 $isInUse = RuleEscalationRecipient::on($this->db)
-                    ->columns('1')
+                    ->columns([new Expression('1')])
                     ->filter(Filter::equal('channel_id', $this->channelId))
                     ->first();
             }

--- a/library/Notifications/Model/Rotation.php
+++ b/library/Notifications/Model/Rotation.php
@@ -145,7 +145,7 @@ class Rotation extends Model
         $requirePriorityUpdate = true;
         if (RotationConfigForm::EXPERIMENTAL_OVERRIDES) {
             $rotations = self::on($db)
-                ->columns('1')
+                ->columns([new Expression('1')])
                 ->filter(Filter::equal('schedule_id', $this->schedule_id))
                 ->filter(Filter::equal('priority', $this->priority))
                 ->first();


### PR DESCRIPTION
ipl\Orm translates this, due to a quirk in PHP where numerical strings are interpreted as integer keys in arrays, to the second column of the given base model. This is undocumented behavior and must be avoided.