### PR TITLE
event-rule: Do not delete rules by pushing Enter

### DIFF
--- a/application/forms/EventRuleConfigForm.php
+++ b/application/forms/EventRuleConfigForm.php
@@ -195,7 +195,13 @@ class EventRuleConfigForm extends Form
      */
     public function createExternalSubmitButtons(): array
     {
-        $buttons = [];
+        $buttons = [
+            $this->createElement('submitButton', 'save', [
+                'data-progress-label' => $this->translate('Saving rule'),
+                'label' => $this->translate('Save'),
+                'form' => 'event-rule-config-form'
+            ])
+        ];
 
         if ((int) $this->getValue('id') !== -1) {
             $buttons[] = $this->createElement('submitButton', 'delete', [
@@ -206,12 +212,6 @@ class EventRuleConfigForm extends Form
                 'formnovalidate' => true
             ]);
         }
-
-        $buttons[] = $this->createElement('submitButton', 'save', [
-            'data-progress-label' => $this->translate('Saving rule'),
-            'label' => $this->translate('Save'),
-            'form' => 'event-rule-config-form'
-        ]);
 
         return $buttons;
     }

--- a/public/css/detail/event-rule-detail.less
+++ b/public/css/detail/event-rule-detail.less
@@ -249,6 +249,7 @@
 
   #save-config {
     display: flex;
+    flex-direction: row-reverse;
     gap: .5em;
     max-height: 2em;
 


### PR DESCRIPTION
External buttons seem to also follow the rule that the first associated button is chosen by default.

fixes #382