### PR TITLE
Adapt mocks to strict ipl types

### DIFF
--- a/test/php/application/forms/EventRuleConfigFormTest.php
+++ b/test/php/application/forms/EventRuleConfigFormTest.php
@@ -5,6 +5,7 @@
 
 namespace Tests\Icinga\Module\Notifications\Forms;
 
+use ArrayIterator;
 use DateTime;
 use Icinga\Module\Notifications\Forms\EventRuleConfigElements\ConfigProviderInterface;
 use Icinga\Module\Notifications\Forms\EventRuleConfigForm;
@@ -19,6 +20,7 @@ use ipl\Orm\Query;
 use ipl\Orm\ResultSet;
 use ipl\Sql\Connection;
 use ipl\Web\Url;
+use PDOStatement;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ServerRequestInterface;
 
@@ -152,7 +154,10 @@ class EventRuleConfigFormTest extends TestCase
         $firstRuleEscalationRecipientMock->expects($this->once())
             ->method('columns')
             ->with(['id', 'contact_id', 'contactgroup_id', 'schedule_id', 'channel_id'])
-            ->willReturn([
+            ->willReturnSelf();
+
+        $firstRuleEscalationRecipientMock->method('getIterator')
+            ->willReturn(new ArrayIterator([
                 (new RuleEscalationRecipient())->setProperties([
                     'id' => 1,
                     'contact_id' => 1,
@@ -160,13 +165,16 @@ class EventRuleConfigFormTest extends TestCase
                     'schedule_id' => null,
                     'channel_id' => 1
                 ])
-            ]);
+            ]));
 
         $secondRuleEscalationRecipientMock = $this->createMock(Query::class);
         $secondRuleEscalationRecipientMock->expects($this->once())
             ->method('columns')
             ->with(['id', 'contact_id', 'contactgroup_id', 'schedule_id', 'channel_id'])
-            ->willReturn([
+            ->willReturnSelf();
+
+        $secondRuleEscalationRecipientMock->method('getIterator')
+            ->willReturn(new ArrayIterator([
                 (new RuleEscalationRecipient())->setProperties([
                     'id' => null,
                     'contact_id' => null,
@@ -181,7 +189,7 @@ class EventRuleConfigFormTest extends TestCase
                     'schedule_id' => 1,
                     'channel_id' => 1
                 ])
-            ]);
+            ]));
 
         $ruleEscalationMock = $this->createMock(Query::class);
         $ruleEscalationMock->expects($this->once())
@@ -190,7 +198,7 @@ class EventRuleConfigFormTest extends TestCase
             ->willReturnSelf();
 
         $queryResult = new ResultSet(
-            new \ArrayIterator([
+            new ArrayIterator([
                 (new RuleEscalation())->setProperties([
                     'id' => 1,
                     'condition' => null,
@@ -271,6 +279,8 @@ class EventRuleConfigFormTest extends TestCase
                 } else {
                     $this->fail(sprintf('Unexpected table %s', $table));
                 }
+
+                return $this->createStub(PDOStatement::class);
             });
 
         $databaseMock->expects($this->once())
@@ -355,6 +365,8 @@ class EventRuleConfigFormTest extends TestCase
                 } else {
                     $this->fail(sprintf('Unexpected table %s', $table));
                 }
+
+                return $this->createStub(PDOStatement::class);
             });
 
         $form = new EventRuleConfigForm($providerMock, $this->createStub(Url::class));
@@ -425,7 +437,10 @@ class EventRuleConfigFormTest extends TestCase
         $escalationRecipientMock->expects($this->once())
             ->method('columns')
             ->with(['id', 'contact_id', 'contactgroup_id', 'schedule_id', 'channel_id'])
-            ->willReturn([
+            ->willReturnSelf();
+
+        $escalationRecipientMock->method('getIterator')
+            ->willReturn(new ArrayIterator([
                 (new RuleEscalationRecipient())->setProperties([
                     'id' => 1,
                     'contact_id' => 1,
@@ -433,7 +448,7 @@ class EventRuleConfigFormTest extends TestCase
                     'schedule_id' => null,
                     'channel_id' => 1
                 ])
-            ]);
+            ]));
 
         $ruleEscalationMock = $this->createMock(Query::class);
         $ruleEscalationMock->expects($this->once())
@@ -442,7 +457,7 @@ class EventRuleConfigFormTest extends TestCase
             ->willReturnSelf();
 
         $queryResult = new ResultSet(
-            new \ArrayIterator([
+            new ArrayIterator([
                 (new RuleEscalation())->setProperties([
                     'id' => 1,
                     'condition' => null,
@@ -538,7 +553,10 @@ class EventRuleConfigFormTest extends TestCase
         $escalationRecipientMock->expects($this->once())
             ->method('columns')
             ->with(['id', 'contact_id', 'contactgroup_id', 'schedule_id', 'channel_id'])
-            ->willReturn([
+            ->willReturnSelf();
+
+        $escalationRecipientMock->method('getIterator')
+            ->willReturn(new ArrayIterator([
                 (new RuleEscalationRecipient())->setProperties([
                     'id' => 1,
                     'contact_id' => 1,
@@ -546,7 +564,7 @@ class EventRuleConfigFormTest extends TestCase
                     'schedule_id' => null,
                     'channel_id' => 1
                 ])
-            ]);
+            ]));
 
         $ruleEscalationMock = $this->createMock(Query::class);
         $ruleEscalationMock->expects($this->once())
@@ -555,7 +573,7 @@ class EventRuleConfigFormTest extends TestCase
             ->willReturnSelf();
 
         $queryResult = new ResultSet(
-            new \ArrayIterator([
+            new ArrayIterator([
                 (new RuleEscalation())->setProperties([
                     'id' => 1,
                     'condition' => null,
@@ -595,6 +613,8 @@ class EventRuleConfigFormTest extends TestCase
                     ],
                     $data
                 );
+
+                return $this->createStub(PDOStatement::class);
             });
         $databaseMock->expects($this->never())
             ->method('insert');
@@ -667,7 +687,10 @@ class EventRuleConfigFormTest extends TestCase
         $escalationRecipientMock->expects($this->once())
             ->method('columns')
             ->with(['id', 'contact_id', 'contactgroup_id', 'schedule_id', 'channel_id'])
-            ->willReturn([
+            ->willReturnSelf();
+
+        $escalationRecipientMock->method('getIterator')
+            ->willReturn(new ArrayIterator([
                 (new RuleEscalationRecipient())->setProperties([
                     'id' => 1,
                     'contact_id' => 1,
@@ -675,7 +698,7 @@ class EventRuleConfigFormTest extends TestCase
                     'schedule_id' => null,
                     'channel_id' => 1
                 ])
-            ]);
+            ]));
 
         $ruleEscalationMock = $this->createMock(Query::class);
         $ruleEscalationMock->expects($this->once())
@@ -684,7 +707,7 @@ class EventRuleConfigFormTest extends TestCase
             ->willReturnSelf();
 
         $queryResult = new ResultSet(
-            new \ArrayIterator([
+            new ArrayIterator([
                 (new RuleEscalation())->setProperties([
                     'id' => 1,
                     'condition' => 'incident_severity>=crit&incident_age>5m',
@@ -727,6 +750,8 @@ class EventRuleConfigFormTest extends TestCase
                     ],
                     $data
                 );
+
+                return $this->createStub(PDOStatement::class);
             });
         $databaseMock->expects($this->never())
             ->method('insert');
@@ -801,7 +826,10 @@ class EventRuleConfigFormTest extends TestCase
         $escalationRecipientMock->expects($this->once())
             ->method('columns')
             ->with(['id', 'contact_id', 'contactgroup_id', 'schedule_id', 'channel_id'])
-            ->willReturn([
+            ->willReturnSelf();
+
+        $escalationRecipientMock->method('getIterator')
+            ->willReturn(new ArrayIterator([
                 (new RuleEscalationRecipient())->setProperties([
                     'id' => 1,
                     'contact_id' => null,
@@ -809,7 +837,7 @@ class EventRuleConfigFormTest extends TestCase
                     'schedule_id' => null,
                     'channel_id' => null
                 ])
-            ]);
+            ]));
 
         $ruleEscalationMock = $this->createMock(Query::class);
         $ruleEscalationMock->expects($this->once())
@@ -818,7 +846,7 @@ class EventRuleConfigFormTest extends TestCase
             ->willReturnSelf();
 
         $queryResult = new ResultSet(
-            new \ArrayIterator([
+            new ArrayIterator([
                 (new RuleEscalation())->setProperties([
                     'id' => 1,
                     'condition' => null,
@@ -860,6 +888,8 @@ class EventRuleConfigFormTest extends TestCase
                     ],
                     $data
                 );
+
+                return $this->createStub(PDOStatement::class);
             });
         $databaseMock->expects($this->never())
             ->method('insert');


### PR DESCRIPTION
This PR adjusts mocks of some ipl functions to match the strict return types declared by ipl.

Mocks of `ipl\sql\Connection` and `ipl\orm\Query` must be adjusted to match the new strict types in ipl.

The `Query::columns()` mocks previously returned an array, even though the return type is supposed to be `static`.
This worked fine because the return value was only used in a `foreach`, To match the `static` type the mocks now use `willReturnSelf` and mock `Query::getIterator()`, so they can be foreached while being compatible with ipl-orm.

The `Connection` some return values were added to match the return types in ipl-sql, but they are unused and should have no effect on the test.