### PR TITLE
Fix/incorrect flyout text

### DIFF
--- a/library/Notifications/Widget/Timeline/EntryFlyout.php
+++ b/library/Notifications/Widget/Timeline/EntryFlyout.php
@@ -281,13 +281,13 @@ class EntryFlyout extends BaseHtmlElement
             'multi'   => $this->rotationOptions['from_at'],
         };
 
-        $startTime = $timeFormatter->format(DateTime::createFromFormat('H:i', $startTime));
-        if (new DateTime() < DateTime::createFromFormat('Y-m-d H:i A', $this->firstHandoff . ' ' . $startTime)) {
+        if (new DateTime() < DateTime::createFromFormat('Y-m-d H:i', $this->firstHandoff . ' ' . $startTime)) {
             $startText = $this->translate('Starts on %s');
         } else {
             $startText = $this->translate('Started on %s');
         }
 
+        $startTime = $timeFormatter->format(DateTime::createFromFormat('H:i', $startTime));
         $firstHandoffInfo = new HtmlElement(
             'span',
             Attributes::create(['class' => 'rotation-info-start']),


### PR DESCRIPTION
fix: #395
The daytime of the handoff is now shown on 24/4 rotations.
<img width="352" height="216" alt="Screenshot from 2025-11-06 09-05-45" src="https://github.com/user-attachments/assets/7beaa505-d9ac-4199-a12a-0e80de1b3c4b" />

Also an other Bug pointed out by @jrauh01 is fixed, where a rotation was marked as started prematurely, if it's start day matched the current day, but the start time was yet to come.