### PR TITLE
Fix FutureEntry indicator

### DIFF
--- a/public/css/timeline.less
+++ b/public/css/timeline.less
@@ -156,6 +156,7 @@
         justify-content: end;
         z-index: 2; // overlap the .clock .time-hand
         pointer-events: all;
+        overflow: hidden;
 
         > div {
           margin-top: 1em;


### PR DESCRIPTION
fix: #405 
The bug was caused by setting the overlay's overflow to visible in #374, so explicitly setting it to hidden on the future-entry should do the trick.