### PR TITLE
`SourceForm`: Allow to configure a `source` without an integration

### DIFF
--- a/application/controllers/SourcesController.php
+++ b/application/controllers/SourcesController.php
@@ -5,7 +5,6 @@
 
 namespace Icinga\Module\Notifications\Controllers;
 
-use Icinga\Application\Hook;
 use Icinga\Module\Notifications\Common\Database;
 use Icinga\Module\Notifications\Forms\SourceForm;
 use Icinga\Module\Notifications\Model\Source;
@@ -75,24 +74,12 @@ class SourcesController extends CompatController
 
         $sources->filter($filter);
 
-        $addButton = new ButtonLink(
+        $addButton = (new ButtonLink(
             t('Add Source'),
             Url::fromPath('notifications/sources/add'),
             'plus',
             ['class' => 'add-new-component']
-        );
-        $emptyStateMessage = null;
-        if (! Hook::has('Notifications/v1/Source')) {
-            $addButton->disable($this->translate(
-                'You have to install a module that serves as an integration for a source first.'
-            ));
-            $emptyStateMessage = $this->translate(
-                'No sources found. To add a new source, please install a module that serves as an integration'
-                . ' for a source first. Notable examples are Icinga DB Web and Icinga for Kubernetes Web.'
-            );
-        } else {
-            $addButton->setBaseTarget('_next');
-        }
+        ))->setBaseTarget('_next');
 
         $this->addControl($paginationControl);
         $this->addControl($sortControl);
@@ -103,7 +90,6 @@ class SourcesController extends CompatController
         $this->addContent(
             (new ObjectList($sources, new SourceRenderer()))
                 ->setItemLayoutClass(MinimalItemLayout::class)
-                ->setEmptyStateMessage($emptyStateMessage)
         );
 
         if (! $searchBar->hasBeenSubmitted() && $searchBar->hasBeenSent()) {

--- a/application/forms/SourceForm.php
+++ b/application/forms/SourceForm.php
@@ -33,6 +33,9 @@ class SourceForm extends CompatForm
     /** @var string|int The used password hash algorithm */
     public const HASH_ALGORITHM = PASSWORD_BCRYPT;
 
+    /** @var string @var The generic source type */
+    public const TYPE_GENERIC = 'generic';
+
     /** @var Connection */
     private $db;
 
@@ -49,17 +52,15 @@ class SourceForm extends CompatForm
         $this->applyDefaultElementDecorators();
         $this->addCsrfCounterMeasure();
 
-        $chosenIntegration = null;
+        $types = [
+            ''                  => ' - ' . $this->translate('Please choose') . ' - ',
+            self::TYPE_GENERIC  => $this->translate('Generic')
+        ];
 
-        $types = ['' => ' - ' . $this->translate('Please choose') . ' - '];
         foreach (Hook::all('Notifications/v1/Source') as $hook) {
             /** @var SourceHook $hook */
             try {
                 $type = $hook->getSourceType();
-                if ($this->getPopulatedValue('type') === $type) {
-                    $chosenIntegration = $hook;
-                }
-
                 $types[$type] = $hook->getSourceLabel();
             } catch (Throwable $e) {
                 Logger::error('Failed to load source integration %s: %s', $hook::class, $e);
@@ -71,9 +72,10 @@ class SourceForm extends CompatForm
             Attributes::create(['class' => 'description']),
             Text::create($this->translate(
                 'Sources are the most vital part of Icinga Notifications. They submit events that will be'
-                . ' processed to notify users about incidents. You can only configure sources that provide an'
-                . ' integration in Icinga Web. If you cannot choose the desired source below, consult their'
-                . ' documentation on how to integrate it.'
+                . ' processed to notify users about incidents. You can either configure sources that provide an'
+                . ' integration in Icinga Web or use the Generic type for sources that communicate directly with the'
+                . ' Icinga Notifications API. If you cannot choose the desired source below, consult its documentation'
+                . ' on how to integrate it.'
             ))
         ));
 
@@ -110,7 +112,7 @@ class SourceForm extends CompatForm
                 . ' source\'s configuration as well:'
             )),
             Text::create(' '),
-            match ($chosenIntegration?->getSourceType()) {
+            match ($this->getValue('type')) {
                 'icinga2' => new Link(
                     [
                         $this->translate('Icinga DB Documentation'),
@@ -135,6 +137,9 @@ class SourceForm extends CompatForm
                     ),
                     ['target' => '_blank']
                 ),
+                self::TYPE_GENERIC => Text::create($this->translate(
+                    'Consult the documentation of your source for configuration details.'
+                )),
                 default => Text::create($this->translate(
                     'Please choose the source type above to see the required configuration.'
                 ))


### PR DESCRIPTION
This PR introduces a built-in `generic` source type, that is now always available, removing the gating on hook presence.
The `SourcesController` no longer needs to check whether hooks are available and disable the `Add source` button if none are present.

resolves #449 