### PR TITLE
Increase z-index for `.schedule-detail-controls`

### DIFF
--- a/public/css/schedule.less
+++ b/public/css/schedule.less
@@ -2,7 +2,7 @@
 
 .schedule-detail-controls {
   .box-shadow(0, 0, 0, 1px, @gray-lighter);
-  z-index: 4; // The content may clip, this ensures the separator and dropdown is always visible
+  z-index: 5; // The content may clip, this ensures the separator and dropdown is always visible
 
   > * {
     margin-bottom: .5em;


### PR DESCRIPTION
As pointed out in #440 the `.time-grid-header` and `.schedule-detail-controls` both have an z-index of **4**. So I increased the z-index of `.schedule-detail-controls` to **5**.

fix #440 