### PR TITLE
delete escalations before updating positions

### DIFF
--- a/application/forms/EventRuleConfigForm.php
+++ b/application/forms/EventRuleConfigForm.php
@@ -311,9 +311,9 @@ class EventRuleConfigForm extends CompatForm
         $escalations = $this->getElement('escalations')->getEscalations();
         $remainingDbEscalations = [];
         $escalationConfigs = [];
-        foreach ($escalations as $escalation) {
+        foreach ($escalations as $index => $escalation) {
             $config = $escalation->getEscalation();
-            $escalationConfigs[] = $config;
+            $escalationConfigs[$index] = $config;
             if ($config['id'] !== null) {
                 $remainingDbEscalations[$config['id']] = $escalationsFromDb[$config['id']];
                 unset($escalationsFromDb[$config['id']]);


### PR DESCRIPTION
fix: #371 
Before updating escalation positions, any escalations removed by the user must be marked as deleted in the database. This prevents duplicate (rule_id, position) entries in the rule_escalation table, which previously caused an SQL error.