### PR TITLE
Timeline: Make sure the header overlaps everything again

### DIFF
--- a/library/Notifications/Widget/TimeGrid/DaysHeader.php
+++ b/library/Notifications/Widget/TimeGrid/DaysHeader.php
@@ -63,6 +63,8 @@ class DaysHeader extends BaseHtmlElement
             $displayTimezone
         );
 
+        $this->addHtml(new HtmlElement('span', Attributes::create(['class' => 'spacer'])));
+
         for ($i = 0; $i < $this->days; $i++) {
             if ($time == $today) {
                 $title = [new HtmlElement(

--- a/public/css/calendar.less
+++ b/public/css/calendar.less
@@ -46,7 +46,7 @@
     display: grid;
     align-items: flex-end;
     border-left: 1px solid transparent;
-    grid-template-columns: repeat(var(--primaryColumns), minmax(var(--minimumPrimaryColumnWidth), 1fr));
+    grid-template-columns: var(--sidebarWidth) repeat(var(--primaryColumns), minmax(var(--minimumPrimaryColumnWidth), 1fr));
 
     .column-title {
       border-right: 1px solid transparent;
@@ -233,7 +233,7 @@
   grid-template-rows: var(--headerHeight) var(--headerHeight) minmax(0, 1fr);
 
   .time-grid-header {
-    grid-area: ~"1 / 2 / 3 / 3";
+    grid-area: ~"1 / 1 / 3 / 3";
   }
 
   .sidebar {
@@ -275,6 +275,19 @@
   .day-name {
     color: @text-color-light;
     text-transform: uppercase;
+  }
+
+  position: relative;
+
+  &::after {
+    content: "";
+    position: absolute;
+    bottom: 0;
+    left: -1px;
+    right: -1px;
+    display: block;
+    height: 1px;
+    .box-shadow(0, 1px, 0, 0, @gray-lighter);
   }
 }
 
@@ -332,6 +345,10 @@
   .step {
     border-color: @gray-lighter;
     color: @text-color-light;
+  }
+
+  &:has(.time-grid-header) .step[data-y-position="0"] {
+    border-top-color: transparent;
   }
 
   .step,

--- a/public/css/timeline.less
+++ b/public/css/timeline.less
@@ -24,7 +24,7 @@
     .time-grid-header {
       box-sizing: border-box;
       position: sticky;
-      z-index: 3; // overlap everything
+      z-index: 4; // overlap everything
       top: 0;
       height: var(--daysHeaderHeight);
     }


### PR DESCRIPTION
Didn't succeed while trying to fix the flyout positioning. The problem is that since the header is a sticky element, it's not influencing the containers offsetHeight/scrollHeight and so there's no way to know for sure where the constraints of the box really are. But the workaround for the user should be straightforward anyway: Just scroll the content down again.

fixes #399