### PR TITLE
Support PHP 8.5

### DIFF
--- a/application/forms/MoveRotationForm.php
+++ b/application/forms/MoveRotationForm.php
@@ -35,7 +35,7 @@ class MoveRotationForm extends Form
      *
      * @param ?Connection $db
      */
-    public function __construct(Connection $db = null)
+    public function __construct(?Connection $db = null)
     {
         $this->db = $db;
     }

--- a/application/forms/RotationConfigForm.php
+++ b/application/forms/RotationConfigForm.php
@@ -584,9 +584,11 @@ class RotationConfigForm extends CompatForm
     /**
      * Remove all versions of the rotation from the database
      *
+     * @param ?int $priority
+     *
      * @return void
      */
-    public function wipeRotation(int $priority = null): void
+    public function wipeRotation(?int $priority = null): void
     {
         $priority = $priority ?? $this->getValue('priority');
         if ($priority === null) {

--- a/library/Notifications/Api/Middleware/MiddlewarePipeline.php
+++ b/library/Notifications/Api/Middleware/MiddlewarePipeline.php
@@ -82,7 +82,7 @@ final class MiddlewarePipeline implements RequestHandlerInterface
      *
      * @return ResponseInterface
      */
-    public function execute(ServerRequestInterface $request = null): ResponseInterface
+    public function execute(?ServerRequestInterface $request = null): ResponseInterface
     {
         if ($request === null) {
             $request = new ServerRequest('GET', '/'); // initial dummy request

--- a/library/Notifications/Api/OpenApiDescriptionElement/Response/Error404Response.php
+++ b/library/Notifications/Api/OpenApiDescriptionElement/Response/Error404Response.php
@@ -13,7 +13,7 @@ use OpenApi\Attributes\XmlContent;
 
 class Error404Response extends Response
 {
-    public function __construct(string $endpointName = null)
+    public function __construct(?string $endpointName = null)
     {
         parent::__construct(
             response: 404,

--- a/library/Notifications/Api/V1/ContactGroups.php
+++ b/library/Notifications/Api/V1/ContactGroups.php
@@ -763,7 +763,7 @@ class ContactGroups extends ApiV1 implements RequestHandlerInterface, EndpointIn
      *
      * @throws HttpException if the username already exists
      */
-    private function assertUniqueName(string $name, int $contactgroupId = null): void
+    private function assertUniqueName(string $name, ?int $contactgroupId = null): void
     {
         $stmt = (new Select())
             ->from('contactgroup')

--- a/library/Notifications/Api/V1/Contacts.php
+++ b/library/Notifications/Api/V1/Contacts.php
@@ -860,7 +860,7 @@ class Contacts extends ApiV1 implements RequestHandlerInterface, EndpointInterfa
      *
      * @throws HttpException if the username already exists
      */
-    private function assertUniqueUsername(string $username, int $contactId = null): void
+    private function assertUniqueUsername(string $username, ?int $contactId = null): void
     {
         $stmt = (new Select())
             ->from('contact')

--- a/library/Notifications/Common/Database.php
+++ b/library/Notifications/Common/Database.php
@@ -78,7 +78,15 @@ final class Database
 
         $config->options = [PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_OBJ];
         if ($config->db === 'mysql') {
-            $config->options[PDO::MYSQL_ATTR_INIT_COMMAND] = "SET SESSION SQL_MODE='STRICT_TRANS_TABLES"
+            // As of PHP 8.5, driver-specific constants of the PDO class are deprecated,
+            // but the replacement constants are only available since PHP 8.4.
+            if (version_compare(PHP_VERSION, '8.4.0', '<')) {
+                $mysqlAttrInitCommand = PDO::MYSQL_ATTR_INIT_COMMAND;
+            } else {
+                $mysqlAttrInitCommand = Pdo\Mysql::ATTR_INIT_COMMAND;
+            }
+
+            $config->options[$mysqlAttrInitCommand] = "SET SESSION SQL_MODE='STRICT_TRANS_TABLES"
                 . ",NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION'";
         }
 

--- a/library/Notifications/Daemon/Daemon.php
+++ b/library/Notifications/Daemon/Daemon.php
@@ -22,8 +22,7 @@ use ipl\Stdlib\Filter;
 use React\EventLoop\Loop;
 use React\EventLoop\LoopInterface;
 
-use function Clue\React\Block\await;
-use function React\Promise\Timer\sleep;
+use function React\Async\delay;
 
 class Daemon extends EventEmitter
 {
@@ -323,8 +322,8 @@ class Daemon extends EventEmitter
 
                 $endMs = (int) (microtime(true) * 1000);
                 if (($endMs - $beginMs) < 3000) {
-                    // run took less than 3 seconds; sleep for the remaining duration to prevent heavy db loads
-                    await(sleep((3000 - ($endMs - $beginMs)) / 1000));
+                    // run took less than 3 seconds; delay for the remaining duration to prevent heavy db loads
+                    delay((3000 - ($endMs - $beginMs)) / 1000);
                 }
             }
             self::$logger::debug(self::PREFIX . "cancellation triggered; exiting loop");

--- a/library/Notifications/Daemon/Daemon.php
+++ b/library/Notifications/Daemon/Daemon.php
@@ -264,7 +264,7 @@ class Daemon extends EventEmitter
         /** @var IncidentHistory $notification */
         $notificationsToProcess = [];
         foreach ($notifications as $notification) {
-            if (isset($connections[$notification->contact_id])) {
+            if ($notification->contact_id !== null && isset($connections[$notification->contact_id])) {
                 ObjectsRendererHook::register($notification->incident->object);
                 $notificationsToProcess[] = $notification;
 

--- a/library/Notifications/Web/Form/ContactForm.php
+++ b/library/Notifications/Web/Form/ContactForm.php
@@ -176,7 +176,7 @@ class ContactForm extends CompatForm
 
         $contact->registerElement($defaultChannel);
 
-        $this->addAddressElements($availableTypes, $channelTypes[$defaultChannel->getValue()] ?? null);
+        $this->addAddressElements($availableTypes, $channelTypes[$defaultChannel->getValue() ?? ''] ?? null);
 
         $this->addHtml(new HtmlElement('hr'));
 

--- a/library/Notifications/Widget/Detail/IncidentQuickActions.php
+++ b/library/Notifications/Widget/Detail/IncidentQuickActions.php
@@ -221,7 +221,7 @@ class IncidentQuickActions extends Form
      *
      * @return void
      */
-    protected function updateHistory(IncidentContact $incidentContact, string $newRole = null): void
+    protected function updateHistory(IncidentContact $incidentContact, ?string $newRole = null): void
     {
         $oldRole = $incidentContact->role;
         $contactId = $incidentContact->contact_id ?? $this->currentUserId;

--- a/library/Notifications/Widget/ShowMore.php
+++ b/library/Notifications/Widget/ShowMore.php
@@ -24,7 +24,7 @@ class ShowMore extends BaseHtmlElement
 
     protected $label;
 
-    public function __construct(ResultSet $resultSet, Url $url, string $label = null)
+    public function __construct(ResultSet $resultSet, Url $url, ?string $label = null)
     {
         $this->label = $label;
         $this->resultSet = $resultSet;

--- a/library/Notifications/Widget/TimeGrid/BaseGrid.php
+++ b/library/Notifications/Widget/TimeGrid/BaseGrid.php
@@ -253,7 +253,7 @@ abstract class BaseGrid extends BaseHtmlElement
                 $cellOccupiers[$rowStart][$column][] = spl_object_id($entry);
             }
 
-            $occupiedCells->attach($entry, $rows);
+            $occupiedCells->offsetSet($entry, $rows);
         }
 
         $rowPlacements = [];

--- a/library/Notifications/Widget/Timeline.php
+++ b/library/Notifications/Widget/Timeline.php
@@ -222,7 +222,7 @@ class Timeline extends BaseHtmlElement implements EntryProvider
         foreach ($occupiedCells as $cell => $entry) {
             $cells = $entryToCellsMap[$entry] ?? [];
             $cells[] = $cell;
-            $entryToCellsMap->attach($entry, $cells);
+            $entryToCellsMap->offsetSet($entry, $cells);
         }
 
         foreach ($entryToCellsMap as $entry) {


### PR DESCRIPTION
### PHP 8.4 changes:
- [Parameters that are `null` by default must be declared nullable](https://www.php.net/manual/en/migration84.deprecated.php#migration84.deprecated.core).

### PHP 8.5 changes:
- Replace [deprecated methods of `SplObjectStorage`](https://www.php.net/manual/en/migration85.deprecated.php#migration85.deprecated.spl).
- [Using `null` as an array offset is deprecated](https://www.php.net/manual/en/migration85.deprecated.php#migration85.deprecated.core.using-null-as-an-array-offset).
- Replace [deprecated constant `PDO::MYSQL_ATTR_INIT_COMMAND`](https://www.php.net/manual/en/migration85.deprecated.php#migration85.deprecated.pdo).

### Other changes:
- Replace usage of abandoned package `clue/block-react` with `react/async`.

resolves #437