### PR TITLE
Use forward compatible Mysql constants of ipl-sql

### DIFF
--- a/doc/02-Installation.md.d/From-Source.md
+++ b/doc/02-Installation.md.d/From-Source.md
@@ -13,7 +13,7 @@ Make sure you use `notifications` as the module name. The following requirements
   or [PostgreSQL](https://www.php.net/manual/en/ref.pdo-pgsql.php) PDO PHP libraries
 - [Icinga Notifications](https://github.com/Icinga/icinga-notifications)
 - [Icinga Web](https://github.com/Icinga/icingaweb2) (≥2.12)
-- [Icinga PHP Library (ipl)](https://github.com/Icinga/icinga-php-library) (≥0.18)
+- [Icinga PHP Library (ipl)](https://github.com/Icinga/icinga-php-library) (≥0.19)
 - [Icinga PHP Thirdparty](https://github.com/Icinga/icinga-php-thirdparty) (≥0.14)
 
 <!-- {% include "02-Installation.md" %} -->

--- a/library/Notifications/Common/Database.php
+++ b/library/Notifications/Common/Database.php
@@ -18,6 +18,7 @@ use ipl\Sql\Insert;
 use ipl\Sql\QueryBuilder;
 use ipl\Sql\Select;
 use ipl\Sql\Update;
+use Pdo\Mysql;
 use PDO;
 
 final class Database
@@ -79,15 +80,7 @@ final class Database
 
         $config->options = [PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_OBJ];
         if ($config->db === 'mysql') {
-            // As of PHP 8.5, driver-specific constants of the PDO class are deprecated,
-            // but the replacement constants are only available since PHP 8.4.
-            if (version_compare(PHP_VERSION, '8.4.0', '<')) {
-                $mysqlAttrInitCommand = PDO::MYSQL_ATTR_INIT_COMMAND;
-            } else {
-                $mysqlAttrInitCommand = Pdo\Mysql::ATTR_INIT_COMMAND;
-            }
-
-            $config->options[$mysqlAttrInitCommand] = "SET SESSION SQL_MODE='STRICT_TRANS_TABLES"
+            $config->options[Mysql::ATTR_INIT_COMMAND] = "SET SESSION SQL_MODE='STRICT_TRANS_TABLES"
                 . ",NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION'";
         }
 


### PR DESCRIPTION
For PHP < 8.4 the constant `Pdo\Mysql::ATTR_INIT_COMMAND` is not yet available but its predecessor is deprecated.
Instead of using a `version_compare` to solve this problem, a forward compatibility shim of ipl-sql can be used to support these versions.

requires: https://github.com/Icinga/ipl-sql/pull/99