### PR TITLE
Ensure a consistent order of entries in the api description

### DIFF
--- a/application/clicommands/OpenapiCommand.php
+++ b/application/clicommands/OpenapiCommand.php
@@ -8,6 +8,7 @@ use FilesystemIterator;
 use Icinga\Application\Icinga;
 use Icinga\Cli\Command;
 use Icinga\Module\Notifications\Api\OpenApiPreprocessor\AddGlobal401Response;
+use Icinga\Module\Notifications\Api\OpenApiPreprocessor\ConsistentOrder;
 use Icinga\Module\Notifications\Common\PsrLogger;
 use OpenApi\Generator;
 use RecursiveDirectoryIterator;
@@ -31,7 +32,7 @@ class OpenapiCommand extends Command
      * OPTIONS
      *
      * --dir <path/>                            Set the path to the directory to scan for PHP files.
-*                                               Default: /library/Notifications/Api/
+     *                                          Default: /library/Notifications/Api/
      *
      * --exclude <comma seperated strings>      Exclude files matching these strings. Wildcard is `*`
      *
@@ -75,7 +76,9 @@ class OpenapiCommand extends Command
 
         $generator = new Generator(new PsrLogger());
         $generator->setVersion($oadVersion);
-        $generator->getProcessorPipeline()->add(new AddGlobal401Response());
+        $generator->getProcessorPipeline()
+            ->add(new ConsistentOrder())
+            ->add(new AddGlobal401Response());
 
         try {
             $openapi = $generator->generate($files);

--- a/doc/api/api-v1-public.json
+++ b/doc/api/api-v1-public.json
@@ -12,84 +12,6 @@
         }
     ],
     "paths": {
-        "/channels/{identifier}": {
-            "get": {
-                "tags": [
-                    "Channels"
-                ],
-                "summary": "Get a specific Channel by its UUID",
-                "description": "Retrieve detailed information about a specific notification Channel using its UUID",
-                "operationId": "getChannel",
-                "parameters": [
-                    {
-                        "name": "identifier",
-                        "in": "path",
-                        "description": "The UUID of the Channel to retrieve",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/components/schemas/ChannelUUID"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful response with a single Channel result",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "properties": {
-                                        "data": {
-                                            "$ref": "#/components/schemas/Channel",
-                                            "description": "Successfull response with the Channel object"
-                                        }
-                                    },
-                                    "type": "object"
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ErrorResponse"
-                                },
-                                "examples": {
-                                    "InvalidIdentifier": {
-                                        "$ref": "#/components/examples/InvalidIdentifier"
-                                    },
-                                    "NoIdentifierWithFilter": {
-                                        "$ref": "#/components/examples/NoIdentifierWithFilter"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "Channel Not Found",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ErrorResponse"
-                                },
-                                "examples": {
-                                    "ResourceNotFound": {
-                                        "summary": "Resource not found",
-                                        "value": {
-                                            "message": "Channel not found"
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "401": {
-                        "description": "Unauthorized"
-                    }
-                }
-            }
-        },
         "/channels": {
             "get": {
                 "tags": [
@@ -183,6 +105,344 @@
                                     },
                                     "InvalidFilterParameter": {
                                         "$ref": "#/components/examples/InvalidFilterParameter"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized"
+                    }
+                }
+            }
+        },
+        "/channels/{identifier}": {
+            "get": {
+                "tags": [
+                    "Channels"
+                ],
+                "summary": "Get a specific Channel by its UUID",
+                "description": "Retrieve detailed information about a specific notification Channel using its UUID",
+                "operationId": "getChannel",
+                "parameters": [
+                    {
+                        "name": "identifier",
+                        "in": "path",
+                        "description": "The UUID of the Channel to retrieve",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/components/schemas/ChannelUUID"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful response with a single Channel result",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/components/schemas/Channel",
+                                            "description": "Successfull response with the Channel object"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                },
+                                "examples": {
+                                    "InvalidIdentifier": {
+                                        "$ref": "#/components/examples/InvalidIdentifier"
+                                    },
+                                    "NoIdentifierWithFilter": {
+                                        "$ref": "#/components/examples/NoIdentifierWithFilter"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Channel Not Found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                },
+                                "examples": {
+                                    "ResourceNotFound": {
+                                        "summary": "Resource not found",
+                                        "value": {
+                                            "message": "Channel not found"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized"
+                    }
+                }
+            }
+        },
+        "/contact-groups": {
+            "get": {
+                "tags": [
+                    "Contact Groups"
+                ],
+                "summary": "List all Contact Groups or filter by parameters",
+                "description": "Retrieve all Contact Groups or filter them by parameters.",
+                "operationId": "listContactgroup",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "query",
+                        "description": "Filter by Contact Group UUID",
+                        "required": false,
+                        "schema": {
+                            "schema": "ContactgroupUUID",
+                            "title": "ContactgroupUUID",
+                            "description": "An UUID representing a notification Contactgroup",
+                            "type": "string",
+                            "format": "uuid",
+                            "maxLength": 36,
+                            "minLength": 36,
+                            "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
+                            "example": null
+                        }
+                    },
+                    {
+                        "name": "name",
+                        "in": "query",
+                        "description": "Filter by Contact Group name",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful response with multiple Contactgroup results",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "data": {
+                                            "description": "Successful response with an array of Contactgroup objects",
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/components/schemas/Contactgroup"
+                                            }
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                },
+                                "examples": {
+                                    "NoIdentifierWithFilter": {
+                                        "$ref": "#/components/examples/NoIdentifierWithFilter"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                },
+                                "examples": {
+                                    "InvalidRequestBodyId": {
+                                        "$ref": "#/components/examples/InvalidRequestBodyId"
+                                    },
+                                    "InvalidFilterParameter": {
+                                        "$ref": "#/components/examples/InvalidFilterParameter"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized"
+                    }
+                }
+            },
+            "post": {
+                "tags": [
+                    "Contact Groups"
+                ],
+                "summary": "Create a new Contact Group",
+                "description": "Create a new Contact Group",
+                "operationId": "createContactgroup",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "allOf": [
+                                    {
+                                        "$ref": "#/components/schemas/Contactgroup"
+                                    },
+                                    {
+                                        "properties": {
+                                            "id": {
+                                                "$ref": "#/components/schemas/NewContactgroupUUID"
+                                            }
+                                        },
+                                        "type": "object"
+                                    }
+                                ]
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "201": {
+                        "description": "Contactgroup created successfully",
+                        "headers": {
+                            "X-Resource-Identifier": {
+                                "description": "The identifier of the created Contactgroup",
+                                "schema": {
+                                    "type": "string",
+                                    "format": "uuid"
+                                }
+                            },
+                            "Location": {
+                                "description": "The URL of the created Contactgroup",
+                                "schema": {
+                                    "type": "string",
+                                    "format": "url",
+                                    "example": "notifications/api/v1/contactgroups/{identifier}"
+                                }
+                            }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/SuccessResponse"
+                                },
+                                "examples": {
+                                    "ContactgroupCreated": {
+                                        "summary": "Contactgroup created successfully",
+                                        "value": {
+                                            "message": "Contactgroup created successfully"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "links": {
+                            "GetContactgroupByIdentifier": {
+                                "operationId": "getContactgroup",
+                                "parameters": {
+                                    "identifier": "$response.header.X-Resource-Identifier"
+                                },
+                                "description": "Retrieve the created contact using the X-Resource-Identifier header"
+                            },
+                            "UpdateContactgroupByIdentifier": {
+                                "operationId": "updateContactgroup",
+                                "parameters": {
+                                    "identifier": "$response.header.X-Resource-Identifier"
+                                },
+                                "description": "Update the created contact using the X-Resource-Identifier header"
+                            },
+                            "DeleteContactgroupByIdentifier": {
+                                "operationId": "deleteContactgroup",
+                                "parameters": {
+                                    "identifier": "$response.header.X-Resource-Identifier"
+                                },
+                                "description": "Delete the created contact using the X-Resource-Identifier header"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                },
+                                "examples": {
+                                    "InvalidRequestBodyFormat": {
+                                        "$ref": "#/components/examples/InvalidRequestBodyFormat"
+                                    },
+                                    "UnexpectedQueryParameter": {
+                                        "$ref": "#/components/examples/UnexpectedQueryParameter"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "415": {
+                        "description": "Unsupported Media Type",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                },
+                                "examples": {
+                                    "InvalidContentType": {
+                                        "$ref": "#/components/examples/InvalidContentType"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                },
+                                "examples": {
+                                    "Contactgroup AlreadyExists": {
+                                        "summary": "Contactgroup already exists",
+                                        "value": {
+                                            "message": "Contactgroup already exists"
+                                        }
+                                    },
+                                    "InvalidRequestBodyFieldFormat": {
+                                        "$ref": "#/components/examples/InvalidRequestBodyFieldFormat"
+                                    },
+                                    "InvalidRequestBodyId": {
+                                        "$ref": "#/components/examples/InvalidRequestBodyId"
+                                    },
+                                    "MissingRequiredRequestBodyField": {
+                                        "$ref": "#/components/examples/MissingRequiredRequestBodyField"
+                                    },
+                                    "InvalidUserFormat": {
+                                        "$ref": "#/components/examples/InvalidUserFormat"
+                                    },
+                                    "InvalidUserUUID": {
+                                        "$ref": "#/components/examples/InvalidUserUUID"
+                                    },
+                                    "NameAlreadyExists": {
+                                        "$ref": "#/components/examples/NameAlreadyExists"
+                                    },
+                                    "UserNotExists": {
+                                        "$ref": "#/components/examples/UserNotExists"
                                     }
                                 }
                             }
@@ -717,24 +977,24 @@
                 }
             }
         },
-        "/contact-groups": {
+        "/contacts": {
             "get": {
                 "tags": [
-                    "Contact Groups"
+                    "Contacts"
                 ],
-                "summary": "List all Contact Groups or filter by parameters",
-                "description": "Retrieve all Contact Groups or filter them by parameters.",
-                "operationId": "listContactgroup",
+                "summary": "List all Contacts or filter by parameters",
+                "description": "Retrieve all Contacts or filter them by parameters.",
+                "operationId": "listContact",
                 "parameters": [
                     {
                         "name": "id",
                         "in": "query",
-                        "description": "Filter by Contact Group UUID",
+                        "description": "Filter Contacts by UUID",
                         "required": false,
                         "schema": {
-                            "schema": "ContactgroupUUID",
-                            "title": "ContactgroupUUID",
-                            "description": "An UUID representing a notification Contactgroup",
+                            "schema": "ContactUUID",
+                            "title": "ContactUUID",
+                            "description": "An UUID representing a notification Contact",
                             "type": "string",
                             "format": "uuid",
                             "maxLength": 36,
@@ -744,27 +1004,37 @@
                         }
                     },
                     {
-                        "name": "name",
+                        "name": "full_name",
                         "in": "query",
-                        "description": "Filter by Contact Group name",
+                        "description": "Filter Contacts by full name",
                         "required": false,
                         "schema": {
                             "type": "string"
+                        }
+                    },
+                    {
+                        "name": "username",
+                        "in": "query",
+                        "description": "Filter Contacts by username",
+                        "required": false,
+                        "schema": {
+                            "type": "string",
+                            "maxLength": 254
                         }
                     }
                 ],
                 "responses": {
                     "200": {
-                        "description": "Successful response with multiple Contactgroup results",
+                        "description": "Successful response with multiple Contact results",
                         "content": {
                             "application/json": {
                                 "schema": {
                                     "properties": {
                                         "data": {
-                                            "description": "Successful response with an array of Contactgroup objects",
+                                            "description": "Successful response with an array of Contact objects",
                                             "type": "array",
                                             "items": {
-                                                "$ref": "#/components/schemas/Contactgroup"
+                                                "$ref": "#/components/schemas/Contact"
                                             }
                                         }
                                     },
@@ -813,11 +1083,11 @@
             },
             "post": {
                 "tags": [
-                    "Contact Groups"
+                    "Contacts"
                 ],
-                "summary": "Create a new Contact Group",
-                "description": "Create a new Contact Group",
-                "operationId": "createContactgroup",
+                "summary": "Create a new Contact",
+                "description": "Create a new Contact",
+                "operationId": "createContact",
                 "requestBody": {
                     "required": true,
                     "content": {
@@ -825,12 +1095,12 @@
                             "schema": {
                                 "allOf": [
                                     {
-                                        "$ref": "#/components/schemas/Contactgroup"
+                                        "$ref": "#/components/schemas/Contact"
                                     },
                                     {
                                         "properties": {
                                             "id": {
-                                                "$ref": "#/components/schemas/NewContactgroupUUID"
+                                                "$ref": "#/components/schemas/NewContactUUID"
                                             }
                                         },
                                         "type": "object"
@@ -842,21 +1112,21 @@
                 },
                 "responses": {
                     "201": {
-                        "description": "Contactgroup created successfully",
+                        "description": "Contact created successfully",
                         "headers": {
                             "X-Resource-Identifier": {
-                                "description": "The identifier of the created Contactgroup",
+                                "description": "The identifier of the created Contact",
                                 "schema": {
                                     "type": "string",
                                     "format": "uuid"
                                 }
                             },
                             "Location": {
-                                "description": "The URL of the created Contactgroup",
+                                "description": "The URL of the created Contact",
                                 "schema": {
                                     "type": "string",
                                     "format": "url",
-                                    "example": "notifications/api/v1/contactgroups/{identifier}"
+                                    "example": "notifications/api/v1/contacts/{identifier}"
                                 }
                             }
                         },
@@ -866,32 +1136,32 @@
                                     "$ref": "#/components/schemas/SuccessResponse"
                                 },
                                 "examples": {
-                                    "ContactgroupCreated": {
-                                        "summary": "Contactgroup created successfully",
+                                    "ContactCreated": {
+                                        "summary": "Contact created successfully",
                                         "value": {
-                                            "message": "Contactgroup created successfully"
+                                            "message": "Contact created successfully"
                                         }
                                     }
                                 }
                             }
                         },
                         "links": {
-                            "GetContactgroupByIdentifier": {
-                                "operationId": "getContactgroup",
+                            "GetContactByIdentifier": {
+                                "operationId": "getContact",
                                 "parameters": {
                                     "identifier": "$response.header.X-Resource-Identifier"
                                 },
                                 "description": "Retrieve the created contact using the X-Resource-Identifier header"
                             },
-                            "UpdateContactgroupByIdentifier": {
-                                "operationId": "updateContactgroup",
+                            "UpdateContactByIdentifier": {
+                                "operationId": "updateContact",
                                 "parameters": {
                                     "identifier": "$response.header.X-Resource-Identifier"
                                 },
                                 "description": "Update the created contact using the X-Resource-Identifier header"
                             },
-                            "DeleteContactgroupByIdentifier": {
-                                "operationId": "deleteContactgroup",
+                            "DeleteContactByIdentifier": {
+                                "operationId": "deleteContact",
                                 "parameters": {
                                     "identifier": "$response.header.X-Resource-Identifier"
                                 },
@@ -940,10 +1210,10 @@
                                     "$ref": "#/components/schemas/ErrorResponse"
                                 },
                                 "examples": {
-                                    "Contactgroup AlreadyExists": {
-                                        "summary": "Contactgroup already exists",
+                                    "Contact AlreadyExists": {
+                                        "summary": "Contact already exists",
                                         "value": {
-                                            "message": "Contactgroup already exists"
+                                            "message": "Contact already exists"
                                         }
                                     },
                                     "InvalidRequestBodyFieldFormat": {
@@ -955,17 +1225,38 @@
                                     "MissingRequiredRequestBodyField": {
                                         "$ref": "#/components/examples/MissingRequiredRequestBodyField"
                                     },
-                                    "InvalidUserFormat": {
-                                        "$ref": "#/components/examples/InvalidUserFormat"
+                                    "ContactgroupNotExists": {
+                                        "$ref": "#/components/examples/ContactgroupNotExists"
                                     },
-                                    "InvalidUserUUID": {
-                                        "$ref": "#/components/examples/InvalidUserUUID"
+                                    "InvalidAddressType": {
+                                        "$ref": "#/components/examples/InvalidAddressType"
                                     },
-                                    "NameAlreadyExists": {
-                                        "$ref": "#/components/examples/NameAlreadyExists"
+                                    "InvalidAddressFormat": {
+                                        "$ref": "#/components/examples/InvalidAddressFormat"
                                     },
-                                    "UserNotExists": {
-                                        "$ref": "#/components/examples/UserNotExists"
+                                    "InvalidContactgroupUUID": {
+                                        "$ref": "#/components/examples/InvalidContactgroupUUID"
+                                    },
+                                    "InvalidContactgroupUUIDFormat": {
+                                        "$ref": "#/components/examples/InvalidContactgroupUUIDFormat"
+                                    },
+                                    "InvalidDefaultChannelUUID": {
+                                        "$ref": "#/components/examples/InvalidDefaultChannelUUID"
+                                    },
+                                    "InvalidEmailAddress": {
+                                        "$ref": "#/components/examples/InvalidEmailAddress"
+                                    },
+                                    "InvalidEmailAddressFormat": {
+                                        "$ref": "#/components/examples/InvalidEmailAddressFormat"
+                                    },
+                                    "InvalidGroupsFormat": {
+                                        "$ref": "#/components/examples/InvalidGroupsFormat"
+                                    },
+                                    "MissingAddress": {
+                                        "$ref": "#/components/examples/MissingAddress"
+                                    },
+                                    "UsernameAlreadyExists": {
+                                        "$ref": "#/components/examples/UsernameAlreadyExists"
                                     }
                                 }
                             }
@@ -1541,301 +1832,32 @@
                     }
                 }
             }
-        },
-        "/contacts": {
-            "get": {
-                "tags": [
-                    "Contacts"
-                ],
-                "summary": "List all Contacts or filter by parameters",
-                "description": "Retrieve all Contacts or filter them by parameters.",
-                "operationId": "listContact",
-                "parameters": [
-                    {
-                        "name": "id",
-                        "in": "query",
-                        "description": "Filter Contacts by UUID",
-                        "required": false,
-                        "schema": {
-                            "schema": "ContactUUID",
-                            "title": "ContactUUID",
-                            "description": "An UUID representing a notification Contact",
-                            "type": "string",
-                            "format": "uuid",
-                            "maxLength": 36,
-                            "minLength": 36,
-                            "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
-                            "example": null
-                        }
-                    },
-                    {
-                        "name": "full_name",
-                        "in": "query",
-                        "description": "Filter Contacts by full name",
-                        "required": false,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "username",
-                        "in": "query",
-                        "description": "Filter Contacts by username",
-                        "required": false,
-                        "schema": {
-                            "type": "string",
-                            "maxLength": 254
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful response with multiple Contact results",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "properties": {
-                                        "data": {
-                                            "description": "Successful response with an array of Contact objects",
-                                            "type": "array",
-                                            "items": {
-                                                "$ref": "#/components/schemas/Contact"
-                                            }
-                                        }
-                                    },
-                                    "type": "object"
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ErrorResponse"
-                                },
-                                "examples": {
-                                    "NoIdentifierWithFilter": {
-                                        "$ref": "#/components/examples/NoIdentifierWithFilter"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "422": {
-                        "description": "Unprocessable Entity",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ErrorResponse"
-                                },
-                                "examples": {
-                                    "InvalidRequestBodyId": {
-                                        "$ref": "#/components/examples/InvalidRequestBodyId"
-                                    },
-                                    "InvalidFilterParameter": {
-                                        "$ref": "#/components/examples/InvalidFilterParameter"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "401": {
-                        "description": "Unauthorized"
-                    }
-                }
-            },
-            "post": {
-                "tags": [
-                    "Contacts"
-                ],
-                "summary": "Create a new Contact",
-                "description": "Create a new Contact",
-                "operationId": "createContact",
-                "requestBody": {
-                    "required": true,
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "allOf": [
-                                    {
-                                        "$ref": "#/components/schemas/Contact"
-                                    },
-                                    {
-                                        "properties": {
-                                            "id": {
-                                                "$ref": "#/components/schemas/NewContactUUID"
-                                            }
-                                        },
-                                        "type": "object"
-                                    }
-                                ]
-                            }
-                        }
-                    }
-                },
-                "responses": {
-                    "201": {
-                        "description": "Contact created successfully",
-                        "headers": {
-                            "X-Resource-Identifier": {
-                                "description": "The identifier of the created Contact",
-                                "schema": {
-                                    "type": "string",
-                                    "format": "uuid"
-                                }
-                            },
-                            "Location": {
-                                "description": "The URL of the created Contact",
-                                "schema": {
-                                    "type": "string",
-                                    "format": "url",
-                                    "example": "notifications/api/v1/contacts/{identifier}"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/SuccessResponse"
-                                },
-                                "examples": {
-                                    "ContactCreated": {
-                                        "summary": "Contact created successfully",
-                                        "value": {
-                                            "message": "Contact created successfully"
-                                        }
-                                    }
-                                }
-                            }
-                        },
-                        "links": {
-                            "GetContactByIdentifier": {
-                                "operationId": "getContact",
-                                "parameters": {
-                                    "identifier": "$response.header.X-Resource-Identifier"
-                                },
-                                "description": "Retrieve the created contact using the X-Resource-Identifier header"
-                            },
-                            "UpdateContactByIdentifier": {
-                                "operationId": "updateContact",
-                                "parameters": {
-                                    "identifier": "$response.header.X-Resource-Identifier"
-                                },
-                                "description": "Update the created contact using the X-Resource-Identifier header"
-                            },
-                            "DeleteContactByIdentifier": {
-                                "operationId": "deleteContact",
-                                "parameters": {
-                                    "identifier": "$response.header.X-Resource-Identifier"
-                                },
-                                "description": "Delete the created contact using the X-Resource-Identifier header"
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ErrorResponse"
-                                },
-                                "examples": {
-                                    "InvalidRequestBodyFormat": {
-                                        "$ref": "#/components/examples/InvalidRequestBodyFormat"
-                                    },
-                                    "UnexpectedQueryParameter": {
-                                        "$ref": "#/components/examples/UnexpectedQueryParameter"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "415": {
-                        "description": "Unsupported Media Type",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ErrorResponse"
-                                },
-                                "examples": {
-                                    "InvalidContentType": {
-                                        "$ref": "#/components/examples/InvalidContentType"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "422": {
-                        "description": "Unprocessable Entity",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ErrorResponse"
-                                },
-                                "examples": {
-                                    "Contact AlreadyExists": {
-                                        "summary": "Contact already exists",
-                                        "value": {
-                                            "message": "Contact already exists"
-                                        }
-                                    },
-                                    "InvalidRequestBodyFieldFormat": {
-                                        "$ref": "#/components/examples/InvalidRequestBodyFieldFormat"
-                                    },
-                                    "InvalidRequestBodyId": {
-                                        "$ref": "#/components/examples/InvalidRequestBodyId"
-                                    },
-                                    "MissingRequiredRequestBodyField": {
-                                        "$ref": "#/components/examples/MissingRequiredRequestBodyField"
-                                    },
-                                    "ContactgroupNotExists": {
-                                        "$ref": "#/components/examples/ContactgroupNotExists"
-                                    },
-                                    "InvalidAddressType": {
-                                        "$ref": "#/components/examples/InvalidAddressType"
-                                    },
-                                    "InvalidAddressFormat": {
-                                        "$ref": "#/components/examples/InvalidAddressFormat"
-                                    },
-                                    "InvalidContactgroupUUID": {
-                                        "$ref": "#/components/examples/InvalidContactgroupUUID"
-                                    },
-                                    "InvalidContactgroupUUIDFormat": {
-                                        "$ref": "#/components/examples/InvalidContactgroupUUIDFormat"
-                                    },
-                                    "InvalidDefaultChannelUUID": {
-                                        "$ref": "#/components/examples/InvalidDefaultChannelUUID"
-                                    },
-                                    "InvalidEmailAddress": {
-                                        "$ref": "#/components/examples/InvalidEmailAddress"
-                                    },
-                                    "InvalidEmailAddressFormat": {
-                                        "$ref": "#/components/examples/InvalidEmailAddressFormat"
-                                    },
-                                    "InvalidGroupsFormat": {
-                                        "$ref": "#/components/examples/InvalidGroupsFormat"
-                                    },
-                                    "MissingAddress": {
-                                        "$ref": "#/components/examples/MissingAddress"
-                                    },
-                                    "UsernameAlreadyExists": {
-                                        "$ref": "#/components/examples/UsernameAlreadyExists"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "401": {
-                        "description": "Unauthorized"
-                    }
-                }
-            }
         }
     },
     "components": {
         "schemas": {
+            "Addresses": {
+                "description": "Schema that represents a contact's addresses",
+                "properties": {
+                    "email": {
+                        "description": "User's email address",
+                        "type": "string",
+                        "format": "email"
+                    },
+                    "rocketchat": {
+                        "description": "Rocket.Chat identifier or URL",
+                        "type": "string",
+                        "example": "rocketchat.example.com"
+                    },
+                    "webhook": {
+                        "description": "Comma-separated list of webhook URLs or identifiers",
+                        "type": "string",
+                        "example": "https://example.com/webhook"
+                    }
+                },
+                "type": "object",
+                "additionalProperties": false
+            },
             "Channel": {
                 "description": "A notification channel represents a destination for notifications in Icinga. \\\n    Channels can be of different types, such as email, webhook, or Rocket.Chat, \n    each with its own configuration requirements. \\\n    Channels are used to route notifications to users or external systems based on their type and configuration.",
                 "required": [
@@ -1877,6 +1899,15 @@
                 },
                 "type": "object"
             },
+            "ChannelTypes": {
+                "description": "Available notification channel types",
+                "type": "string",
+                "enum": [
+                    "email",
+                    "webhook",
+                    "rocketchat"
+                ]
+            },
             "ChannelUUID": {
                 "title": "ChannelUUID",
                 "description": "An UUID representing a notification Channel",
@@ -1887,28 +1918,99 @@
                 "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
                 "example": "bb4af7bd-f0da-489c-ae31-23f714bde714"
             },
-            "ChannelTypes": {
-                "description": "Available notification channel types",
-                "type": "string",
-                "enum": [
-                    "email",
-                    "webhook",
-                    "rocketchat"
-                ]
-            },
-            "WebhookChannelConfig": {
-                "title": "Webhook Channel Config",
-                "description": "The configuration for a webhook notification channel",
+            "Contact": {
+                "description": "Schema that represents a contact in the Icinga Notifications API",
                 "required": [
-                    "url_template"
+                    "id",
+                    "full_name",
+                    "default_channel",
+                    "addresses"
                 ],
                 "properties": {
-                    "url_template": {
-                        "$ref": "#/components/schemas/Url",
-                        "description": "URL template for the webhook"
+                    "id": {
+                        "$ref": "#/components/schemas/ContactUUID"
+                    },
+                    "full_name": {
+                        "description": "The full name of the contact",
+                        "type": "string",
+                        "example": "Icinga User"
+                    },
+                    "username": {
+                        "description": "The username of the contact",
+                        "type": "string",
+                        "maxLength": 254,
+                        "example": "icingauser"
+                    },
+                    "default_channel": {
+                        "$ref": "#/components/schemas/ChannelUUID",
+                        "description": "The default channel UUID for the contact"
+                    },
+                    "groups": {
+                        "description": "List of group UUIDs the contact belongs to",
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/ContactgroupUUID",
+                            "description": "Group UUIDs the contact belongs to"
+                        }
+                    },
+                    "addresses": {
+                        "$ref": "#/components/schemas/Addresses",
+                        "description": "Contact addresses by type"
+                    }
+                },
+                "type": "object",
+                "additionalProperties": false
+            },
+            "ContactUUID": {
+                "title": "ContactUUID",
+                "description": "An UUID representing a notification Contact",
+                "type": "string",
+                "format": "uuid",
+                "maxLength": 36,
+                "minLength": 36,
+                "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
+                "example": "9e868ad0-e774-465b-8075-c5a07e8f0726"
+            },
+            "Contactgroup": {
+                "description": "A contact group",
+                "required": [
+                    "id",
+                    "name"
+                ],
+                "properties": {
+                    "id": {
+                        "$ref": "#/components/schemas/ContactgroupUUID"
+                    },
+                    "name": {
+                        "description": "The name of the Contact Group",
+                        "type": "string",
+                        "example": "My Contact Group"
+                    },
+                    "users": {
+                        "description": "List of user identifiers (UUIDs) that belong to this Contact Group",
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/ContactUUID"
+                        }
                     }
                 },
                 "type": "object"
+            },
+            "ContactgroupUUID": {
+                "title": "ContactgroupUUID",
+                "description": "An UUID representing a notification Contactgroup",
+                "type": "string",
+                "format": "uuid",
+                "maxLength": 36,
+                "minLength": 36,
+                "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
+                "example": "81fb569f-5669-4cd6-93bb-9259446b8b23"
+            },
+            "Email": {
+                "description": "An email address",
+                "type": "string",
+                "format": "email",
+                "maxLength": 320
             },
             "EmailChannelConfig": {
                 "title": "Email Channel Config",
@@ -1956,6 +2058,42 @@
                 },
                 "type": "object"
             },
+            "ErrorResponse": {
+                "description": "Error response format",
+                "properties": {
+                    "message": {
+                        "description": "Detailed error message",
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "NewContactUUID": {
+                "title": "NewContactUUID",
+                "description": "An UUID representing a notification NewContact",
+                "type": "string",
+                "format": "uuid",
+                "maxLength": 36,
+                "minLength": 36,
+                "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
+                "example": "52668ad0-e774-465b-8075-c5a07e8f0726"
+            },
+            "NewContactgroupUUID": {
+                "title": "NewContactgroupUUID",
+                "description": "An UUID representing a notification NewContactgroup",
+                "type": "string",
+                "format": "uuid",
+                "maxLength": 36,
+                "minLength": 36,
+                "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
+                "example": "31fb569f-5669-4cd6-93bb-9259446b8b74"
+            },
+            "Port": {
+                "description": "A port number",
+                "type": "string",
+                "maxLength": 5,
+                "minLength": 1
+            },
             "RocketChatChannelConfig": {
                 "title": "RocketChat Channel Config",
                 "description": "The configuration for a Rocket.Chat notification channel",
@@ -1980,136 +2118,6 @@
                 },
                 "type": "object"
             },
-            "Contactgroup": {
-                "description": "A contact group",
-                "required": [
-                    "id",
-                    "name"
-                ],
-                "properties": {
-                    "id": {
-                        "$ref": "#/components/schemas/ContactgroupUUID"
-                    },
-                    "name": {
-                        "description": "The name of the Contact Group",
-                        "type": "string",
-                        "example": "My Contact Group"
-                    },
-                    "users": {
-                        "description": "List of user identifiers (UUIDs) that belong to this Contact Group",
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/ContactUUID"
-                        }
-                    }
-                },
-                "type": "object"
-            },
-            "ContactgroupUUID": {
-                "title": "ContactgroupUUID",
-                "description": "An UUID representing a notification Contactgroup",
-                "type": "string",
-                "format": "uuid",
-                "maxLength": 36,
-                "minLength": 36,
-                "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
-                "example": "81fb569f-5669-4cd6-93bb-9259446b8b23"
-            },
-            "NewContactgroupUUID": {
-                "title": "NewContactgroupUUID",
-                "description": "An UUID representing a notification NewContactgroup",
-                "type": "string",
-                "format": "uuid",
-                "maxLength": 36,
-                "minLength": 36,
-                "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
-                "example": "31fb569f-5669-4cd6-93bb-9259446b8b74"
-            },
-            "Contact": {
-                "description": "Schema that represents a contact in the Icinga Notifications API",
-                "required": [
-                    "id",
-                    "full_name",
-                    "default_channel",
-                    "addresses"
-                ],
-                "properties": {
-                    "id": {
-                        "$ref": "#/components/schemas/ContactUUID"
-                    },
-                    "full_name": {
-                        "description": "The full name of the contact",
-                        "type": "string",
-                        "example": "Icinga User"
-                    },
-                    "username": {
-                        "description": "The username of the contact",
-                        "type": "string",
-                        "maxLength": 254,
-                        "example": "icingauser"
-                    },
-                    "default_channel": {
-                        "$ref": "#/components/schemas/ChannelUUID",
-                        "description": "The default channel UUID for the contact"
-                    },
-                    "groups": {
-                        "description": "List of group UUIDs the contact belongs to",
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/ContactgroupUUID",
-                            "description": "Group UUIDs the contact belongs to"
-                        }
-                    },
-                    "addresses": {
-                        "$ref": "#/components/schemas/Addresses",
-                        "description": "Contact addresses by type"
-                    }
-                },
-                "type": "object",
-                "additionalProperties": false
-            },
-            "Addresses": {
-                "description": "Schema that represents a contact's addresses",
-                "properties": {
-                    "email": {
-                        "description": "User's email address",
-                        "type": "string",
-                        "format": "email"
-                    },
-                    "rocketchat": {
-                        "description": "Rocket.Chat identifier or URL",
-                        "type": "string",
-                        "example": "rocketchat.example.com"
-                    },
-                    "webhook": {
-                        "description": "Comma-separated list of webhook URLs or identifiers",
-                        "type": "string",
-                        "example": "https://example.com/webhook"
-                    }
-                },
-                "type": "object",
-                "additionalProperties": false
-            },
-            "ContactUUID": {
-                "title": "ContactUUID",
-                "description": "An UUID representing a notification Contact",
-                "type": "string",
-                "format": "uuid",
-                "maxLength": 36,
-                "minLength": 36,
-                "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
-                "example": "9e868ad0-e774-465b-8075-c5a07e8f0726"
-            },
-            "NewContactUUID": {
-                "title": "NewContactUUID",
-                "description": "An UUID representing a notification NewContact",
-                "type": "string",
-                "format": "uuid",
-                "maxLength": 36,
-                "minLength": 36,
-                "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
-                "example": "52668ad0-e774-465b-8075-c5a07e8f0726"
-            },
             "SuccessResponse": {
                 "description": "Success response format",
                 "properties": {
@@ -2120,36 +2128,100 @@
                 },
                 "type": "object"
             },
-            "ErrorResponse": {
-                "description": "Error response format",
-                "properties": {
-                    "message": {
-                        "description": "Detailed error message",
-                        "type": "string"
-                    }
-                },
-                "type": "object"
-            },
-            "Email": {
-                "description": "An email address",
-                "type": "string",
-                "format": "email",
-                "maxLength": 320
-            },
-            "Port": {
-                "description": "A port number",
-                "type": "string",
-                "maxLength": 5,
-                "minLength": 1
-            },
             "Url": {
                 "description": "A URL used in the API",
                 "type": "string",
                 "maxLength": 2048,
                 "example": "example.com"
+            },
+            "WebhookChannelConfig": {
+                "title": "Webhook Channel Config",
+                "description": "The configuration for a webhook notification channel",
+                "required": [
+                    "url_template"
+                ],
+                "properties": {
+                    "url_template": {
+                        "$ref": "#/components/schemas/Url",
+                        "description": "URL template for the webhook"
+                    }
+                },
+                "type": "object"
             }
         },
         "examples": {
+            "IdentifierMismatch": {
+                "summary": "Identifier mismatch",
+                "value": {
+                    "message": "Identifier mismatch"
+                }
+            },
+            "IdentifierNotFound": {
+                "summary": "Identifier not found",
+                "value": {
+                    "message": "Identifier not found"
+                }
+            },
+            "IdentifierPayloadIdMissmatch": {
+                "summary": "Identifier and payload Id missmatch",
+                "value": {
+                    "message": "Identifier mismatch: the Payload id must be different from the URL identifier"
+                }
+            },
+            "InvalidContentType": {
+                "summary": "Invalid content type",
+                "value": {
+                    "message": "Invalid request header: Content-Type must be application/json"
+                }
+            },
+            "InvalidFilterParameter": {
+                "summary": "Invalid filter parameter",
+                "value": {
+                    "message": "Invalid request parameter: Filter column x is not allowed"
+                }
+            },
+            "InvalidIdentifier": {
+                "summary": "Identifier is not valid",
+                "value": {
+                    "message": "The given identifier is not a valid UUID"
+                }
+            },
+            "InvalidRequestBodyFieldFormat": {
+                "summary": "Invalid request body field format",
+                "value": {
+                    "message": "Invalid request body: expects x to be of type y"
+                }
+            },
+            "InvalidRequestBodyFormat": {
+                "summary": "Invalid request body format",
+                "value": {
+                    "message": "Invalid request body: given content is not a valid JSON"
+                }
+            },
+            "InvalidRequestBodyId": {
+                "summary": "Invalid request body id",
+                "value": {
+                    "message": "Invalid request body: given id is not a valid UUID"
+                }
+            },
+            "MissingRequiredRequestBodyField": {
+                "summary": "Missing required request body field",
+                "value": {
+                    "message": "Invalid request body: the field x must be present"
+                }
+            },
+            "NoIdentifierWithFilter": {
+                "summary": "No identifier with filter",
+                "value": {
+                    "message": "Invalid request: GET with identifier and query parameters, it's not allowed to use both together."
+                }
+            },
+            "UnexpectedQueryParameter": {
+                "summary": "Unexpected query parameter",
+                "value": {
+                    "message": "Unexpected query parameter: Filter is only allowed for GET requests"
+                }
+            },
             "InvalidUserFormat": {
                 "summary": "Invalid user format",
                 "value": {
@@ -2239,78 +2311,6 @@
                 "value": {
                     "message": "Username x already exists"
                 }
-            },
-            "IdentifierMismatch": {
-                "summary": "Identifier mismatch",
-                "value": {
-                    "message": "Identifier mismatch"
-                }
-            },
-            "IdentifierNotFound": {
-                "summary": "Identifier not found",
-                "value": {
-                    "message": "Identifier not found"
-                }
-            },
-            "IdentifierPayloadIdMissmatch": {
-                "summary": "Identifier and payload Id missmatch",
-                "value": {
-                    "message": "Identifier mismatch: the Payload id must be different from the URL identifier"
-                }
-            },
-            "InvalidContentType": {
-                "summary": "Invalid content type",
-                "value": {
-                    "message": "Invalid request header: Content-Type must be application/json"
-                }
-            },
-            "InvalidFilterParameter": {
-                "summary": "Invalid filter parameter",
-                "value": {
-                    "message": "Invalid request parameter: Filter column x is not allowed"
-                }
-            },
-            "InvalidIdentifier": {
-                "summary": "Identifier is not valid",
-                "value": {
-                    "message": "The given identifier is not a valid UUID"
-                }
-            },
-            "InvalidRequestBodyFieldFormat": {
-                "summary": "Invalid request body field format",
-                "value": {
-                    "message": "Invalid request body: expects x to be of type y"
-                }
-            },
-            "InvalidRequestBodyFormat": {
-                "summary": "Invalid request body format",
-                "value": {
-                    "message": "Invalid request body: given content is not a valid JSON"
-                }
-            },
-            "InvalidRequestBodyId": {
-                "summary": "Invalid request body id",
-                "value": {
-                    "message": "Invalid request body: given id is not a valid UUID"
-                }
-            },
-            "MissingRequiredRequestBodyField": {
-                "summary": "Missing required request body field",
-                "value": {
-                    "message": "Invalid request body: the field x must be present"
-                }
-            },
-            "NoIdentifierWithFilter": {
-                "summary": "No identifier with filter",
-                "value": {
-                    "message": "Invalid request: GET with identifier and query parameters, it's not allowed to use both together."
-                }
-            },
-            "UnexpectedQueryParameter": {
-                "summary": "Unexpected query parameter",
-                "value": {
-                    "message": "Unexpected query parameter: Filter is only allowed for GET requests"
-                }
             }
         },
         "securitySchemes": {
@@ -2328,16 +2328,16 @@
     ],
     "tags": [
         {
-            "name": "Contacts",
-            "description": "Operations related to notification Contacts"
+            "name": "Channels",
+            "description": "Operations related to notification Channels"
         },
         {
             "name": "Contact Groups",
             "description": "Operations related to notification Contact Groups"
         },
         {
-            "name": "Channels",
-            "description": "Operations related to notification Channels"
+            "name": "Contacts",
+            "description": "Operations related to notification Contacts"
         }
     ]
 }

--- a/library/Notifications/Api/OpenApiPreprocessor/ConsistentOrder.php
+++ b/library/Notifications/Api/OpenApiPreprocessor/ConsistentOrder.php
@@ -1,0 +1,27 @@
+<?php
+
+/* Icinga Notifications Web | (c) 2025 Icinga GmbH | GPLv2 */
+
+namespace Icinga\Module\Notifications\Api\OpenApiPreprocessor;
+
+use OpenApi\Analysis;
+
+class ConsistentOrder
+{
+    public function __invoke(Analysis $analysis): void
+    {
+        if (is_object($analysis->openapi->components) && is_iterable($analysis->openapi->components->schemas)) {
+            usort($analysis->openapi->components->schemas, function ($a, $b) {
+                return $a->schema <=> $b->schema;
+            });
+        }
+
+        usort($analysis->openapi->paths, function ($a, $b) {
+            return $a->path <=> $b->path;
+        });
+
+        usort($analysis->openapi->tags, function ($a, $b) {
+            return $a->name <=> $b->name;
+        });
+    }
+}


### PR DESCRIPTION
It's a rather large file and so I'd like to have as less noise in diffs as possible when re-generating it.