### PR TITLE
Calculate the days since latest handoff correctly

### DIFF
--- a/library/Notifications/Widget/Timeline/Rotation.php
+++ b/library/Notifications/Widget/Timeline/Rotation.php
@@ -151,7 +151,12 @@ class Rotation
                 );
 
                 if ($timeperiodEntry->start_time < $before) {
-                    $daysSinceLatestHandoff = $timeperiodEntry->start_time->diff($before)->days % $interval;
+                    $daysSinceFirstHandoff = $timeperiodEntry->start_time->diff($before)->days;
+                    $daysSinceLatestHandoff = $daysSinceFirstHandoff % $interval;
+                    if ($daysSinceFirstHandoff > 0 && $daysSinceLatestHandoff === 0) {
+                        $daysSinceLatestHandoff = $interval;
+                    }
+
                     $firstHandoff = (clone $before)->sub(new DateInterval(sprintf('P%dD', $daysSinceLatestHandoff)));
                 } else {
                     $firstHandoff = $timeperiodEntry->start_time;


### PR DESCRIPTION
## Problem

If the **last handoff ends today** and the **next handoff did already happen today**, the days since the latest handoff are `0`. That is correct, because the latest handoff happened today. Thus we get the current handoff as the first one. What we want is the handoff before.

## Solution

We now calculate the days since the latest handoff that did not happen **today**.

Checks:
- Check if there was an handoff before by checking if `days since the first handoff > 0`
- Check if `days since first handoff % $interval === 0`

If so set `$daysSinceLatestHandoff` to `$interval`.

fixes #412 