### PR TITLE
fix handling of multi day rotation entries that end the same day they started

### DIFF
--- a/application/forms/RotationConfigForm.php
+++ b/application/forms/RotationConfigForm.php
@@ -1431,7 +1431,8 @@ class RotationConfigForm extends CompatForm
                 if (
                     $fromDay < $toDay && ($firstHandoffDay < $fromDay || $firstHandoffDay > $toDay)
                     || $toDay < $fromDay && ($firstHandoffDay < $fromDay && $firstHandoffDay > $toDay)
-                    || $firstHandoffDay === $toDay && $toDay !== $fromDay && $options["to_at"] === "00:00"
+                    || $firstHandoffDay === $toDay && $toDay !== $fromDay
+                    && $firstHandoff >= $this->parseDateAndTime($this->getValue('first_handoff'), $options['to_at'])
                 ) {
                     // Normalize the first handoff to the first day of the shift in case it's outside the range
                     $firstHandoff->add(new DateInterval(sprintf(


### PR DESCRIPTION
fix: #366
Rotations that have their start on the same day as their to-day, will now have their first entries created correctly.
<img width="1152" height="432" alt="Screenshot from 2025-11-05 14-37-19" src="https://github.com/user-attachments/assets/a60aa974-5f95-464f-a706-d79ec06a3f74" />
