### PR TITLE
Handle rule filter serialization

### DIFF
--- a/application/controllers/EventRuleController.php
+++ b/application/controllers/EventRuleController.php
@@ -7,6 +7,7 @@ namespace Icinga\Module\Notifications\Controllers;
 
 use Icinga\Application\Hook;
 use Icinga\Application\Logger;
+use Icinga\Exception\ConfigurationError;
 use Icinga\Exception\Http\HttpNotFoundException;
 use Icinga\Module\Notifications\Common\Auth;
 use Icinga\Module\Notifications\Common\Database;
@@ -14,20 +15,25 @@ use Icinga\Module\Notifications\Common\Links;
 use Icinga\Module\Notifications\Forms\EventRuleConfigElements\NotificationConfigProvider;
 use Icinga\Module\Notifications\Forms\EventRuleConfigForm;
 use Icinga\Module\Notifications\Forms\EventRuleForm;
-use Icinga\Module\Notifications\Hook\V1\SourceHook;
+use Icinga\Module\Notifications\Hook\V2\SourceHook;
 use Icinga\Module\Notifications\Model\Rule;
 use Icinga\Module\Notifications\Model\Source;
+use Icinga\Module\Notifications\Util\RuleParser;
+use Icinga\Module\Notifications\Util\RuleSerializer;
 use Icinga\Module\Notifications\Web\Control\SearchBar\ExtraTagSuggestions;
 use Icinga\Web\Notification;
 use Icinga\Web\Session;
 use ipl\Html\Contract\Form;
 use ipl\Html\Html;
 use ipl\Stdlib\Filter;
+use ipl\Stdlib\Filter\Condition;
 use ipl\Web\Compat\CompatController;
-use ipl\Web\Compat\CompatForm;
+use ipl\Web\Control\SearchBar\SearchException;
+use ipl\Web\Control\SearchEditor;
 use ipl\Web\Url;
 use ipl\Web\Widget\Icon;
 use ipl\Web\Widget\Link;
+use JsonException;
 use Psr\Http\Message\ServerRequestInterface;
 use Throwable;
 
@@ -195,7 +201,71 @@ class EventRuleController extends CompatController
     {
         $ruleId = (int) $this->params->getRequired('id');
         $filter = $this->params->get('object_filter', $this->session->get('object_filter'));
+        $hook = $this->resolveSourceHook($ruleId);
 
+        if ($filter) {
+            try {
+                $parsedFilter = (new RuleParser())->parseJson($filter);
+                $applyLabels = function (Filter\Rule $rule) use ($hook, &$applyLabels): void {
+                    if ($rule instanceof Filter\Chain) {
+                        foreach ($rule as $child) {
+                            $applyLabels($child);
+                        }
+                    } else {
+                        /** @var Condition $rule */
+                        $hook->enrichCondition($rule);
+                    }
+                };
+
+                $applyLabels($parsedFilter);
+            } catch (JsonException $e) {
+                Logger::error('Failed to parse rule filter configuration: %s (Error: %s)', $filter, $e);
+                throw new ConfigurationError($this->translate(
+                    'Failed to parse rule filter configuration. Please contact your system administrator.'
+                ));
+            }
+        }
+
+        $editor = (new SearchEditor())
+            ->setFilter($parsedFilter ?? new Filter\All())
+            ->setSuggestionUrl(
+                Url::fromPath(
+                    'notifications/event-rule/suggest',
+                    ['id' => $ruleId, '_disableLayout' => true, 'showCompact' => true]
+                )
+            )
+            ->setAction(Url::fromRequest()->with('object_filter', $filter)->getAbsoluteUrl())
+            ->setMetadataFields(['customvarid'])
+            ->on(
+                SearchEditor::ON_VALIDATE_COLUMN,
+                function (Condition $condition) use ($hook) {
+                    if (! $hook->isValidCondition($condition)) {
+                        throw new SearchException($this->translate('Is not a valid column'));
+                    }
+
+                    $condition->metaData()->set('jsonPath', $hook->getJsonPath($condition));
+                }
+            )
+            ->on(Form::ON_SUBMIT, function (SearchEditor $form) use ($ruleId, $hook) {
+                $this->session->set('object_filter', (new RuleSerializer($form->getFilter()))->getJson());
+                $this->redirectNow(Links::eventRule($ruleId)->setParam('_filterOnly'));
+            })
+            ->handleRequest($this->getServerRequest());
+
+        $this->getDocument()->addHtml($editor);
+
+        $this->setTitle($this->translate('Adjust Filter'));
+    }
+
+    public function suggestAction(): void
+    {
+        $hook = $this->resolveSourceHook((int) $this->params->getRequired('id'));
+        $suggestions = $hook->getSuggestions();
+        $this->getDocument()->addHtml($suggestions->forRequest($this->getServerRequest()));
+    }
+
+    protected function resolveSourceHook(int $ruleId): SourceHook
+    {
         $source = null;
         if ($ruleId !== -1) {
             $source = Rule::on(Database::get())
@@ -217,7 +287,7 @@ class EventRuleController extends CompatController
         }
 
         $hook = null;
-        foreach (Hook::all('Notifications/v1/Source') as $h) {
+        foreach (Hook::all('Notifications/v2/Source') as $h) {
             /** @var SourceHook $h */
             try {
                 if ($h->getSourceType() === $source->type) {
@@ -237,51 +307,7 @@ class EventRuleController extends CompatController
             ), $source->type));
         }
 
-        if (! $filter) {
-            $targets = $hook->getRuleFilterTargets($source->id);
-            if (count($targets) === 1 && ! is_array(reset($targets))) {
-                $filter = key($targets);
-            } else {
-                $target = null;
-                $form = (new CompatForm())
-                    ->applyDefaultElementDecorators()
-                    ->setAction(Url::fromRequest()->getAbsoluteUrl())
-                    ->addElement('select', 'target', [
-                        'required' => true,
-                        'label' => $this->translate('Filter Target'),
-                        'options' => ['' => ' - ' . $this->translate('Please choose') . ' - '] + $targets,
-                        'disabledOptions' => ['']
-                    ])
-                    ->addElement('submit', 'btn_submit', [
-                        // translators: shown on a submit button to proceed to the next step of a form wizard
-                        'label' => $this->translate('Next')
-                    ])
-                    ->on(Form::ON_SUBMIT, function (CompatForm $form) use (&$target) {
-                        $target = $form->getValue('target');
-                    })
-                    ->handleRequest($this->getServerRequest());
-
-                if ($target !== null) {
-                    $filter = $target;
-                } else {
-                    $this->addContent($form);
-                }
-            }
-        }
-
-        if ($filter) {
-            $form = $hook->getRuleFilterEditor($filter)
-                ->setAction(Url::fromRequest()->with('object_filter', $filter)->getAbsoluteUrl())
-                ->on(Form::ON_SUBMIT, function (Form $form) use ($ruleId, $hook) {
-                    $this->session->set('object_filter', $hook->serializeRuleFilter($form));
-                    $this->redirectNow(Links::eventRule($ruleId)->setParam('_filterOnly'));
-                })
-                ->handleRequest($this->getServerRequest());
-
-            $this->getDocument()->addHtml($form);
-        }
-
-        $this->setTitle($this->translate('Adjust Filter'));
+        return $hook;
     }
 
     public function editAction(): void

--- a/application/controllers/EventRuleController.php
+++ b/application/controllers/EventRuleController.php
@@ -235,7 +235,7 @@ class EventRuleController extends CompatController
                 )
             )
             ->setAction(Url::fromRequest()->with('object_filter', $filter)->getAbsoluteUrl())
-            ->setMetadataFields(['customvarid'])
+            ->setMetadataFields($hook->getMetadataKeys())
             ->on(
                 SearchEditor::ON_VALIDATE_COLUMN,
                 function (Condition $condition) use ($hook) {
@@ -247,7 +247,10 @@ class EventRuleController extends CompatController
                 }
             )
             ->on(Form::ON_SUBMIT, function (SearchEditor $form) use ($ruleId, $hook) {
-                $this->session->set('object_filter', (new RuleSerializer($form->getFilter()))->getJson());
+                $this->session->set(
+                    'object_filter',
+                    (new RuleSerializer($form->getFilter(), $hook->getMetadataKeys()))->getJson()
+                );
                 $this->redirectNow(Links::eventRule($ruleId)->setParam('_filterOnly'));
             })
             ->handleRequest($this->getServerRequest());

--- a/application/controllers/EventRuleController.php
+++ b/application/controllers/EventRuleController.php
@@ -5,29 +5,37 @@
 
 namespace Icinga\Module\Notifications\Controllers;
 
-use Icinga\Application\Hook;
 use Icinga\Application\Logger;
+use Icinga\Exception\ConfigurationError;
 use Icinga\Exception\Http\HttpNotFoundException;
 use Icinga\Module\Notifications\Common\Auth;
 use Icinga\Module\Notifications\Common\Database;
 use Icinga\Module\Notifications\Common\Links;
+use Icinga\Module\Notifications\Common\SourceHookLocator;
 use Icinga\Module\Notifications\Forms\EventRuleConfigElements\NotificationConfigProvider;
 use Icinga\Module\Notifications\Forms\EventRuleConfigForm;
 use Icinga\Module\Notifications\Forms\EventRuleForm;
-use Icinga\Module\Notifications\Hook\V1\SourceHook;
+use Icinga\Module\Notifications\Hook\V2\SourceHook;
 use Icinga\Module\Notifications\Model\Rule;
 use Icinga\Module\Notifications\Model\Source;
+use Icinga\Module\Notifications\Util\RuleSerializer;
 use Icinga\Module\Notifications\Web\Control\SearchBar\ExtraTagSuggestions;
 use Icinga\Web\Notification;
 use Icinga\Web\Session;
 use ipl\Html\Contract\Form;
 use ipl\Html\Html;
 use ipl\Stdlib\Filter;
+use ipl\Stdlib\Filter\Condition;
+use ipl\Stdlib\Seq;
 use ipl\Web\Compat\CompatController;
-use ipl\Web\Compat\CompatForm;
+use ipl\Web\Control\SearchBar\SearchException;
+use ipl\Web\Control\SearchEditor;
+use ipl\Web\Filter\QueryString;
+use ipl\Web\FormElement\SearchSuggestions;
 use ipl\Web\Url;
 use ipl\Web\Widget\Icon;
 use ipl\Web\Widget\Link;
+use JsonException;
 use Psr\Http\Message\ServerRequestInterface;
 use Throwable;
 
@@ -195,7 +203,130 @@ class EventRuleController extends CompatController
     {
         $ruleId = (int) $this->params->getRequired('id');
         $filter = $this->params->get('object_filter', $this->session->get('object_filter'));
+        $hook = $this->resolveSourceHook($ruleId);
 
+        $parsedFilter = null;
+        if ($filter) {
+            try {
+                $parsedFilter = json_decode($filter, true, flags: JSON_THROW_ON_ERROR);
+            } catch (JsonException $e) {
+                Logger::error('Failed to parse rule filter configuration: %s (Error: %s)', $filter, $e);
+                throw new ConfigurationError($this->translate(
+                    'Failed to parse rule filter configuration. Please contact your system administrator.'
+                ));
+            }
+
+            $version = $parsedFilter['version'] ?? null;
+            if ($version !== RuleSerializer::VERSION) {
+                Logger::error(
+                    'Cannot load filter for rule with id %d: filter version \'%s\' is not supported (expected %d)',
+                    $ruleId,
+                    $version,
+                    RuleSerializer::VERSION
+                );
+                throw new ConfigurationError($this->translate(
+                    'Unsupported rule filter version. Please contact your system administrator.'
+                ));
+            }
+        }
+
+        $editor = (new SearchEditor())
+            ->setQueryString($parsedFilter['qs'] ?? '')
+            ->setSuggestionUrl(
+                Url::fromPath(
+                    'notifications/event-rule/suggest',
+                    ['id' => $ruleId, '_disableLayout' => true, 'showCompact' => true]
+                )
+            )
+            ->setAction(Url::fromRequest()->with('object_filter', $filter)->getAbsoluteUrl())
+            ->on(
+                SearchEditor::ON_VALIDATE_COLUMN,
+                function (Condition $condition) use ($hook) {
+                    try {
+                        $hook->assertValidCondition($condition);
+                    } catch (SearchException $e) {
+                        throw $e;
+                    } catch (Throwable $e) {
+                        Logger::error(
+                            'Source hook %s failed to validate filter condition: %s',
+                            get_class($hook),
+                            $e
+                        );
+
+                        throw new SearchException($this->translate(
+                            'Failed to validate column. Please contact your system administrator.'
+                        ));
+                    }
+                }
+            )
+            ->on(Form::ON_SUBMIT, function (SearchEditor $form) use ($ruleId, $hook) {
+                $filter = $form->getFilter();
+
+                $this->session->set(
+                    'object_filter',
+                    (new RuleSerializer(
+                        $filter,
+                        $hook->getJsonPaths(...Seq::unique(Seq::map($filter->yieldRules(), fn($r) => $r->getColumn())))
+                    ))->getJson()
+                );
+                $this->redirectNow(Links::eventRule($ruleId)->setParam('_filterOnly'));
+            });
+
+        $editor->getParser()->on(QueryString::ON_CONDITION, function (Condition $condition) use ($hook) {
+            try {
+                $hook->enrichCondition($condition);
+            } catch (Throwable $e) {
+                Logger::error(
+                    'Source hook %s failed to enrich filter condition: %s',
+                    get_class($hook),
+                    $e
+                );
+            }
+        });
+        $editor->handleRequest($this->getServerRequest());
+
+        $this->getDocument()->addHtml($editor);
+
+        $this->setTitle($this->translate('Adjust Filter'));
+    }
+
+    public function suggestAction(): void
+    {
+        $hook = $this->resolveSourceHook((int) $this->params->getRequired('id'));
+        $requestData = SearchSuggestions::parseRequest($this->getServerRequest()) ?? [];
+
+        $type = $requestData['term']['type'] ?? null;
+        $label = $requestData['term']['label'] ?? '';
+        $failureMessage = null;
+
+        if ($type === 'column') {
+            $provider = $hook->getColumnSuggestions($label);
+        } else {
+            $column = $requestData['column'] ?? null;
+            if ($column === null || $column === SearchEditor::FAKE_COLUMN) {
+                $failureMessage = $this->translate('Missing column name');
+                $provider = [];
+            } else {
+                /** @var Filter\Chain $searchFilter */
+                $searchFilter = QueryString::parse($requestData['searchFilter'] ?? '');
+                $provider = $hook->getValueSuggestions($column, $label, $searchFilter);
+            }
+        }
+
+        $suggestions = (new SearchSuggestions($provider))
+            ->setSearchTerm($label)
+            ->setOriginalSearchValue($requestData['term']['search'] ?? '')
+            ->showFailureMessage($failureMessage);
+
+        if ($type === 'column') {
+            $suggestions->setGroupingCallback(fn ($x) => $x['group']);
+        }
+
+        $this->getDocument()->addHtml($suggestions);
+    }
+
+    protected function resolveSourceHook(int $ruleId): SourceHook
+    {
         $source = null;
         if ($ruleId !== -1) {
             $source = Rule::on(Database::get())
@@ -216,19 +347,7 @@ class EventRuleController extends CompatController
             $this->httpNotFound($this->translate('Rule not found'));
         }
 
-        $hook = null;
-        foreach (Hook::all('Notifications/v1/Source') as $h) {
-            /** @var SourceHook $h */
-            try {
-                if ($h->getSourceType() === $source->type) {
-                    $hook = $h;
-
-                    break;
-                }
-            } catch (Throwable $e) {
-                Logger::error('Failed to load source integration %s: %s', $h::class, $e);
-            }
-        }
+        $hook = SourceHookLocator::forType($source->type);
 
         if ($hook === null) {
             $this->httpNotFound(sprintf($this->translate(
@@ -237,51 +356,7 @@ class EventRuleController extends CompatController
             ), $source->type));
         }
 
-        if (! $filter) {
-            $targets = $hook->getRuleFilterTargets($source->id);
-            if (count($targets) === 1 && ! is_array(reset($targets))) {
-                $filter = key($targets);
-            } else {
-                $target = null;
-                $form = (new CompatForm())
-                    ->applyDefaultElementDecorators()
-                    ->setAction(Url::fromRequest()->getAbsoluteUrl())
-                    ->addElement('select', 'target', [
-                        'required' => true,
-                        'label' => $this->translate('Filter Target'),
-                        'options' => ['' => ' - ' . $this->translate('Please choose') . ' - '] + $targets,
-                        'disabledOptions' => ['']
-                    ])
-                    ->addElement('submit', 'btn_submit', [
-                        // translators: shown on a submit button to proceed to the next step of a form wizard
-                        'label' => $this->translate('Next')
-                    ])
-                    ->on(Form::ON_SUBMIT, function (CompatForm $form) use (&$target) {
-                        $target = $form->getValue('target');
-                    })
-                    ->handleRequest($this->getServerRequest());
-
-                if ($target !== null) {
-                    $filter = $target;
-                } else {
-                    $this->addContent($form);
-                }
-            }
-        }
-
-        if ($filter) {
-            $form = $hook->getRuleFilterEditor($filter)
-                ->setAction(Url::fromRequest()->with('object_filter', $filter)->getAbsoluteUrl())
-                ->on(Form::ON_SUBMIT, function (Form $form) use ($ruleId, $hook) {
-                    $this->session->set('object_filter', $hook->serializeRuleFilter($form));
-                    $this->redirectNow(Links::eventRule($ruleId)->setParam('_filterOnly'));
-                })
-                ->handleRequest($this->getServerRequest());
-
-            $this->getDocument()->addHtml($form);
-        }
-
-        $this->setTitle($this->translate('Adjust Filter'));
+        return $hook;
     }
 
     public function editAction(): void

--- a/application/forms/EventRuleConfigForm.php
+++ b/application/forms/EventRuleConfigForm.php
@@ -177,13 +177,15 @@ class EventRuleConfigForm extends CompatForm
     /**
      * Get the element to update in case the object filter of the rule is changed
      *
-     * @param string $newFilter
+     * @param ?string $newFilter
      *
      * @return ValidHtml
      */
-    public function prepareObjectFilterUpdate(string $newFilter): ValidHtml
+    public function prepareObjectFilterUpdate(?string $newFilter): ValidHtml
     {
-        $this->populate(['object_filter' => $newFilter]);
+        if ($newFilter !== null) {
+            $this->populate(['object_filter' => $newFilter]);
+        }
 
         return new HtmlElement(
             'div',

--- a/application/forms/SourceForm.php
+++ b/application/forms/SourceForm.php
@@ -9,7 +9,7 @@ use DateTime;
 use Icinga\Application\Hook;
 use Icinga\Application\Logger;
 use Icinga\Exception\Http\HttpNotFoundException;
-use Icinga\Module\Notifications\Hook\V1\SourceHook;
+use Icinga\Module\Notifications\Hook\V2\SourceHook;
 use Icinga\Module\Notifications\Model\Source;
 use ipl\Html\Attributes;
 use ipl\Html\HtmlDocument;
@@ -57,7 +57,7 @@ class SourceForm extends CompatForm
             self::TYPE_GENERIC  => $this->translate('Generic')
         ];
 
-        foreach (Hook::all('Notifications/v1/Source') as $hook) {
+        foreach (Hook::all('Notifications/v2/Source') as $hook) {
             /** @var SourceHook $hook */
             try {
                 $type = $hook->getSourceType();

--- a/application/forms/SourceForm.php
+++ b/application/forms/SourceForm.php
@@ -6,10 +6,7 @@
 namespace Icinga\Module\Notifications\Forms;
 
 use DateTime;
-use Icinga\Application\Hook;
-use Icinga\Application\Logger;
 use Icinga\Exception\Http\HttpNotFoundException;
-use Icinga\Module\Notifications\Hook\V1\SourceHook;
 use Icinga\Module\Notifications\Model\Source;
 use ipl\Html\Attributes;
 use ipl\Html\HtmlDocument;
@@ -24,7 +21,6 @@ use ipl\Web\Url;
 use ipl\Web\Widget\ButtonLink;
 use ipl\Web\Widget\Icon;
 use ipl\Web\Widget\Link;
-use Throwable;
 
 class SourceForm extends CompatForm
 {
@@ -51,22 +47,6 @@ class SourceForm extends CompatForm
     {
         $this->applyDefaultElementDecorators();
         $this->addCsrfCounterMeasure();
-
-        $types = [
-            ''                  => ' - ' . $this->translate('Please choose') . ' - ',
-            self::TYPE_GENERIC  => $this->translate('Generic')
-        ];
-
-        foreach (Hook::all('Notifications/v1/Source') as $hook) {
-            /** @var SourceHook $hook */
-            try {
-                $type = $hook->getSourceType();
-                $types[$type] = $hook->getSourceLabel();
-            } catch (Throwable $e) {
-                Logger::error('Failed to load source integration %s: %s', $hook::class, $e);
-            }
-        }
-
         $this->addHtml(new HtmlElement(
             'p',
             Attributes::create(['class' => 'description']),
@@ -74,8 +54,7 @@ class SourceForm extends CompatForm
                 'Sources are the most vital part of Icinga Notifications. They submit events that will be'
                 . ' processed to notify users about incidents. You can either configure sources that provide an'
                 . ' integration in Icinga Web or use the Generic type for sources that communicate directly with the'
-                . ' Icinga Notifications API. If you cannot choose the desired source below, consult its documentation'
-                . ' on how to integrate it.'
+                . ' Icinga Notifications API. Refer to the source\'s documentation for the correct source type.'
             ))
         ));
 
@@ -88,14 +67,11 @@ class SourceForm extends CompatForm
             ]
         );
         $this->addElement(
-            'select',
+            'text',
             'type',
             [
                 'required'          => true,
                 'label'             => $this->translate('Source Type'),
-                'class'             => 'autosubmit',
-                'options'           => $types,
-                'disabledOptions'   => ['']
             ]
         );
 

--- a/library/Notifications/Common/SourceHookLocator.php
+++ b/library/Notifications/Common/SourceHookLocator.php
@@ -1,0 +1,38 @@
+<?php
+
+// SPDX-FileCopyrightText: 2026 Icinga GmbH <https://icinga.com>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+namespace Icinga\Module\Notifications\Common;
+
+use Icinga\Application\Hook;
+use Icinga\Module\Notifications\Hook\V2\SourceHook;
+use ipl\Stdlib\Str;
+
+class SourceHookLocator
+{
+    /**
+     * Get the source hook responsible for the given source type
+     *
+     * Returns `null` if no module providing such a hook is enabled.
+     *
+     * {@see Hook::assertValidHook()} derives the expected base class of a hook from its name. Since the hook's name
+     * carries the source type, a class alias of {@see SourceHook} matching the expected class name is created
+     * so the validation passes.
+     *
+     * @param string $type The source type as stored in the `source` table
+     *
+     * @return ?SourceHook
+     */
+    public static function forType(string $type): ?SourceHook
+    {
+        $name = ucfirst(Str::camel($type));
+
+        $alias = 'Icinga\\Module\\Notifications\\Hook\\V2\\' . $name . 'SourceHook';
+        if (! interface_exists($alias)) {
+            class_alias(SourceHook::class, $alias);
+        }
+
+        return Hook::first('Notifications\\V2\\' . $name . 'Source');
+    }
+}

--- a/library/Notifications/Hook/V2/SourceHook.php
+++ b/library/Notifications/Hook/V2/SourceHook.php
@@ -65,4 +65,13 @@ interface SourceHook
      * @return Suggestions
      */
     public function getSuggestions(): Suggestions;
+
+    /**
+     * Get the metadata keys for the conditions
+     *
+     * Only the given keys will be added to the SearchEditor and stored in the database
+     *
+     * @return string[]
+     */
+    public function getMetadataKeys(): array;
 }

--- a/library/Notifications/Hook/V2/SourceHook.php
+++ b/library/Notifications/Hook/V2/SourceHook.php
@@ -1,0 +1,68 @@
+<?php
+
+// SPDX-FileCopyrightText: 2026 Icinga GmbH <https://icinga.com>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+namespace Icinga\Module\Notifications\Hook\V2;
+
+use ipl\Stdlib\Filter\Condition;
+use ipl\Web\Control\SearchBar\Suggestions;
+use ipl\Web\Widget\Icon;
+
+interface SourceHook
+{
+    /**
+     * Get the type of source this integration is responsible for
+     *
+     * @return string
+     */
+    public function getSourceType(): string;
+
+    /**
+     * Get the label of the source this integration is responsible for
+     *
+     * @return string
+     */
+    public function getSourceLabel(): string;
+
+    /**
+     * Get the icon of the source this integration is responsible for
+     *
+     * @return Icon
+     */
+    public function getSourceIcon(): Icon;
+
+    /**
+     * Get whether the condition is valid
+     *
+     * @param Condition $condition
+     *
+     * @return bool
+     */
+    public function isValidCondition(Condition $condition): bool;
+
+    /**
+     * Enrich the given condition with metadata like the columnLabel
+     *
+     * @param Condition $condition
+     *
+     * @return void
+     */
+    public function enrichCondition(Condition $condition): void;
+
+    /**
+     * Get the JsonPath metadata for a condition
+     *
+     * @param Condition $condition
+     *
+     * @return string
+     */
+    public function getJsonPath(Condition $condition): string;
+
+    /**
+     * Get the Suggestions for the editor
+     *
+     * @return Suggestions
+     */
+    public function getSuggestions(): Suggestions;
+}

--- a/library/Notifications/Hook/V2/SourceHook.php
+++ b/library/Notifications/Hook/V2/SourceHook.php
@@ -1,0 +1,82 @@
+<?php
+
+// SPDX-FileCopyrightText: 2026 Icinga GmbH <https://icinga.com>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+namespace Icinga\Module\Notifications\Hook\V2;
+
+use ipl\Stdlib\Filter\Chain;
+use ipl\Stdlib\Filter\Condition;
+use ipl\Web\Control\SearchBar\SearchException;
+use ipl\Web\FormElement\SearchSuggestions;
+use ipl\Web\Widget\Icon;
+use Traversable;
+
+interface SourceHook
+{
+    /**
+     * Get the label of the source this integration is responsible for
+     *
+     * @return string
+     */
+    public function getSourceLabel(): string;
+
+    /**
+     * Get the icon of the source this integration is responsible for
+     *
+     * @return Icon
+     */
+    public function getSourceIcon(): Icon;
+
+    /**
+     * Assert that the given condition is valid
+     *
+     * Implementations must throw a {@see SearchException} carrying a user-facing
+     * message if the condition is not valid.
+     *
+     * @param Condition $condition
+     *
+     * @return void
+     *
+     * @throws SearchException If the condition is not valid
+     */
+    public function assertValidCondition(Condition $condition): void;
+
+    /**
+     * Enrich the given condition with metadata like the columnLabel
+     *
+     * @param Condition $condition
+     *
+     * @return void
+     */
+    public function enrichCondition(Condition $condition): void;
+
+    /**
+     * Get all JsonPaths for all given columns, keyed by the column
+     *
+     * @param string ...$columns
+     *
+     * @return array<string, string[]>
+     */
+    public function getJsonPaths(string ...$columns): array;
+
+    /**
+     * Get suggestions for a value field
+     *
+     * @param string $column
+     * @param string $searchTerm
+     * @param Chain $searchFilter
+     *
+     * @return Traversable Provider for {@see SearchSuggestions::__construct}
+     */
+    public function getValueSuggestions(string $column, string $searchTerm, Chain $searchFilter): Traversable;
+
+    /**
+     * Get suggestions for a column field
+     *
+     * @param string $searchTerm
+     *
+     * @return Traversable Provider for {@see SearchSuggestions::__construct}
+     */
+    public function getColumnSuggestions(string $searchTerm): Traversable;
+}

--- a/library/Notifications/Model/Source.php
+++ b/library/Notifications/Model/Source.php
@@ -8,7 +8,7 @@ namespace Icinga\Module\Notifications\Model;
 use DateTime;
 use Icinga\Application\Hook;
 use Icinga\Application\Logger;
-use Icinga\Module\Notifications\Hook\V1\SourceHook;
+use Icinga\Module\Notifications\Hook\V2\SourceHook;
 use ipl\Orm\Behavior\BoolCast;
 use ipl\Orm\Behavior\MillisecondTimestamp;
 use ipl\Orm\Behaviors;
@@ -103,7 +103,7 @@ class Source extends Model
         // Fallback, in case an integration is inactive or missing
         $icon = new Icon('share-nodes');
 
-        foreach (Hook::all('Notifications/v1/Source') as $hook) {
+        foreach (Hook::all('Notifications/v2/Source') as $hook) {
             /** @var SourceHook $hook */
             try {
                 if ($hook->getSourceType() === $this->type) {

--- a/library/Notifications/Model/Source.php
+++ b/library/Notifications/Model/Source.php
@@ -6,9 +6,9 @@
 namespace Icinga\Module\Notifications\Model;
 
 use DateTime;
-use Icinga\Application\Hook;
 use Icinga\Application\Logger;
-use Icinga\Module\Notifications\Hook\V1\SourceHook;
+use Icinga\Module\Notifications\Common\SourceHookLocator;
+use Icinga\Module\Notifications\Hook\V2\SourceHook;
 use ipl\Orm\Behavior\BoolCast;
 use ipl\Orm\Behavior\MillisecondTimestamp;
 use ipl\Orm\Behaviors;
@@ -103,22 +103,17 @@ class Source extends Model
         // Fallback, in case an integration is inactive or missing
         $icon = new Icon('share-nodes');
 
-        foreach (Hook::all('Notifications/v1/Source') as $hook) {
+        $hook = SourceHookLocator::forType($this->type);
+        if ($hook !== null) {
             /** @var SourceHook $hook */
             try {
-                if ($hook->getSourceType() === $this->type) {
-                    $icon = $hook->getSourceIcon();
-
-                    break;
-                }
+                $icon = $hook->getSourceIcon();
             } catch (Throwable $e) {
                 Logger::error(
                     'Failed to retrieve source icon for source type "%s": %s',
                     $this->type,
                     $e
                 );
-
-                break;
             }
         }
 

--- a/library/Notifications/Util/RuleParser.php
+++ b/library/Notifications/Util/RuleParser.php
@@ -1,0 +1,67 @@
+<?php
+
+// SPDX-FileCopyrightText: 2026 Icinga GmbH <https://icinga.com>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+namespace Icinga\Module\Notifications\Util;
+
+use ipl\Stdlib\Filter;
+
+class RuleParser
+{
+    public function parseJson(string $json): Filter\Rule
+    {
+        return $this->parseRule(json_decode($json, true));
+    }
+
+    /**
+     * Parse a serialized rule
+     *
+     * @param array $rule A rule serialized as json
+     *
+     * @return Filter\Rule
+     */
+    public function parseRule(array $rule): Filter\Rule
+    {
+        if (in_array($rule['op'], ['&', '|', '!'])) {
+            return $this->parseChain($rule);
+        } else {
+            return $this->parseCondition($rule);
+        }
+    }
+
+    protected function parseChain(array $data): Filter\Chain
+    {
+        $rules = [];
+        foreach ($data['rules'] as $rule) {
+            $rules[] = $this->parseRule($rule);
+        }
+
+
+        return match ($data['op']) {
+            '&' => new Filter\All(...$rules),
+            '|' => new Filter\Any(...$rules),
+            '!' => new Filter\None(...$rules),
+        };
+    }
+
+    protected function parseCondition(array $data): Filter\Condition
+    {
+        $condition = match ($data['op']) {
+            '!~' => new Filter\Unlike($data['column'], $data['value']),
+            '!=' => new Filter\Unequal($data['column'], $data['value']),
+            '~' => new Filter\Like($data['column'], $data['value']),
+            '=' => new Filter\Equal($data['column'], $data['value']),
+            '>' => new Filter\GreaterThan($data['column'], $data['value']),
+            '<' => new Filter\LessThan($data['column'], $data['value']),
+            '>=' => new Filter\GreaterThanOrEqual($data['column'], $data['value']),
+            '<=' => new Filter\LessThanOrEqual($data['column'], $data['value']),
+        };
+
+        if (isset($data['jsonPath'])) {
+            $condition->metaData()->set('jsonPath', $data['jsonPath']);
+        }
+
+        return $condition;
+    }
+}

--- a/library/Notifications/Util/RuleParser.php
+++ b/library/Notifications/Util/RuleParser.php
@@ -48,18 +48,20 @@ class RuleParser
     protected function parseCondition(array $data): Filter\Condition
     {
         $condition = match ($data['op']) {
-            '!~' => new Filter\Unlike($data['column'], $data['value']),
-            '!=' => new Filter\Unequal($data['column'], $data['value']),
-            '~' => new Filter\Like($data['column'], $data['value']),
-            '=' => new Filter\Equal($data['column'], $data['value']),
-            '>' => new Filter\GreaterThan($data['column'], $data['value']),
-            '<' => new Filter\LessThan($data['column'], $data['value']),
-            '>=' => new Filter\GreaterThanOrEqual($data['column'], $data['value']),
-            '<=' => new Filter\LessThanOrEqual($data['column'], $data['value']),
+            '!~' => new Filter\Unlike($data['columnName'], $data['value']),
+            '!=' => new Filter\Unequal($data['columnName'], $data['value']),
+            '~' => new Filter\Like($data['columnName'], $data['value']),
+            '=' => new Filter\Equal($data['columnName'], $data['value']),
+            '>' => new Filter\GreaterThan($data['columnName'], $data['value']),
+            '<' => new Filter\LessThan($data['columnName'], $data['value']),
+            '>=' => new Filter\GreaterThanOrEqual($data['columnName'], $data['value']),
+            '<=' => new Filter\LessThanOrEqual($data['columnName'], $data['value']),
         };
 
-        if (isset($data['jsonPath'])) {
-            $condition->metaData()->set('jsonPath', $data['jsonPath']);
+        $condition->metaData()->set('jsonPath', $data['column']);
+
+        foreach ($data['metadata'] ?? [] as $key => $value) {
+            $condition->metaData()->set($key, $value);
         }
 
         return $condition;

--- a/library/Notifications/Util/RuleSerializer.php
+++ b/library/Notifications/Util/RuleSerializer.php
@@ -13,14 +13,17 @@ class RuleSerializer
 {
     protected Filter\Rule $filter;
 
+    protected array $metadataKeys = [];
+
     /**
      * Create an object that can be used to serialize a rule to JSON
      *
      * @param Filter\Rule $filter
      */
-    public function __construct(Filter\Rule $filter)
+    public function __construct(Filter\Rule $filter, array $metadataKeys = [])
     {
         $this->filter = $filter;
+        $this->metadataKeys = $metadataKeys;
     }
 
     /**
@@ -92,9 +95,27 @@ class RuleSerializer
                 $condition instanceof Filter\GreaterThanOrEqual => '>=',
                 $condition instanceof Filter\LessThanOrEqual => '<=',
             },
-            'column' => $condition->getColumn(),
+            'column' => $condition->metaData()->get('jsonPath'),
             'value' => $condition->getValue(),
-            'jsonPath' => $condition->metaData()->get('jsonPath'),
+            'columnName' => $condition->getColumn(),
+            'metadata' => $this->serializeConditionMetadata($condition),
         ];
+    }
+
+    /**
+     * Serialize the metadata of a condtion into an array
+     *
+     * @param Filter\Condition $condition
+     *
+     * @return array<string, mixed>
+     */
+    protected function serializeConditionMetadata(Filter\Condition $condition): array
+    {
+        $result = [];
+        foreach ($this->metadataKeys as $key) {
+            $result[$key] = $condition->metaData()->get($key);
+        }
+
+        return $result;
     }
 }

--- a/library/Notifications/Util/RuleSerializer.php
+++ b/library/Notifications/Util/RuleSerializer.php
@@ -1,0 +1,100 @@
+<?php
+
+// SPDX-FileCopyrightText: 2026 Icinga GmbH <https://icinga.com>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+namespace Icinga\Module\Notifications\Util;
+
+use Icinga\Util\Json;
+use ipl\Stdlib\Filter;
+use ipl\Stdlib\Filter\Chain;
+
+class RuleSerializer
+{
+    protected Filter\Rule $filter;
+
+    /**
+     * Create an object that can be used to serialize a rule to JSON
+     *
+     * @param Filter\Rule $filter
+     */
+    public function __construct(Filter\Rule $filter)
+    {
+        $this->filter = $filter;
+    }
+
+    /**
+     * Serialize the filter as Json
+     *
+     * @return string
+     *
+     * @throws \Icinga\Exception\Json\JsonEncodeException
+     */
+    public function getJson(): string
+    {
+        if ($this->filter instanceof Filter\Chain) {
+            $result = $this->serializeChain($this->filter);
+        } else {
+            /** @var Filter\Condition $this->filter */
+            $result = $this->serializeCondition($this->filter);
+        }
+
+        return Json::encode($result);
+    }
+
+    /**
+     * Create an array with keys `op` and `rules` from a chain
+     *
+     * @param Chain $chain
+     *
+     * @return array{op: string, rules: array}
+     */
+    protected function serializeChain(Chain $chain): array
+    {
+        $result = [
+            'op' => match (true) {
+                $chain instanceof Filter\All => '&',
+                $chain instanceof Filter\None => '!',
+                $chain instanceof Filter\Any => '|'
+            }
+        ];
+
+        $rules = [];
+        foreach ($chain as $rule) {
+            if ($rule instanceof Chain) {
+                $rules[] = $this->serializeChain($rule);
+            } else {
+                $rules[] = $this->serializeCondition($rule);
+            }
+        }
+
+        $result['rules'] = $rules;
+        return $result;
+    }
+
+    /**
+     * Create an array with the keys `op`, `column` and `value` from a condition
+     *
+     * @param Filter\Condition $condition
+     *
+     * @return array{op: string, column: string, value: mixed}
+     */
+    protected function serializeCondition(Filter\Condition $condition): array
+    {
+        return [
+            'op' => match (true) {
+                $condition instanceof Filter\Unlike => '!~',
+                $condition instanceof Filter\Unequal => '!=',
+                $condition instanceof Filter\Like => '~',
+                $condition instanceof Filter\Equal => '=',
+                $condition instanceof Filter\GreaterThan => '>',
+                $condition instanceof Filter\LessThan => '<',
+                $condition instanceof Filter\GreaterThanOrEqual => '>=',
+                $condition instanceof Filter\LessThanOrEqual => '<=',
+            },
+            'column' => $condition->getColumn(),
+            'value' => $condition->getValue(),
+            'jsonPath' => $condition->metaData()->get('jsonPath'),
+        ];
+    }
+}

--- a/library/Notifications/Util/RuleSerializer.php
+++ b/library/Notifications/Util/RuleSerializer.php
@@ -1,0 +1,152 @@
+<?php
+
+// SPDX-FileCopyrightText: 2026 Icinga GmbH <https://icinga.com>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+namespace Icinga\Module\Notifications\Util;
+
+use Icinga\Exception\Json\JsonEncodeException;
+use Icinga\Util\Json;
+use ipl\Stdlib\Filter;
+use ipl\Stdlib\Filter\Chain;
+use ipl\Web\Filter\QueryString;
+use RuntimeException;
+
+class RuleSerializer
+{
+    /** @var int The filter version */
+    public const VERSION = 2;
+
+    /** @var Filter\Condition|Filter\Chain */
+    protected Filter\Rule $filter;
+
+    /** @var array<string, string[]> JSON paths keyed by column name */
+    protected array $jsonPaths;
+
+    /**
+     * Create an object that can be used to serialize a rule to JSON
+     *
+     * @param Filter\Rule $filter
+     * @param array<string, string[]> $jsonPaths JSON paths keyed by column name
+     */
+    public function __construct(Filter\Rule $filter, array $jsonPaths)
+    {
+        $this->filter = $filter;
+        $this->jsonPaths = $jsonPaths;
+    }
+
+    /**
+     * Serialize the filter as Json
+     *
+     * @return ?string The serialized filter, `null` for an empty chain
+     *
+     * @throws JsonEncodeException
+     */
+    public function getJson(): ?string
+    {
+        $result = [
+            'version' => self::VERSION,
+            'qs'      => QueryString::render($this->filter),
+        ];
+        if ($this->filter instanceof Filter\Chain) {
+            if ($this->filter->isEmpty()) {
+                return null;
+            }
+
+            $result['ast'] = $this->serializeChain($this->filter);
+        } else {
+            $result['ast'] = $this->serializeCondition($this->filter);
+        }
+
+        return Json::encode($result);
+    }
+
+    /**
+     * Create an array with keys `op` and `rules` from a chain
+     *
+     * @param Chain $chain
+     *
+     * @return array{op: string, rules: list<array<string, mixed>>}
+     */
+    protected function serializeChain(Chain $chain): array
+    {
+        $result = [
+            'op' => match (true) {
+                $chain instanceof Filter\All => '&',
+                $chain instanceof Filter\None => '!',
+                $chain instanceof Filter\Any => '|'
+            }
+        ];
+
+        $rules = [];
+        foreach ($chain as $rule) {
+            if ($rule instanceof Chain) {
+                $rules[] = $this->serializeChain($rule);
+            } else {
+                $rules[] = $this->serializeCondition($rule);
+            }
+        }
+
+        $result['rules'] = $rules;
+
+        return $result;
+    }
+
+    /**
+     * Create an array with the keys `op`, `attributes` and either `value` or `regex`
+     *
+     * @param Filter\Condition $condition
+     *
+     * @return array{op: string, attributes: list<string>, value: string}
+     *       | array{op: string, attributes: list<string>, regex: string}
+     *
+     * @throws RuntimeException If the source hook did not provide a JSON path for the condition's column
+     */
+    protected function serializeCondition(Filter\Condition $condition): array
+    {
+        $op = match (true) {
+            $condition instanceof Filter\Unlike, $condition instanceof Filter\Unequal => '!=',
+            $condition instanceof Filter\Like, $condition instanceof Filter\Equal => '=',
+            $condition instanceof Filter\GreaterThan => '>',
+            $condition instanceof Filter\LessThan => '<',
+            $condition instanceof Filter\GreaterThanOrEqual => '>=',
+            $condition instanceof Filter\LessThanOrEqual => '<=',
+        };
+
+        $value = $condition instanceof Filter\Like || $condition instanceof Filter\Unlike
+            ? ['regex' => $this->createRegularExpression($condition->getValue())]
+            : ['value' => $condition->getValue()];
+
+        $column = $condition->getColumn();
+        if (
+            ! isset($this->jsonPaths[$column])
+            || ! is_array($this->jsonPaths[$column])
+            || empty($this->jsonPaths[$column])
+        ) {
+            throw new RuntimeException(sprintf(
+                'Source hook did not provide a JSON path for column "%s"',
+                $column
+            ));
+        }
+
+        return [
+            'op' => $op,
+            'attributes' => $this->jsonPaths[$column],
+            ...$value,
+        ];
+    }
+
+    /**
+     * Get the preprocessed value of a condition
+     *
+     * Creates a regex for Like and Unlike rules
+     *
+     * @param string $value
+     *
+     * @return string
+     */
+    protected function createRegularExpression(string $value): string
+    {
+        return '^' . str_replace('\*', '.*', preg_quote($value)) . '$';
+    }
+}

--- a/test/php/library/Notifications/Common/SourceHookLocatorTest.php
+++ b/test/php/library/Notifications/Common/SourceHookLocatorTest.php
@@ -1,0 +1,73 @@
+<?php
+
+// SPDX-FileCopyrightText: 2026 Icinga GmbH <https://icinga.com>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+namespace Tests\Icinga\Module\Notifications\Common;
+
+use EmptyIterator;
+use Icinga\Application\Hook;
+use Icinga\Module\Notifications\Common\SourceHookLocator;
+use Icinga\Module\Notifications\Hook\V2\SourceHook;
+use ipl\Stdlib\Filter\Chain;
+use ipl\Stdlib\Filter\Condition;
+use ipl\Web\Widget\Icon;
+use PHPUnit\Framework\TestCase;
+use Traversable;
+
+class TestSource implements SourceHook
+{
+    public function getSourceLabel(): string
+    {
+        return '';
+    }
+
+    public function getSourceIcon(): Icon
+    {
+        return new Icon('');
+    }
+
+    public function assertValidCondition(Condition $condition): void
+    {
+    }
+
+    public function enrichCondition(Condition $condition): void
+    {
+    }
+
+    public function getJsonPaths(string ...$columns): array
+    {
+        return [];
+    }
+
+    public function getValueSuggestions(string $column, string $searchTerm, Chain $searchFilter): Traversable
+    {
+        return new EmptyIterator();
+    }
+
+    public function getColumnSuggestions(string $searchTerm): Traversable
+    {
+        return new EmptyIterator();
+    }
+}
+
+// phpcs:ignore PSR1.Classes.ClassDeclaration.MultipleClasses
+class SourceHookLocatorTest extends TestCase
+{
+    public function setUp(): void
+    {
+        Hook::register('Notifications\\V2\\TestSource', 'stub', TestSource::class, true);
+    }
+
+    public function testForTypeReturnsTheRegisteredHook()
+    {
+        $hook = SourceHookLocator::forType('test');
+
+        $this->assertInstanceOf(TestSource::class, $hook);
+    }
+
+    public function testForTypeReturnsNullWhenNoHookIsRegistered()
+    {
+        $this->assertNull(SourceHookLocator::forType('unregistered'));
+    }
+}

--- a/test/php/library/Notifications/Util/RuleSerializerTest.php
+++ b/test/php/library/Notifications/Util/RuleSerializerTest.php
@@ -1,0 +1,102 @@
+<?php
+
+// SPDX-FileCopyrightText: 2026 Icinga GmbH <https://icinga.com>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+namespace Tests\Icinga\Module\Notifications\Util;
+
+use Icinga\Module\Notifications\Util\RuleSerializer;
+use ipl\Stdlib\Filter;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+class RuleSerializerTest extends TestCase
+{
+    public function testGetJsonIncludesVersionAndQueryString()
+    {
+        $filter = Filter::equal('a', 'x');
+
+        $result = json_decode((new RuleSerializer($filter, ['a' => ['$.a']]))->getJson(), true);
+
+        $this->assertSame(RuleSerializer::VERSION, $result['version']);
+        $this->assertSame('a=x', $result['qs']);
+    }
+
+    public function testGetJsonSerializesAllChainWithOperatorAndAttributeMapping()
+    {
+        $filter = Filter::all(
+            Filter::equal('column1', 'value1'),
+            Filter::unequal('column2', 'value2'),
+            Filter::greaterThan('column3', 3),
+            Filter::lessThanOrEqual('column4', 4),
+        );
+
+        $jsonPaths = [
+            'column1' => ['$.a'],
+            'column2' => ['$.b'],
+            'column3' => ['$.c'],
+            'column4' => ['$.d'],
+        ];
+
+        $result = json_decode((new RuleSerializer($filter, $jsonPaths))->getJson(), true);
+
+        $this->assertSame('&', $result['ast']['op']);
+        $this->assertSame(
+            [
+                ['op' => '=',  'attributes' => ['$.a'], 'value' => 'value1'],
+                ['op' => '!=', 'attributes' => ['$.b'], 'value' => 'value2'],
+                ['op' => '>',  'attributes' => ['$.c'], 'value' => 3],
+                ['op' => '<=', 'attributes' => ['$.d'], 'value' => 4],
+            ],
+            $result['ast']['rules']
+        );
+    }
+
+    public function testGetJsonSerializesNoneAndAnyChainsRecursively()
+    {
+        $filter = Filter::all(
+            Filter::none(Filter::equal('a', 'x')),
+            Filter::any(
+                Filter::equal('a', 'y'),
+                Filter::equal('a', 'z')
+            ),
+        );
+
+        $result = json_decode((new RuleSerializer($filter, ['a' => ['$.a']]))->getJson(), true);
+
+        $this->assertSame('!', $result['ast']['rules'][0]['op']);
+        $this->assertSame('|', $result['ast']['rules'][1]['op']);
+        $this->assertCount(2, $result['ast']['rules'][1]['rules']);
+    }
+
+    public function testGetJsonTurnsLikeIntoRegexAndKeepsLiteralsEscaped()
+    {
+        $filter = Filter::any(
+            Filter::like('a', '*foo.bar*'),
+            Filter::unlike('a', '*bar[foo]'),
+        );
+
+        $result = json_decode((new RuleSerializer($filter, ['a' => ['$.a']]))->getJson(), true);
+
+        $this->assertArrayNotHasKey('value', $result['ast']);
+        $this->assertSame('^.*foo\\.bar.*$', $result['ast']['rules'][0]['regex']);
+        $this->assertSame('^.*bar\\[foo\\]$', $result['ast']['rules'][1]['regex']);
+    }
+
+    public function testGetJsonThrowsWhenColumnHasNoJsonPath()
+    {
+        $filter = Filter::equal('absent', 'x');
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Source hook did not provide a JSON path for column "absent"');
+
+        (new RuleSerializer($filter, []))->getJson();
+    }
+
+    public function testGetJsonReturnsNullForEmptyChain()
+    {
+        $result = (new RuleSerializer(Filter::all(), []))->getJson();
+
+        $this->assertNull($result);
+    }
+}


### PR DESCRIPTION
resolve #466 

Introduce `RuleSerializer` to create Json from a configured filter.

Introduce `Icinga\Module\Notifications\Hook\V2` which no longer requires `serializeRuleFilter()` and `getRuleFilterTargets()` as they are now obsolete.

Adjust `EventRuleController` to skip target selection use the new `RuleSerializer`.


require https://github.com/Icinga/ipl-web/pull/380
require https://github.com/Icinga/ipl-web/pull/383
require https://github.com/Icinga/ipl-stdlib/pull/75
require https://github.com/Icinga/ipl-stdlib/pull/76