### PR TITLE
Allow integrations to interact with Incidents

### DIFF
--- a/library/Notifications/Integrations/Incident.php
+++ b/library/Notifications/Integrations/Incident.php
@@ -1,0 +1,240 @@
+<?php
+
+// SPDX-FileCopyrightText: 2026 Icinga GmbH <https://icinga.com>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+namespace Icinga\Module\Notifications\Integrations;
+
+use DateTime;
+use Exception;
+use Generator;
+use Icinga\Module\Notifications\Common\Database;
+use Icinga\Module\Notifications\Model\Contact;
+use Icinga\Module\Notifications\Model\Incident as IncidentModel;
+use Icinga\Module\Notifications\Model\IncidentContact;
+use ipl\Stdlib\Filter;
+
+class Incident
+{
+    protected IncidentModel $incident;
+
+    public function __construct(IncidentModel $incident)
+    {
+        $this->incident = $incident;
+    }
+
+    /**
+     * Add the contact as manager of the incident
+     *
+     * @param Contact $contact
+     *
+     * @return $this
+     */
+    public function addManager(Contact $contact): static
+    {
+        $this->setRole($contact, 'manager');
+
+        return $this;
+    }
+
+    /**
+     * Change the contact's role from manager to subscriber
+     *
+     * This has no effect if the contact is not a manager of the incident
+     *
+     * @param Contact $contact
+     *
+     * @return $this
+     */
+    public function removeManager(Contact $contact): static
+    {
+        $existing = $this->fetchIncidentContact($contact);
+        if ($existing?->role !== 'manager') {
+            return $this;
+        }
+
+        $this->setRole($contact, 'subscriber', $existing);
+        return $this;
+    }
+
+    /**
+     * Add the contact as a subscriber
+     *
+     * This has no effect if the contact is already a subscriber or a manager
+     *
+     * @param Contact $contact
+     *
+     * @return $this
+     */
+    public function addSubscriber(Contact $contact): static
+    {
+        $existing = $this->fetchIncidentContact($contact);
+        if ($existing?->role === 'subscriber' || $existing?->role === 'manager') {
+            return $this;
+        }
+
+        $this->setRole($contact, 'subscriber', $existing);
+        return $this;
+    }
+
+    /**
+     * Remove the contact as a subscriber
+     *
+     * This will delete the incident_contact row. Has no effect if the contact is not a subscriber.
+     *
+     * @param Contact $contact
+     *
+     * @return $this
+     */
+    public function removeSubscriber(Contact $contact): static
+    {
+        $db = Database::get();
+        $existing = $this->fetchIncidentContact($contact);
+        if ($existing === null || $existing->role !== 'subscriber') {
+            return $this;
+        }
+
+        $db->beginTransaction();
+        try {
+            $db->delete('incident_contact', [
+                'incident_id = ?' => $this->incident->id,
+                'contact_id = ?'  => $contact->id,
+                'role = ?'        => 'subscriber'
+            ]);
+
+            $this->insertHistory($contact->id, 'subscriber', null);
+        } catch (Exception $e) {
+            $db->rollBackTransaction();
+            throw $e;
+        }
+
+        $db->commitTransaction();
+        return $this;
+    }
+
+    /**
+     * Get all managers of the incident
+     *
+     * @return Generator<int, IncidentContact>
+     */
+    public function getManagers(): Generator
+    {
+        yield from $this->fetchContactsByRole('manager');
+    }
+
+    /**
+     * Get all subscribers of the incident
+     *
+     * @return Generator<int, IncidentContact>
+     */
+    public function getSubscribers(): Generator
+    {
+        yield from $this->fetchContactsByRole('subscriber');
+    }
+
+    /**
+     * Get all contacts that were notified about this incident
+     *
+     * @return Generator<int, Contact>
+     */
+    public function getNotifiedContacts(): Generator
+    {
+        $query = Contact::on(Database::get())
+            ->filter(Filter::all(
+                Filter::equal('incident_history.incident_id', $this->incident->id),
+                Filter::equal('incident_history.type', 'notified')
+            ));
+        $query->getSelectBase()->distinct();
+
+        yield from $query;
+    }
+
+    public function isMuted(): bool
+    {
+        return $this->incident->mute_reason !== null;
+    }
+
+    protected function setRole(Contact $contact, string $role, ?IncidentContact $existing = null): void
+    {
+        $db = Database::get();
+        if ($existing === null) {
+            $existing = $this->fetchIncidentContact($contact);
+        }
+
+        $oldRole = $existing?->role;
+
+        if ($oldRole === $role) {
+            return;
+        }
+
+        $db->beginTransaction();
+        try {
+            if ($existing !== null) {
+                $db->update(
+                    'incident_contact',
+                    ['role' => $role],
+                    [
+                        'incident_id = ?' => $this->incident->id,
+                        'contact_id = ?'  => $contact->id
+                    ]
+                );
+            } else {
+                $db->insert('incident_contact', [
+                    'incident_id' => $this->incident->id,
+                    'contact_id'  => $contact->id,
+                    'role'        => $role
+                ]);
+            }
+
+            $this->insertHistory($contact->id, $oldRole, $role);
+        } catch (Exception $e) {
+            $db->rollBackTransaction();
+            throw $e;
+        }
+
+        $db->commitTransaction();
+    }
+
+    protected function fetchIncidentContact(Contact $contact): ?IncidentContact
+    {
+        /** @var ?IncidentContact $entry */
+        $entry = IncidentContact::on(Database::get())
+            ->filter(Filter::all(
+                Filter::equal('incident_id', $this->incident->id),
+                Filter::equal('contact_id', $contact->id)
+            ))
+            ->first();
+
+        return $entry;
+    }
+
+    /**
+     * Fetch all contacts that have the given role
+     *
+     * @return Generator<int, IncidentContact>
+     */
+    protected function fetchContactsByRole(string $role): Generator
+    {
+        yield from IncidentContact::on(Database::get())
+            ->filter(Filter::all(
+                Filter::equal('incident_id', $this->incident->id),
+                Filter::equal('role', $role)
+            ));
+    }
+
+    protected function insertHistory(int $contactId, ?string $oldRole, ?string $newRole): void
+    {
+        $now = new DateTime();
+        Database::get()->insert(
+            'incident_history',
+            [
+                'incident_id'        => $this->incident->id,
+                'contact_id'         => $contactId,
+                'type'               => 'recipient_role_changed',
+                'new_recipient_role' => $newRole,
+                'old_recipient_role' => $oldRole,
+                'time'               => (int) $now->format('Uv')
+            ]
+        );
+    }
+}

--- a/library/Notifications/Integrations/Incident.php
+++ b/library/Notifications/Integrations/Incident.php
@@ -1,0 +1,333 @@
+<?php
+
+// SPDX-FileCopyrightText: 2026 Icinga GmbH <https://icinga.com>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+namespace Icinga\Module\Notifications\Integrations;
+
+use DateTime;
+use Generator;
+use Icinga\Module\Notifications\Common\EntityManager;
+use Icinga\Module\Notifications\Model\Contact;
+use Icinga\Module\Notifications\Model\Incident as IncidentModel;
+use Icinga\Module\Notifications\Model\IncidentContact;
+use Icinga\Module\Notifications\Model\IncidentHistory;
+use InvalidArgumentException;
+use ipl\Sql\Connection;
+use ipl\Stdlib\Filter;
+
+/**
+ * Manage an incident's recipients and read its state
+ */
+class Incident
+{
+    /** @var IncidentModel The managed incident */
+    private IncidentModel $incident;
+
+    /** @var Connection The database connection to use */
+    private Connection $db;
+
+    /**
+     * Create a new wrapper for the given model
+     *
+     * @param IncidentModel $incident
+     * @param Connection $db The connection to read and persist through
+     */
+    public function __construct(IncidentModel $incident, Connection $db)
+    {
+        $this->incident = $incident;
+        $this->db = $db;
+    }
+
+    /**
+     * Add the contact with the given username as manager
+     *
+     * Has no effect if the contact is already a manager.
+     *
+     * @param string $username
+     *
+     * @return $this
+     *
+     * @throws InvalidArgumentException If no contact with that username exists
+     */
+    public function addManager(string $username): static
+    {
+        $this->assignRole($username, 'manager', ['manager']);
+
+        return $this;
+    }
+
+    /**
+     * Add the contact with the given username as subscriber
+     *
+     * Has no effect if the contact is already a subscriber or a manager.
+     *
+     * @param string $username
+     *
+     * @return $this
+     *
+     * @throws InvalidArgumentException If no contact with that username exists
+     */
+    public function addSubscriber(string $username): static
+    {
+        $this->assignRole($username, 'subscriber', ['subscriber', 'manager']);
+
+        return $this;
+    }
+
+    /**
+     * Demote the manager with the given username to subscriber
+     *
+     * Has no effect if the contact is not a manager of the incident.
+     *
+     * @param string $username
+     *
+     * @return $this
+     *
+     * @throws InvalidArgumentException If no contact with that username exists
+     */
+    public function removeManager(string $username): static
+    {
+        $this->assignRole($username, 'subscriber', [null, 'recipient', 'subscriber']);
+
+        return $this;
+    }
+
+    /**
+     * Remove the subscriber with the given username
+     *
+     * Has no effect if the contact is not a subscriber.
+     *
+     * @param string $username
+     *
+     * @return $this
+     *
+     * @throws InvalidArgumentException If no contact with that username exists
+     */
+    public function removeSubscriber(string $username): static
+    {
+        $contact = $this->getContactByName($username);
+        $existing = $this->existingContact($contact->id);
+
+        if ($existing?->role !== 'subscriber') {
+            return $this;
+        }
+
+        (new EntityManager($this->db))->save($existing->delete());
+        $this->addRoleChangedHistory($contact->id, 'subscriber', null);
+
+        return $this;
+    }
+
+    /**
+     * Yield each active subscriber of the incident
+     *
+     * @return Generator<int, array{
+     *     name: string,
+     *     full_name: string,
+     *     role: 'manager'|'subscriber',
+     *     roleChangedAt: DateTime}>
+     */
+    public function getSubscribers(): Generator
+    {
+        foreach ($this->resolveRecipients(['manager', 'subscriber']) as $recipient) {
+            yield [
+                'name'          => $recipient['name'],
+                'full_name'     => $recipient['full_name'],
+                'role'          => $recipient['role'],
+                'roleChangedAt' => $recipient['roleChangedAt'],
+            ];
+        }
+    }
+
+    /**
+     * Yield each configured recipient of the incident
+     *
+     * @return Generator<int, array{
+     *     type: 'contact'|'contactgroup'|'schedule',
+     *     name: string,
+     *     full_name: ?string,
+     *     roleChangedAt: DateTime}>
+     */
+    public function getRecipients(): Generator
+    {
+        foreach ($this->resolveRecipients(['recipient']) as $recipient) {
+            yield [
+                'type'          => $recipient['type'],
+                'name'          => $recipient['name'],
+                'full_name'     => $recipient['full_name'],
+                'roleChangedAt' => $recipient['roleChangedAt']
+            ];
+        }
+    }
+
+    /**
+     * Get whether the incident is muted
+     *
+     * @return bool
+     */
+    public function isMuted(): bool
+    {
+        return $this->incident->mute_reason !== null;
+    }
+
+    /**
+     * Load the contact with the given username
+     *
+     * @param string $username
+     *
+     * @return Contact
+     */
+    private function getContactByName(string $username): Contact
+    {
+        /** @var ?Contact $contact */
+        $contact = Contact::on($this->db)->filter(Filter::equal('username', $username))->first();
+
+        if ($contact === null) {
+            throw new InvalidArgumentException(sprintf('There is no contact with the username "%s"', $username));
+        }
+
+        return $contact;
+    }
+
+    /**
+     * Load the incident's `incident_contact` entry for the given contact id
+     *
+     * @param int $contactId
+     *
+     * @return ?IncidentContact
+     */
+    private function existingContact(int $contactId): ?IncidentContact
+    {
+        /** @var ?IncidentContact $entry */
+        $entry = IncidentContact::on($this->db)
+            ->filter(Filter::all(
+                Filter::equal('incident_id', $this->incident->id),
+                Filter::equal('contact_id', $contactId)
+            ))
+            ->first()
+            ?->setNew(false);
+
+        return $entry;
+    }
+
+    /**
+     * Resolve the incident's recipients who match any of the given roles
+     *
+     * @param string[] $roles
+     *
+     * @return list<array{
+     *     type: 'contact'|'contactgroup'|'schedule',
+     *     id: int,
+     *     name: string,
+     *     full_name: ?string,
+     *     role: 'manager'|'subscriber'|'recipient',
+     *     roleChangedAt: DateTime
+     * }>
+     */
+    private function resolveRecipients(array $roles): array
+    {
+        $entries = IncidentContact::on($this->db)
+            ->with(['contact', 'contactgroup', 'schedule'])
+            ->filter(
+                Filter::all(
+                    Filter::equal('incident_id', $this->incident->id),
+                    Filter::equal('role', $roles),
+                    Filter::unequal('contact.deleted', true),
+                    Filter::unequal('contactgroup.deleted', true),
+                    Filter::unequal('schedule.deleted', true),
+                )
+            );
+
+        $recipients = [];
+        foreach ($entries as $entry) {
+            if ($entry->contact_id !== null) {
+                $recipients[] = [
+                    'type'      => 'contact',
+                    'id'        => $entry->contact_id,
+                    'name'      => $entry->contact->username,
+                    'full_name' => $entry->contact->full_name,
+                    'role'      => $entry->role,
+                    'roleChangedAt' => $entry->changed_at
+                ];
+            } elseif ($entry->contactgroup_id !== null) {
+                $recipients[] = [
+                    'type'      => 'contactgroup',
+                    'id'        => $entry->contactgroup_id,
+                    'name'      => $entry->contactgroup->name,
+                    'full_name' => null,
+                    'role'      => $entry->role,
+                    'roleChangedAt' => $entry->changed_at
+                ];
+            } elseif ($entry->schedule_id !== null) {
+                $recipients[] = [
+                    'type'      => 'schedule',
+                    'id'        => $entry->schedule_id,
+                    'name'      => $entry->schedule->name,
+                    'full_name' => null,
+                    'role'      => $entry->role,
+                    'roleChangedAt' => $entry->changed_at
+                ];
+            }
+        }
+
+        return $recipients;
+    }
+
+    /**
+     * Set the contact's role, appending a new `incident_contact` entry if it has none yet
+     *
+     * @param string $username
+     * @param string $role The role to assign
+     * @param array<?string> $noopRoles Existing roles for which this is a no-op, `null` matches an absent contact
+     *
+     * @return $this
+     */
+    private function assignRole(string $username, string $role, array $noopRoles): static
+    {
+        $contact = $this->getContactByName($username);
+        $existing = $this->existingContact($contact->id);
+
+        if (in_array($existing?->role, $noopRoles, true)) {
+            return $this;
+        }
+
+        $oldRole = $existing?->role;
+
+        if ($existing !== null) {
+            $existing->role = $role;
+            (new EntityManager($this->db))->save($existing);
+        } else {
+            $incidentContact = (new IncidentContact())->setNew();
+            $incidentContact->incident_id = $this->incident->id;
+            $incidentContact->contact_id = $contact->id;
+            $incidentContact->role = $role;
+            (new EntityManager($this->db))->save($incidentContact);
+        }
+
+        $this->addRoleChangedHistory($contact->id, $oldRole, $role);
+
+        return $this;
+    }
+
+    /**
+     * Persist a `recipient_role_changed` history entry for the incident
+     *
+     * @param int $contactId
+     * @param ?string $oldRole
+     * @param ?string $newRole
+     *
+     * @return void
+     */
+    private function addRoleChangedHistory(int $contactId, ?string $oldRole, ?string $newRole): void
+    {
+        $history = (new IncidentHistory())->setNew();
+        $history->incident_id = $this->incident->id;
+        $history->contact_id = $contactId;
+        $history->type = 'recipient_role_changed';
+        $history->old_recipient_role = $oldRole;
+        $history->new_recipient_role = $newRole;
+        $history->time = new DateTime();
+        (new EntityManager($this->db))->save($history);
+    }
+}

--- a/library/Notifications/Integrations/Incidents.php
+++ b/library/Notifications/Integrations/Incidents.php
@@ -1,0 +1,97 @@
+<?php
+
+// SPDX-FileCopyrightText: 2026 Icinga GmbH <https://icinga.com>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+namespace Icinga\Module\Notifications\Integrations;
+
+use Generator;
+use Icinga\Module\Notifications\Common\Database;
+use Icinga\Module\Notifications\Model\Incident as IncidentModel;
+use InvalidArgumentException;
+use ipl\Orm\Query;
+use ipl\Orm\ResultSet;
+use ipl\Stdlib\Filter;
+use IteratorAggregate;
+
+class Incidents implements IteratorAggregate
+{
+    /** @var string Hex-encoded SHA256 hash of the identifying source/tags */
+    protected string $objectId;
+
+    protected ?ResultSet $resultSet = null;
+
+    /**
+     * Create new Incidents
+     *
+     * @param int $sourceId The id of the source that owns the object
+     * @param array<string, string> $tags The complete identifying tags of the object
+     */
+    public function __construct(int $sourceId, array $tags)
+    {
+        $this->objectId = self::objectId($sourceId, $tags);
+    }
+
+    public function hasIncident(): bool
+    {
+        return $this->incidents()->hasResult();
+    }
+
+    /**
+     * @return Generator<int, Incident>
+     */
+    public function getIterator(): Generator
+    {
+        foreach ($this->incidents() as $incident) {
+            yield new Incident($incident);
+        }
+    }
+
+    protected function incidents(): ResultSet
+    {
+        if ($this->resultSet === null) {
+            $this->resultSet = $this->buildQuery()->execute();
+        }
+
+        return $this->resultSet;
+    }
+
+    protected function buildQuery(): Query
+    {
+        return IncidentModel::on(Database::get())
+            ->with('object')
+            ->filter(Filter::equal('object_id', $this->objectId));
+    }
+
+    /**
+     * Compute the object id for a given source and tags
+     *
+     * Mirrors the daemon's ID function in icinga-notifications/internal/object/object.go so the
+     * resulting hash matches the value stored in object.id.
+     *
+     * @param int $sourceId
+     * @param array<string, string> $tags
+     *
+     * @return string
+     */
+    public static function objectId(int $sourceId, array $tags): string
+    {
+        if ($sourceId < 0) {
+            throw new InvalidArgumentException(sprintf('source id %d is negative', $sourceId));
+        }
+
+        $payload = pack('J', $sourceId);
+
+        ksort($tags);
+
+        // A minor bug in the daemon adds these bytes, but fixing it would break all existing object_id's
+        // so we reproduce it here. See: https://github.com/Icinga/icinga-notifications/issues/421
+        $payload .= str_repeat("\0\0", count($tags));
+
+        foreach ($tags as $key => $value) {
+            $payload .= $key . "\0" . $value . "\0";
+        }
+
+        return hash('sha256', $payload);
+    }
+}

--- a/library/Notifications/Integrations/Incidents.php
+++ b/library/Notifications/Integrations/Incidents.php
@@ -1,0 +1,111 @@
+<?php
+
+// SPDX-FileCopyrightText: 2026 Icinga GmbH <https://icinga.com>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+namespace Icinga\Module\Notifications\Integrations;
+
+use Countable;
+use Generator;
+use Icinga\Module\Notifications\Common\Database;
+use Icinga\Module\Notifications\Model\Incident as IncidentModel;
+use ipl\Orm\Query;
+use ipl\Orm\ResultSet;
+use ipl\Sql\Connection;
+use ipl\Stdlib\Filter;
+use IteratorAggregate;
+
+class Incidents implements IteratorAggregate, Countable
+{
+    /** @var array<string, ?string> Required tags keyed by name; a null value requires the tag's absence */
+    protected array $tags;
+
+    /** @var Connection The database connection to read from */
+    protected Connection $db;
+
+    /** @var ?ResultSet The executed query result */
+    private ?ResultSet $results = null;
+
+    /**
+     * Create new Incidents
+     *
+     * Matches the incidents of every object that carries each tag given with a value and lacks each tag
+     * given as null. Tags not listed are unconstrained. Matching is performed by tag alone, independent of the source.
+     *
+     * Examples:
+     *   ['host' => 'icinga2']                     — host icinga2 and all of its services
+     *   ['host' => 'icinga2', 'service' => 'ssh'] — only the ssh service on icinga2
+     *   ['host' => 'icinga2', 'service' => null]  — only the host icinga2, none of its services
+     *
+     * @param array<string, ?string> $tags Required tags keyed by name, a null value requires the tag's absence
+     * @param Connection $db The database connection to read from
+     */
+    public function __construct(array $tags, Connection $db)
+    {
+        $this->tags = $tags;
+        $this->db = $db;
+    }
+
+    /**
+     * Create new Incidents for the given tags, reading through the default database connection
+     *
+     * @param array<string, ?string> $tags Required tags keyed by name, a null value requires the tag's absence
+     *
+     * @return static
+     */
+    public static function find(array $tags): static
+    {
+        return new static($tags, Database::get());
+    }
+
+    /**
+     * Get whether the object has at least one incident
+     *
+     * @return bool
+     */
+    public function hasIncident(): bool
+    {
+        return $this->incidents()->hasResult();
+    }
+
+    /**
+     * Yield an interaction wrapper for each of the object's incidents
+     *
+     * @return Generator<Incident>
+     */
+    public function getIterator(): Generator
+    {
+        foreach ($this->incidents() as $incident) {
+            yield new Incident($incident, $this->db);
+        }
+    }
+
+    public function count(): int
+    {
+        return $this->buildQuery()->count();
+    }
+
+    private function incidents(): ResultSet
+    {
+        if ($this->results === null) {
+            $this->results = $this->buildQuery()->execute();
+        }
+
+        return $this->results;
+    }
+
+    private function buildQuery(): Query
+    {
+        $query = IncidentModel::on($this->db)->filter(Filter::unlike('recovered_at', '*'));
+
+        foreach ($this->tags as $tag => $value) {
+            if ($value === null) {
+                $query->filter(Filter::unlike("incident.object.tag.$tag", '*'));
+            } else {
+                $query->filter(Filter::equal("incident.object.tag.$tag", $value));
+            }
+        }
+
+        return $query;
+    }
+}

--- a/library/Notifications/Model/IncidentContact.php
+++ b/library/Notifications/Model/IncidentContact.php
@@ -5,17 +5,25 @@
 
 namespace Icinga\Module\Notifications\Model;
 
+use DateTime;
 use Icinga\Module\Notifications\Common\Model;
+use ipl\Orm\Behavior\MillisecondTimestamp;
+use ipl\Orm\Behaviors;
 use ipl\Orm\Query;
 use ipl\Orm\Relations;
 
 /**
  * @property int $incident_id
  * @property ?int $contact_id
+ * @property ?int $contactgroup_id
+ * @property ?int $schedule_id
  * @property string $role
+ * @property DateTime $changed_at
  *
  * @property Query|Incident $incident
  * @property Query|Contact $contact
+ * @property Query|Contactgroup $contactgroup
+ * @property Query|Schedule $schedule
  */
 class IncidentContact extends Model
 {
@@ -34,22 +42,38 @@ class IncidentContact extends Model
         return [
             'incident_id',
             'contact_id',
-            'role'
+            'contactgroup_id',
+            'schedule_id',
+            'role',
+            'changed_at',
         ];
     }
 
     public function getColumnDefinitions(): array
     {
         return [
-            'incident_id'   => t('Incident Id'),
-            'contact_id'    => t('Contact Id'),
-            'role'          => t('Role')
+            'incident_id'     => t('Incident Id'),
+            'contact_id'      => t('Contact Id'),
+            'contactgroup_id' => t('Contact Group Id'),
+            'schedule_id'     => t('Schedule Id'),
+            'role'            => t('Role'),
+            'changed_at'      => t('Changed At'),
         ];
+    }
+
+    public function createBehaviors(Behaviors $behaviors): void
+    {
+        $behaviors->add(new MillisecondTimestamp(['changed_at']));
     }
 
     public function createRelations(Relations $relations): void
     {
         $relations->belongsTo('incident', Incident::class);
-        $relations->belongsTo('contact', Contact::class);
+        $relations->belongsTo('contact', Contact::class)
+            ->setJoinType('LEFT');
+        $relations->belongsTo('contactgroup', Contactgroup::class)
+            ->setJoinType('LEFT');
+        $relations->belongsTo('schedule', Schedule::class)
+            ->setJoinType('LEFT');
     }
 }

--- a/test/php/library/Notifications/Integrations/IncidentTest.php
+++ b/test/php/library/Notifications/Integrations/IncidentTest.php
@@ -1,0 +1,622 @@
+<?php
+
+// SPDX-FileCopyrightText: 2026 Icinga GmbH <https://icinga.com>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+namespace Tests\Icinga\Module\Notifications\Integrations;
+
+use DateTime;
+use Icinga\Module\Notifications\Integrations\Incident;
+use Icinga\Module\Notifications\Model\Incident as IncidentModel;
+use InvalidArgumentException;
+use ipl\Stdlib\Filter;
+use PDO;
+use PHPUnit\Framework\TestCase;
+use Tests\Icinga\Module\Notifications\Lib\EntityManager\RecordingConnection;
+
+/**
+ * Contract of the integration-facing {@see Incident}: it is identified by usernames (never Contact
+ * instances), and every write operation persists immediately, so the change is in the database the
+ * moment the call returns.
+ *
+ * Its two recipient readers split the incident's `incident_contact` rows by role: {@see Incident::getSubscribers()}
+ * yields the active subscribers (roles `manager` and `subscriber`), {@see Incident::getRecipients()} the
+ * configured recipients (role `recipient`). Both are polymorphic — a recipient may be a contact, contact
+ * group or schedule — and yield a uniform shape carrying a `type` discriminator, the display `name` and a
+ * nullable `full_name`. Subscribers additionally carry their `role` and the `roleChangedAt` time their
+ * current role was last changed; deleted contact groups and schedules are omitted from both.
+ */
+class IncidentTest extends TestCase
+{
+    /** @var int Millisecond timestamp seeded into `incident_contact.changed_at` when a test does not care about it */
+    private const SEEDED_CHANGED_AT = 1700000000000;
+
+    private RecordingConnection $db;
+
+    /**
+     * Set up an in-memory SQLite database with the tables these operations touch. The integration
+     * under test reads usernames and persists through the connection it is handed, so no global state
+     * is involved.
+     */
+    protected function setUp(): void
+    {
+        $this->db = new RecordingConnection(['db' => 'sqlite', 'dbname' => ':memory:']);
+        $this->db->exec(
+            'CREATE TABLE incident (id INTEGER PRIMARY KEY AUTOINCREMENT,'
+            . ' object_id BLOB, started_at INTEGER, recovered_at INTEGER, severity VARCHAR, mute_reason VARCHAR);'
+            . 'CREATE TABLE contact (id INTEGER PRIMARY KEY AUTOINCREMENT, full_name VARCHAR, username VARCHAR,'
+            . ' default_channel_id INTEGER, changed_at INTEGER, deleted VARCHAR, external_uuid VARCHAR);'
+            . 'CREATE TABLE contactgroup (id INTEGER PRIMARY KEY AUTOINCREMENT, name VARCHAR, changed_at INTEGER,'
+            . ' deleted VARCHAR, external_uuid VARCHAR);'
+            . 'CREATE TABLE schedule (id INTEGER PRIMARY KEY AUTOINCREMENT, name VARCHAR, changed_at INTEGER,'
+            . ' timezone VARCHAR, deleted VARCHAR);'
+            . 'CREATE TABLE incident_contact (incident_id INTEGER NOT NULL, contact_id INTEGER,'
+            . ' contactgroup_id INTEGER, schedule_id INTEGER, role VARCHAR, changed_at INTEGER);'
+            . 'CREATE TABLE incident_history (id INTEGER PRIMARY KEY AUTOINCREMENT, incident_id INTEGER NOT NULL,'
+            . ' rule_id INTEGER, rule_escalation_id INTEGER, time INTEGER, type VARCHAR, contact_id INTEGER,'
+            . ' schedule_id INTEGER, contactgroup_id INTEGER, channel_id INTEGER, new_severity VARCHAR,'
+            . ' old_severity VARCHAR, new_recipient_role VARCHAR, old_recipient_role VARCHAR, message VARCHAR,'
+            . ' notification_state VARCHAR, sent_at INTEGER);'
+        );
+    }
+
+    public function testAddManagerAddsTheContactAsManagerByUsername(): void
+    {
+        $id = $this->seedIncident();
+        $this->seedContact('uname');
+
+        $incident = $this->incident($id);
+        $incident->addManager('uname');
+
+        $this->assertSame(
+            [['name' => 'uname', 'full_name' => 'Uname Example', 'role' => 'manager']],
+            $this->withoutRoleChangedAt($incident->getSubscribers())
+        );
+        $this->assertSame(
+            [['username' => 'uname', 'role' => 'manager']],
+            $this->storedContactRoles(),
+            'addManager() persists immediately'
+        );
+    }
+
+    public function testAddManagerThrowsForAnUnknownUsername(): void
+    {
+        $id = $this->seedIncident();
+
+        $this->expectException(InvalidArgumentException::class);
+
+        $this->incident($id)->addManager('ghost');
+    }
+
+    public function testRemoveManagerDemotesTheManagerToSubscriber(): void
+    {
+        $id = $this->seedIncident();
+        $contactId = $this->seedContact('uname');
+        $this->seedIncidentContact($id, $contactId, 'manager');
+
+        $incident = $this->incident($id);
+        $incident->removeManager('uname');
+
+        $this->assertSame(
+            [['name' => 'uname', 'full_name' => 'Uname Example', 'role' => 'subscriber']],
+            $this->withoutRoleChangedAt($incident->getSubscribers())
+        );
+        $this->assertSame(
+            [['username' => 'uname', 'role' => 'subscriber']],
+            $this->storedContactRoles(),
+            'removeManager() persists the demotion immediately'
+        );
+    }
+
+    public function testAddSubscriberAddsTheContactAsSubscriberByUsername(): void
+    {
+        $id = $this->seedIncident();
+        $this->seedContact('uname');
+
+        $incident = $this->incident($id);
+        $incident->addSubscriber('uname');
+
+        $this->assertSame(
+            [['name' => 'uname', 'full_name' => 'Uname Example', 'role' => 'subscriber']],
+            $this->withoutRoleChangedAt($incident->getSubscribers())
+        );
+        $this->assertSame(
+            [['username' => 'uname', 'role' => 'subscriber']],
+            $this->storedContactRoles(),
+            'addSubscriber() persists immediately'
+        );
+    }
+
+    public function testRemoveSubscriberDeletesTheSubscriberEntry(): void
+    {
+        $id = $this->seedIncident();
+        $contactId = $this->seedContact('uname');
+        $this->seedIncidentContact($id, $contactId, 'subscriber');
+
+        $incident = $this->incident($id);
+        $incident->removeSubscriber('uname');
+
+        $this->assertSame([], iterator_to_array($incident->getSubscribers(), false));
+        $this->assertSame(
+            [],
+            $this->storedContactRoles(),
+            'removeSubscriber() deletes the entry immediately'
+        );
+    }
+
+    public function testGetSubscribersExcludesConfiguredRecipients(): void
+    {
+        $id = $this->seedIncident();
+        $this->seedIncidentContact($id, $this->seedContact('alice'), 'manager');
+        $this->seedIncidentContact($id, $this->seedContact('bob'), 'recipient');
+
+        $this->assertSame(
+            [['name' => 'alice', 'full_name' => 'Alice Example', 'role' => 'manager']],
+            $this->withoutRoleChangedAt($this->incident($id)->getSubscribers())
+        );
+    }
+
+    public function testGetSubscribersIgnoresRowsWithoutARecipientReference(): void
+    {
+        $id = $this->seedIncident();
+        $this->seedIncidentContact($id, $this->seedContact('alice'), 'manager');
+        // Neither contact, contact group nor schedule is referenced; such a row yields nothing.
+        $this->seedIncidentContact($id, null, 'subscriber');
+
+        $this->assertSame(
+            [['name' => 'alice', 'full_name' => 'Alice Example', 'role' => 'manager']],
+            $this->withoutRoleChangedAt($this->incident($id)->getSubscribers())
+        );
+    }
+
+    public function testGetSubscribersOmitsDeletedRecipients(): void
+    {
+        $id = $this->seedIncident();
+        $this->seedIncidentContact($id, $this->seedContact('alice'), 'subscriber');
+        $this->seedIncidentContact($id, $this->seedContact('gone-contact', deleted: true), 'subscriber');
+        $this->seedIncidentContact(
+            $id,
+            null,
+            'subscriber',
+            contactgroupId: $this->seedContactgroup('gone-group', deleted: true)
+        );
+        $this->seedIncidentContact(
+            $id,
+            null,
+            'subscriber',
+            scheduleId: $this->seedSchedule('gone-schedule', deleted: true)
+        );
+
+        $this->assertSame(
+            [['name' => 'alice', 'full_name' => 'Alice Example', 'role' => 'subscriber']],
+            $this->withoutRoleChangedAt($this->incident($id)->getSubscribers())
+        );
+    }
+
+    public function testGetSubscribersResolvesRoleChangedAtFromTheContactsChangedAt(): void
+    {
+        $id = $this->seedIncident();
+        $alice = $this->seedContact('alice');
+        $this->seedIncidentContact($id, $alice, 'manager', changedAt: 1700000000000);
+
+        $subscribers = iterator_to_array($this->incident($id)->getSubscribers(), false);
+
+        $this->assertCount(1, $subscribers);
+        $this->assertInstanceOf(DateTime::class, $subscribers[0]['roleChangedAt']);
+        $this->assertSame(1700000000, $subscribers[0]['roleChangedAt']->getTimestamp());
+
+        unset($subscribers[0]['roleChangedAt']);
+        $this->assertSame(
+            ['name' => 'alice', 'full_name' => 'Alice Example', 'role' => 'manager'],
+            $subscribers[0],
+            'Apart from roleChangedAt the entry carries the uniform recipient shape'
+        );
+    }
+
+    public function testGetRecipientsYieldsConfiguredRecipientsOfEachType(): void
+    {
+        $id = $this->seedIncident();
+        $this->seedIncidentContact($id, $this->seedContact('alice'), 'recipient');
+        $this->seedIncidentContact($id, null, 'recipient', contactgroupId: $this->seedContactgroup('windows-admins'));
+        $this->seedIncidentContact($id, null, 'recipient', scheduleId: $this->seedSchedule('On-Call'));
+
+        $this->assertSame(
+            [
+                ['type' => 'contact', 'name' => 'alice', 'full_name' => 'Alice Example'],
+                ['type' => 'contactgroup', 'name' => 'windows-admins', 'full_name' => null],
+                ['type' => 'schedule', 'name' => 'On-Call', 'full_name' => null],
+            ],
+            $this->withoutRoleChangedAt($this->sortedByTypeAndName($this->incident($id)->getRecipients()))
+        );
+    }
+
+    public function testGetRecipientsExcludesActiveSubscribers(): void
+    {
+        $id = $this->seedIncident();
+        $this->seedIncidentContact($id, $this->seedContact('alice'), 'manager');
+        $this->seedIncidentContact($id, $this->seedContact('bob'), 'subscriber');
+        $this->seedIncidentContact($id, $this->seedContact('carol'), 'recipient');
+
+        $this->assertSame(
+            [['type' => 'contact', 'name' => 'carol', 'full_name' => 'Carol Example']],
+            $this->withoutRoleChangedAt($this->incident($id)->getRecipients())
+        );
+    }
+
+    public function testGetRecipientsOmitsDeletedRecipients(): void
+    {
+        $id = $this->seedIncident();
+        $this->seedIncidentContact($id, $this->seedContact('alice'), 'recipient');
+        $this->seedIncidentContact($id, $this->seedContact('gone-contact', deleted: true), 'recipient');
+        $this->seedIncidentContact(
+            $id,
+            null,
+            'recipient',
+            contactgroupId: $this->seedContactgroup('gone-group', deleted: true)
+        );
+        $this->seedIncidentContact(
+            $id,
+            null,
+            'recipient',
+            scheduleId: $this->seedSchedule('gone-schedule', deleted: true)
+        );
+
+        $this->assertSame(
+            [['type' => 'contact', 'name' => 'alice', 'full_name' => 'Alice Example']],
+            $this->withoutRoleChangedAt($this->incident($id)->getRecipients())
+        );
+    }
+
+    public function testIsMutedReflectsTheMuteReason(): void
+    {
+        $muted = $this->seedIncident('down for maintenance');
+        $notMuted = $this->seedIncident();
+
+        $this->assertTrue($this->incident($muted)->isMuted());
+        $this->assertFalse($this->incident($notMuted)->isMuted());
+    }
+
+    public function testAddManagerWritesRoleChangedHistory(): void
+    {
+        $id = $this->seedIncident();
+        $this->seedContact('uname');
+
+        $this->incident($id)->addManager('uname');
+
+        $this->assertSame(
+            [['username' => 'uname', 'old_role' => null, 'new_role' => 'manager']],
+            $this->storedRoleHistory()
+        );
+    }
+
+    public function testRemoveManagerWritesRoleChangedHistory(): void
+    {
+        $id = $this->seedIncident();
+        $this->seedIncidentContact($id, $this->seedContact('uname'), 'manager');
+
+        $this->incident($id)->removeManager('uname');
+
+        $this->assertSame(
+            [['username' => 'uname', 'old_role' => 'manager', 'new_role' => 'subscriber']],
+            $this->storedRoleHistory()
+        );
+    }
+
+    public function testAddSubscriberWritesRoleChangedHistory(): void
+    {
+        $id = $this->seedIncident();
+        $this->seedContact('uname');
+
+        $this->incident($id)->addSubscriber('uname');
+
+        $this->assertSame(
+            [['username' => 'uname', 'old_role' => null, 'new_role' => 'subscriber']],
+            $this->storedRoleHistory()
+        );
+    }
+
+    public function testRemoveSubscriberWritesRoleChangedHistory(): void
+    {
+        $id = $this->seedIncident();
+        $this->seedIncidentContact($id, $this->seedContact('uname'), 'subscriber');
+
+        $this->incident($id)->removeSubscriber('uname');
+
+        $this->assertSame(
+            [['username' => 'uname', 'old_role' => 'subscriber', 'new_role' => null]],
+            $this->storedRoleHistory()
+        );
+    }
+
+    public function testChainedRoleChangesEachWriteAHistoryRow(): void
+    {
+        $id = $this->seedIncident();
+        $this->seedContact('alice');
+        $this->seedContact('bob');
+
+        $this->incident($id)
+            ->addManager('alice')
+            ->addSubscriber('bob');
+
+        $this->assertSame(
+            [
+                ['username' => 'alice', 'old_role' => null, 'new_role' => 'manager'],
+                ['username' => 'bob', 'old_role' => null, 'new_role' => 'subscriber'],
+            ],
+            $this->storedRoleHistory()
+        );
+    }
+
+    public function testASecondWriteDoesNotDuplicateHistoryFromAnEarlierWrite(): void
+    {
+        $id = $this->seedIncident();
+        $this->seedContact('alice');
+        $this->seedContact('bob');
+
+        $incident = $this->incident($id);
+        $incident->addManager('alice');
+        $incident->addSubscriber('bob');
+
+        $this->assertSame(
+            [
+                ['username' => 'alice', 'old_role' => null, 'new_role' => 'manager'],
+                ['username' => 'bob', 'old_role' => null, 'new_role' => 'subscriber'],
+            ],
+            $this->storedRoleHistory()
+        );
+    }
+
+    public function testAddSubscriberDoesNotDemoteAnExistingManager(): void
+    {
+        $id = $this->seedIncident();
+        $this->seedIncidentContact($id, $this->seedContact('uname'), 'manager');
+
+        $this->incident($id)->addSubscriber('uname');
+
+        $this->assertSame([['username' => 'uname', 'role' => 'manager']], $this->storedContactRoles());
+        $this->assertSame([], $this->storedRoleHistory());
+    }
+
+    public function testAddManagerPromotesAnExistingSubscriberInPlace(): void
+    {
+        $id = $this->seedIncident();
+        $this->seedIncidentContact($id, $this->seedContact('uname'), 'subscriber');
+
+        $this->incident($id)->addManager('uname');
+
+        $this->assertSame([['username' => 'uname', 'role' => 'manager']], $this->storedContactRoles());
+        $this->assertSame(
+            [['username' => 'uname', 'old_role' => 'subscriber', 'new_role' => 'manager']],
+            $this->storedRoleHistory()
+        );
+    }
+
+    public function testAddManagerOnAnExistingManagerIsANoop(): void
+    {
+        $id = $this->seedIncident();
+        $this->seedIncidentContact($id, $this->seedContact('uname'), 'manager');
+
+        $this->incident($id)->addManager('uname');
+
+        $this->assertSame([['username' => 'uname', 'role' => 'manager']], $this->storedContactRoles());
+        $this->assertSame([], $this->storedRoleHistory(), 'A no-op records no role change');
+    }
+
+    public function testAddSubscriberOnAnExistingSubscriberIsANoop(): void
+    {
+        $id = $this->seedIncident();
+        $this->seedIncidentContact($id, $this->seedContact('uname'), 'subscriber');
+
+        $this->incident($id)->addSubscriber('uname');
+
+        $this->assertSame([['username' => 'uname', 'role' => 'subscriber']], $this->storedContactRoles());
+        $this->assertSame([], $this->storedRoleHistory(), 'A no-op records no role change');
+    }
+
+    public function testRemoveManagerOfANonManagerIsANoop(): void
+    {
+        $id = $this->seedIncident();
+        $this->seedIncidentContact($id, $this->seedContact('uname'), 'subscriber');
+
+        $this->incident($id)->removeManager('uname');
+
+        // A subscriber must not be demoted by removeManager, and no history is written.
+        $this->assertSame([['username' => 'uname', 'role' => 'subscriber']], $this->storedContactRoles());
+        $this->assertSame([], $this->storedRoleHistory());
+    }
+
+    public function testRemoveManagerWithoutAnEntryIsANoop(): void
+    {
+        $id = $this->seedIncident();
+        $this->seedContact('uname');
+
+        $this->incident($id)->removeManager('uname');
+
+        $this->assertSame([], $this->storedContactRoles());
+        $this->assertSame([], $this->storedRoleHistory());
+    }
+
+    public function testRemoveSubscriberOfANonSubscriberIsANoop(): void
+    {
+        $id = $this->seedIncident();
+        $this->seedIncidentContact($id, $this->seedContact('uname'), 'manager');
+
+        $this->incident($id)->removeSubscriber('uname');
+
+        // A manager entry must not be deleted by removeSubscriber.
+        $this->assertSame([['username' => 'uname', 'role' => 'manager']], $this->storedContactRoles());
+        $this->assertSame([], $this->storedRoleHistory());
+    }
+
+    public function testRemoveSubscriberWithoutAnEntryIsANoop(): void
+    {
+        $id = $this->seedIncident();
+        $this->seedContact('uname');
+
+        $this->incident($id)->removeSubscriber('uname');
+
+        $this->assertSame([], $this->storedContactRoles());
+        $this->assertSame([], $this->storedRoleHistory());
+    }
+
+    /**
+     * Insert an incident and return its generated id.
+     */
+    private function seedIncident(?string $muteReason = null): int
+    {
+        $this->db->insert('incident', ['severity' => 'crit', 'mute_reason' => $muteReason]);
+
+        return (int) $this->db->lastInsertId();
+    }
+
+    /**
+     * Insert a contact with the given username and return its generated id.
+     *
+     * The full name defaults to a distinct value derived from the username (e.g. "Alice Example" for
+     * "alice"), so the readers' username/full_name pairing can be asserted unambiguously.
+     */
+    private function seedContact(string $username, bool $deleted = false): int
+    {
+        $fullName = ucfirst($username) . ' Example';
+
+        $this->db->insert(
+            'contact',
+            ['full_name' => $fullName, 'username' => $username, 'deleted' => $deleted ? 'y' : 'n']
+        );
+
+        return (int) $this->db->lastInsertId();
+    }
+
+    /**
+     * Insert a contact group with the given name and return its generated id.
+     */
+    private function seedContactgroup(string $name, bool $deleted = false): int
+    {
+        $this->db->insert('contactgroup', ['name' => $name, 'deleted' => $deleted ? 'y' : 'n']);
+
+        return (int) $this->db->lastInsertId();
+    }
+
+    /**
+     * Insert a schedule with the given name and return its generated id.
+     */
+    private function seedSchedule(string $name, bool $deleted = false): int
+    {
+        $this->db->insert('schedule', ['name' => $name, 'deleted' => $deleted ? 'y' : 'n']);
+
+        return (int) $this->db->lastInsertId();
+    }
+
+    /**
+     * Insert an `incident_contact` row referencing exactly one recipient.
+     *
+     * Exactly one of $contactId, $contactgroupId or $scheduleId is expected to be set; the others stay
+     * null, mirroring the polymorphic recipient key the daemon writes.
+     */
+    private function seedIncidentContact(
+        int $incidentId,
+        ?int $contactId,
+        string $role,
+        ?int $contactgroupId = null,
+        ?int $scheduleId = null,
+        int $changedAt = self::SEEDED_CHANGED_AT
+    ): void {
+        $this->db->insert(
+            'incident_contact',
+            [
+                'incident_id'     => $incidentId,
+                'contact_id'      => $contactId,
+                'contactgroup_id' => $contactgroupId,
+                'schedule_id'     => $scheduleId,
+                'role'            => $role,
+                'changed_at'      => $changedAt
+            ]
+        );
+    }
+
+    /**
+     * Wrap the seeded incident in the integration object under test.
+     *
+     * @param int $id
+     */
+    private function incident(int $id): Incident
+    {
+        /** @var IncidentModel $model */
+        $model = IncidentModel::on($this->db)
+            ->filter(Filter::equal('id', $id))
+            ->first();
+
+        return new Incident($model, $this->db);
+    }
+
+    /**
+     * Collect the given recipients into a list ordered by type and name.
+     *
+     * The readers do not guarantee an order, so tests asserting more than one recipient normalise it here
+     * instead of relying on the database's row order.
+     *
+     * @param iterable<array{type?: string, name: string}> $recipients
+     *
+     * @return list<array<string, mixed>>
+     */
+    private function sortedByTypeAndName(iterable $recipients): array
+    {
+        $list = iterator_to_array($recipients, false);
+        usort($list, fn(array $a, array $b): int => [$a['type'] ?? '', $a['name']] <=> [$b['type'] ?? '', $b['name']]);
+
+        return $list;
+    }
+
+    /**
+     * Collect the given recipients into a list with the `roleChangedAt` timestamp dropped.
+     *
+     * The timestamp cannot be asserted verbatim — a write stamps the role change with the current time, and a
+     * seeded one yields a {@see DateTime} that is never `assertSame`-equal — so tests not focused on it drop it
+     * here. Its contract is covered by the dedicated test that seeds a known time.
+     *
+     * @param iterable<array<string, mixed>> $recipients
+     *
+     * @return list<array<string, mixed>>
+     */
+    private function withoutRoleChangedAt(iterable $recipients): array
+    {
+        return array_map(
+            function (array $entry): array {
+                $this->assertArrayHasKey('roleChangedAt', $entry);
+                $this->assertInstanceOf(DateTime::class, $entry['roleChangedAt']);
+                unset($entry['roleChangedAt']);
+
+                return $entry;
+            },
+            iterator_to_array($recipients, false)
+        );
+    }
+
+    /**
+     * Read the stored contact roles as `[['username' => ..., 'role' => ...], ...]`, ordered by username.
+     *
+     * @return list<array<string, mixed>>
+     */
+    private function storedContactRoles(): array
+    {
+        return $this->db->prepexec(
+            'SELECT c.username, ic.role FROM incident_contact ic'
+            . ' JOIN contact c ON c.id = ic.contact_id ORDER BY c.username'
+        )->fetchAll(PDO::FETCH_ASSOC);
+    }
+
+    /**
+     * Read the stored `recipient_role_changed` history as
+     * `[['username' => ..., 'old_role' => ..., 'new_role' => ...], ...]`, in insertion order.
+     *
+     * @return list<array<string, mixed>>
+     */
+    private function storedRoleHistory(): array
+    {
+        return $this->db->prepexec(
+            'SELECT c.username, h.old_recipient_role AS old_role, h.new_recipient_role AS new_role'
+            . ' FROM incident_history h JOIN contact c ON c.id = h.contact_id'
+            . ' WHERE h.type = \'recipient_role_changed\' ORDER BY h.id'
+        )->fetchAll(PDO::FETCH_ASSOC);
+    }
+}

--- a/test/php/library/Notifications/Integrations/IncidentTest.php
+++ b/test/php/library/Notifications/Integrations/IncidentTest.php
@@ -1,0 +1,497 @@
+<?php
+
+// SPDX-FileCopyrightText: 2026 Icinga GmbH <https://icinga.com>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+namespace Tests\Icinga\Module\Notifications\Integrations;
+
+use Generator;
+use Icinga\Module\Notifications\Common\Database;
+use Icinga\Module\Notifications\Integrations\Incident;
+use Icinga\Module\Notifications\Model\Contact;
+use Icinga\Module\Notifications\Model\Incident as IncidentModel;
+use Icinga\Module\Notifications\Model\IncidentContact;
+use ipl\Sql\Connection;
+use PDOStatement;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use RuntimeException;
+
+class IncidentTest extends TestCase
+{
+    private ?Connection $previousDatabaseInstance = null;
+
+    /**
+     * Snapshots the {@see Database} singleton so each test can swap in a mock {@see Connection} via
+     * {@see self::injectDatabase()} without leaking state into the next test.
+     */
+    protected function setUp(): void
+    {
+        $instance = (new ReflectionClass(Database::class))->getProperty('instance');
+        $this->previousDatabaseInstance = $instance->getValue();
+    }
+
+    /**
+     * Restores the {@see Database} singleton to whatever it was before this test ran.
+     */
+    protected function tearDown(): void
+    {
+        $instance = (new ReflectionClass(Database::class))->getProperty('instance');
+        $instance->setValue(null, $this->previousDatabaseInstance);
+        $this->previousDatabaseInstance = null;
+    }
+
+    public function testAddManagerInsertsIncidentContactWhenContactHasNoExistingRow(): void
+    {
+        $db = $this->createMock(Connection::class);
+        $db->expects($this->once())->method('beginTransaction');
+        $db->expects($this->never())->method('update');
+        $db->expects($this->exactly(2))
+            ->method('insert')
+            ->willReturnCallback(function (string $table, array $data) {
+                $this->assertSame(42, $data['incident_id']);
+                $this->assertSame(7, $data['contact_id']);
+
+                if ($table === 'incident_contact') {
+                    $this->assertSame('manager', $data['role']);
+                } elseif ($table === 'incident_history') {
+                    $this->assertSame('recipient_role_changed', $data['type']);
+                    $this->assertSame('manager', $data['new_recipient_role']);
+                    $this->assertNull($data['old_recipient_role']);
+                } else {
+                    $this->fail(sprintf('Unexpected insert into %s', $table));
+                }
+
+                return $this->createStub(PDOStatement::class);
+            });
+        $db->expects($this->once())->method('commitTransaction');
+        $db->expects($this->never())->method('rollBackTransaction');
+
+        $this->injectDatabase($db);
+
+        $this->incidentFor(self::incidentWithId(42), null)
+            ->addManager(self::contact(7));
+    }
+
+    public function testAddManagerUpdatesExistingIncidentContactRole(): void
+    {
+        $db = $this->createMock(Connection::class);
+        $db->expects($this->once())->method('beginTransaction');
+        $db->expects($this->once())
+            ->method('update')
+            ->willReturnCallback(function (string $table, array $data, array $where) {
+                $this->assertSame('incident_contact', $table);
+                $this->assertSame('manager', $data['role']);
+                $this->assertContains(42, $where);
+                $this->assertContains(7, $where);
+
+                return $this->createStub(PDOStatement::class);
+            });
+        $db->expects($this->once())
+            ->method('insert')
+            ->willReturnCallback(function (string $table, array $data) {
+                $this->assertSame('incident_history', $table);
+                $this->assertSame(42, $data['incident_id']);
+                $this->assertSame(7, $data['contact_id']);
+                $this->assertSame('subscriber', $data['old_recipient_role']);
+                $this->assertSame('manager', $data['new_recipient_role']);
+
+                return $this->createStub(PDOStatement::class);
+            });
+        $db->expects($this->once())->method('commitTransaction');
+
+        $this->injectDatabase($db);
+
+        $this->incidentFor(self::incidentWithId(42), self::incidentContact('subscriber', 7))
+            ->addManager(self::contact(7));
+    }
+
+    public function testAddManagerIsNoopWhenContactIsAlreadyManager(): void
+    {
+        $db = $this->createMock(Connection::class);
+        $db->expects($this->never())->method('beginTransaction');
+        $db->expects($this->never())->method('insert');
+        $db->expects($this->never())->method('update');
+        $db->expects($this->never())->method('commitTransaction');
+
+        $this->injectDatabase($db);
+
+        $this->incidentFor(self::incidentWithId(42), self::incidentContact('manager', 7))
+            ->addManager(self::contact(7));
+    }
+
+    public function testAddManagerRollsBackOnException(): void
+    {
+        $db = $this->createMock(Connection::class);
+        $db->expects($this->once())->method('beginTransaction');
+        $db->expects($this->once())
+            ->method('insert')
+            ->willThrowException(new RuntimeException('boom'));
+        $db->expects($this->once())->method('rollBackTransaction');
+        $db->expects($this->never())->method('commitTransaction');
+
+        $this->injectDatabase($db);
+
+        $this->expectException(RuntimeException::class);
+
+        $this->incidentFor(self::incidentWithId(42), null)
+            ->addManager(self::contact(7));
+    }
+
+    public function testAddSubscriberInsertsRowWithSubscriberRole(): void
+    {
+        $db = $this->createMock(Connection::class);
+        $db->expects($this->once())->method('beginTransaction');
+        $db->expects($this->exactly(2))
+            ->method('insert')
+            ->willReturnCallback(function (string $table, array $data) {
+                $this->assertSame(42, $data['incident_id']);
+                $this->assertSame(7, $data['contact_id']);
+
+                if ($table === 'incident_contact') {
+                    $this->assertSame('subscriber', $data['role']);
+                } elseif ($table === 'incident_history') {
+                    $this->assertSame('recipient_role_changed', $data['type']);
+                    $this->assertSame('subscriber', $data['new_recipient_role']);
+                    $this->assertNull($data['old_recipient_role']);
+                }
+
+                return $this->createStub(PDOStatement::class);
+            });
+        $db->expects($this->once())->method('commitTransaction');
+
+        $this->injectDatabase($db);
+
+        $this->incidentFor(self::incidentWithId(42), null)
+            ->addSubscriber(self::contact(7));
+    }
+
+    public function testAddSubscriberIsNoopWhenContactIsAlreadySubscriber(): void
+    {
+        $db = $this->createMock(Connection::class);
+        $db->expects($this->never())->method('beginTransaction');
+        $db->expects($this->never())->method('insert');
+        $db->expects($this->never())->method('update');
+
+        $this->injectDatabase($db);
+
+        $this->incidentFor(self::incidentWithId(42), self::incidentContact('subscriber', 7))
+            ->addSubscriber(self::contact(7));
+    }
+
+    public function testAddSubscriberDoesNotDemoteAnExistingManager(): void
+    {
+        $db = $this->createMock(Connection::class);
+        $db->expects($this->never())->method('beginTransaction');
+        $db->expects($this->never())->method('insert');
+        $db->expects($this->never())->method('update');
+
+        $this->injectDatabase($db);
+
+        $this->incidentFor(self::incidentWithId(42), self::incidentContact('manager', 7))
+            ->addSubscriber(self::contact(7));
+    }
+
+    public function testRemoveManagerDemotesManagerToSubscriber(): void
+    {
+        $db = $this->createMock(Connection::class);
+        $db->expects($this->once())->method('beginTransaction');
+        $db->expects($this->once())
+            ->method('update')
+            ->willReturnCallback(function (string $table, array $data, array $where) {
+                $this->assertSame('incident_contact', $table);
+                $this->assertSame('subscriber', $data['role']);
+                $this->assertContains(42, $where);
+                $this->assertContains(7, $where);
+
+                return $this->createStub(PDOStatement::class);
+            });
+        $db->expects($this->once())
+            ->method('insert')
+            ->willReturnCallback(function (string $table, array $data) {
+                $this->assertSame('incident_history', $table);
+                $this->assertSame(42, $data['incident_id']);
+                $this->assertSame(7, $data['contact_id']);
+                $this->assertSame('manager', $data['old_recipient_role']);
+                $this->assertSame('subscriber', $data['new_recipient_role']);
+
+                return $this->createStub(PDOStatement::class);
+            });
+        $db->expects($this->once())->method('commitTransaction');
+
+        $this->injectDatabase($db);
+
+        $this->incidentFor(self::incidentWithId(42), self::incidentContact('manager', 7))
+            ->removeManager(self::contact(7));
+    }
+
+    public function testRemoveManagerIsNoopWhenContactHasNoIncidentContact(): void
+    {
+        $db = $this->createMock(Connection::class);
+        $db->expects($this->never())->method('beginTransaction');
+        $db->expects($this->never())->method('insert');
+        $db->expects($this->never())->method('update');
+
+        $this->injectDatabase($db);
+
+        $this->incidentFor(self::incidentWithId(42), null)
+            ->removeManager(self::contact(7));
+    }
+
+    public function testRemoveManagerIsNoopWhenContactIsSubscriber(): void
+    {
+        $db = $this->createMock(Connection::class);
+        $db->expects($this->never())->method('beginTransaction');
+        $db->expects($this->never())->method('insert');
+        $db->expects($this->never())->method('update');
+
+        $this->injectDatabase($db);
+
+        $this->incidentFor(self::incidentWithId(42), self::incidentContact('subscriber', 7))
+            ->removeManager(self::contact(7));
+    }
+
+    public function testRemoveSubscriberDeletesSubscriberRow(): void
+    {
+        $db = $this->createMock(Connection::class);
+        $db->expects($this->once())->method('beginTransaction');
+        $db->expects($this->once())
+            ->method('delete')
+            ->willReturnCallback(function (string $table, array $where) {
+                $this->assertSame('incident_contact', $table);
+                $this->assertContains(42, $where);
+                $this->assertContains(7, $where);
+
+                return $this->createStub(PDOStatement::class);
+            });
+        $db->expects($this->once())
+            ->method('insert')
+            ->willReturnCallback(function (string $table, array $data) {
+                $this->assertSame('incident_history', $table);
+                $this->assertSame(42, $data['incident_id']);
+                $this->assertSame(7, $data['contact_id']);
+                $this->assertSame('subscriber', $data['old_recipient_role']);
+                $this->assertNull($data['new_recipient_role']);
+
+                return $this->createStub(PDOStatement::class);
+            });
+        $db->expects($this->once())->method('commitTransaction');
+
+        $this->injectDatabase($db);
+
+        $this->incidentFor(self::incidentWithId(42), self::incidentContact('subscriber', 7))
+            ->removeSubscriber(self::contact(7));
+    }
+
+    public function testRemoveSubscriberIsNoopWhenContactIsNotSubscribed(): void
+    {
+        $db = $this->createMock(Connection::class);
+        $db->expects($this->never())->method('beginTransaction');
+        $db->expects($this->never())->method('delete');
+        $db->expects($this->never())->method('insert');
+
+        $this->injectDatabase($db);
+
+        $this->incidentFor(self::incidentWithId(42), self::incidentContact('manager', 7))
+            ->removeSubscriber(self::contact(7));
+    }
+
+    public function testRemoveSubscriberIsNoopWhenContactHasNoIncidentContact(): void
+    {
+        $db = $this->createMock(Connection::class);
+        $db->expects($this->never())->method('beginTransaction');
+        $db->expects($this->never())->method('delete');
+
+        $this->injectDatabase($db);
+
+        $this->incidentFor(self::incidentWithId(42), null)
+            ->removeSubscriber(self::contact(7));
+    }
+
+    public function testIsMutedIsTrueWhenIncidentHasMuteReason(): void
+    {
+        $model = new IncidentModel();
+        $model->mute_reason = 'down for maintenance';
+
+        $this->assertTrue((new Incident($model))->isMuted());
+    }
+
+    public function testIsMutedIsFalseWhenIncidentHasNoMuteReason(): void
+    {
+        $model = new IncidentModel();
+        $model->mute_reason = null;
+
+        $this->assertFalse((new Incident($model))->isMuted());
+    }
+
+    public function testGetSubscribersAsksFetchContactsByRoleForSubscribers(): void
+    {
+        $a = self::incidentContact('subscriber', 1);
+        $b = self::incidentContact('subscriber', 2);
+
+        $incident = $this->incidentReturning(self::incidentWithId(42), 'subscriber', [$a, $b]);
+
+        $this->assertSame([$a, $b], iterator_to_array($incident->getSubscribers(), false));
+    }
+
+    public function testGetSubscribersIsEmptyWhenNoSubscribersExist(): void
+    {
+        $incident = $this->incidentReturning(self::incidentWithId(42), 'subscriber', []);
+
+        $this->assertSame([], iterator_to_array($incident->getSubscribers(), false));
+    }
+
+    public function testGetSubscribersIncludesContactgroupAndScheduleEntries(): void
+    {
+        $contactSub = new IncidentContact();
+        $contactSub->role = 'subscriber';
+        $contactSub->contact_id = 7;
+
+        $groupSub = new IncidentContact();
+        $groupSub->role = 'subscriber';
+        $groupSub->contactgroup_id = 8;
+
+        $scheduleSub = new IncidentContact();
+        $scheduleSub->role = 'subscriber';
+        $scheduleSub->schedule_id = 9;
+
+        $incident = $this->incidentReturning(
+            self::incidentWithId(42),
+            'subscriber',
+            [$contactSub, $groupSub, $scheduleSub]
+        );
+
+        $this->assertCount(3, iterator_to_array($incident->getSubscribers(), false));
+    }
+
+    public function testGetManagersAsksFetchContactsByRoleForManagers(): void
+    {
+        $a = self::incidentContact('manager', 1);
+        $b = self::incidentContact('manager', 2);
+
+        $incident = $this->incidentReturning(self::incidentWithId(42), 'manager', [$a, $b]);
+
+        $this->assertSame([$a, $b], iterator_to_array($incident->getManagers(), false));
+    }
+
+    public function testGetManagersIsEmptyWhenNoManagersExist(): void
+    {
+        $incident = $this->incidentReturning(self::incidentWithId(42), 'manager', []);
+
+        $this->assertSame([], iterator_to_array($incident->getManagers(), false));
+    }
+
+    public function testGetManagersIncludesContactgroupAndScheduleEntries(): void
+    {
+        $contactMgr = new IncidentContact();
+        $contactMgr->role = 'manager';
+        $contactMgr->contact_id = 7;
+
+        $groupMgr = new IncidentContact();
+        $groupMgr->role = 'manager';
+        $groupMgr->contactgroup_id = 8;
+
+        $scheduleMgr = new IncidentContact();
+        $scheduleMgr->role = 'manager';
+        $scheduleMgr->schedule_id = 9;
+
+        $incident = $this->incidentReturning(
+            self::incidentWithId(42),
+            'manager',
+            [$contactMgr, $groupMgr, $scheduleMgr]
+        );
+
+        $this->assertCount(3, iterator_to_array($incident->getManagers(), false));
+    }
+
+    private static function incidentContact(string $role, int $contactId): IncidentContact
+    {
+        $entry = new IncidentContact();
+        $entry->role = $role;
+        $entry->contact_id = $contactId;
+
+        return $entry;
+    }
+
+    private static function contact(int $id): Contact
+    {
+        $contact = new Contact();
+        $contact->id = $id;
+
+        return $contact;
+    }
+
+    private static function incidentWithId(int $id): IncidentModel
+    {
+        $model = new IncidentModel();
+        $model->id = $id;
+
+        return $model;
+    }
+
+    /**
+     * Build an Incident integration whose existing-row lookup is bypassed with the supplied IncidentContact.
+     *
+     * The override avoids hitting the ORM SELECT path so write-method tests only need to mock
+     * Connection::insert/update/delete and the transaction methods. Pass null to model "no existing row".
+     */
+    private function incidentFor(IncidentModel $model, ?IncidentContact $existing): Incident
+    {
+        return new class ($model, $existing) extends Incident {
+            private ?IncidentContact $existing;
+
+            public function __construct(IncidentModel $incident, ?IncidentContact $existing)
+            {
+                parent::__construct($incident);
+                $this->existing = $existing;
+            }
+
+            protected function fetchIncidentContact(Contact $contact): ?IncidentContact
+            {
+                return $this->existing;
+            }
+        };
+    }
+
+    /**
+     * Build an Incident integration whose role lookup is bypassed with the supplied rows.
+     *
+     * The override yields {@see $rows} when {@see Incident::fetchContactsByRole()} is called with
+     * {@see $expectedRole}, and fails the test for any other role. This avoids the ORM SELECT path so
+     * reader tests stay self-contained, and verifies the unit-under-test asks for the expected role.
+     *
+     * @param IncidentContact[] $rows
+     */
+    private function incidentReturning(IncidentModel $model, string $expectedRole, array $rows): Incident
+    {
+        return new class ($model, $expectedRole, $rows) extends Incident {
+            private string $expectedRole;
+            /** @var IncidentContact[] */
+            private array $rows;
+
+            public function __construct(IncidentModel $incident, string $expectedRole, array $rows)
+            {
+                parent::__construct($incident);
+                $this->expectedRole = $expectedRole;
+                $this->rows = $rows;
+            }
+
+            protected function fetchContactsByRole(string $role): Generator
+            {
+                TestCase::assertSame($this->expectedRole, $role);
+                yield from $this->rows;
+            }
+        };
+    }
+
+    /**
+     * Replace the {@see Database} singleton with the given connection so the unit under test hits the mock.
+     *
+     * Restored by tearDown via the snapshot taken in setUp.
+     */
+    private function injectDatabase(Connection $db): void
+    {
+        $instance = (new ReflectionClass(Database::class))->getProperty('instance');
+        $instance->setValue(null, $db);
+    }
+}

--- a/test/php/library/Notifications/Integrations/IncidentsTest.php
+++ b/test/php/library/Notifications/Integrations/IncidentsTest.php
@@ -1,0 +1,238 @@
+<?php
+
+// SPDX-FileCopyrightText: 2026 Icinga GmbH <https://icinga.com>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+namespace Tests\Icinga\Module\Notifications\Integrations;
+
+use Icinga\Module\Notifications\Integrations\Incident;
+use Icinga\Module\Notifications\Integrations\Incidents;
+use ipl\Orm\Query;
+use ipl\Stdlib\Filter\Chain;
+use ipl\Stdlib\Filter\Condition;
+use ipl\Stdlib\Filter\Equal;
+use ipl\Stdlib\Filter\Unlike;
+use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
+use Tests\Icinga\Module\Notifications\Lib\EntityManager\RecordingConnection;
+
+class IncidentsTest extends TestCase
+{
+    /** @var array<string, true> Object ids seeded into the current test's database, keyed by hex id */
+    private array $seededObjects = [];
+
+    private RecordingConnection $db;
+
+    /**
+     * Reset the set of seeded object ids so each test starts with a fresh, empty database
+     */
+    protected function setUp(): void
+    {
+        $this->seededObjects = [];
+        $this->db = $this->createDatabase();
+    }
+
+    public function testBuildsAnEqualFilterForEachTagWithAValue(): void
+    {
+        $conditions = $this->conditions($this->builtFilter(['host' => 'icinga2', 'service' => 'http']));
+
+        $this->assertCount(3, $conditions);
+        $this->assertContains([Unlike::class, 'recovered_at', '*'], $conditions);
+        $this->assertContains([Equal::class, 'incident.object.tag.host', 'icinga2'], $conditions);
+        $this->assertContains([Equal::class, 'incident.object.tag.service', 'http'], $conditions);
+    }
+
+    public function testBuildsAnAbsenceFilterForTagsGivenAsNull(): void
+    {
+        $conditions = $this->conditions($this->builtFilter(['host' => 'icinga2', 'service' => null]));
+
+        $this->assertCount(3, $conditions);
+        $this->assertContains([Equal::class, 'incident.object.tag.host', 'icinga2'], $conditions);
+        // A null value requires the tag's absence, expressed as "no value matches the wildcard".
+        $this->assertContains([Unlike::class, 'incident.object.tag.service', '*'], $conditions);
+    }
+
+    public function testAlwaysFiltersOutRecoveredIncidents(): void
+    {
+        // Even without any tags the query is constrained to open incidents (recovered_at IS NULL).
+        $this->assertSame([[Unlike::class, 'recovered_at', '*']], $this->conditions($this->builtFilter([])));
+    }
+
+    public function testGetIterator(): void
+    {
+        $this->seedIncident(1, ['host' => 'a']);
+        $this->seedIncident(2, ['host' => 'b']);
+
+        $incidents = iterator_to_array(new Incidents([], $this->db), false);
+
+        $this->assertCount(2, $incidents);
+        foreach ($incidents as $incident) {
+            $this->assertInstanceOf(Incident::class, $incident);
+        }
+    }
+
+    public function testHasIncident(): void
+    {
+        $this->assertFalse((new Incidents([], $this->db))->hasIncident());
+
+        $this->seedIncident(1, ['host' => 'a']);
+
+        $this->assertTrue((new Incidents([], $this->db))->hasIncident());
+    }
+
+    public function testIteratingAfterHasIncidentYieldsAllMatchesFromTheSameInstance(): void
+    {
+        $this->seedIncident(1, ['host' => 'a']);
+        $this->seedIncident(2, ['host' => 'b']);
+
+        $incidents = new Incidents([], $this->db);
+
+        $this->assertTrue($incidents->hasIncident());
+        $this->assertCount(2, iterator_to_array($incidents, false));
+    }
+
+    public function testCount(): void
+    {
+        $this->seedIncident(1, ['host' => 'a']);
+
+        $this->assertEquals(1, (new Incidents([], $this->db))->count());
+    }
+
+    public function testExcludesClosedIncidents(): void
+    {
+        // A recovered (closed) incident must never be yielded — the integration only deals with open
+        // incidents (recovered_at IS NULL).
+        $this->seedIncident(1, ['host' => 'a']);
+        $this->seedIncident(2, ['host' => 'b'], 1_700_000_000_000);
+
+        $incidents = new Incidents([], $this->db);
+
+        $this->assertEquals(1, $incidents->count());
+        $this->assertCount(1, iterator_to_array($incidents, false));
+    }
+
+    /**
+     * Build the query {@see Incidents} would run for the given tags and return its filter
+     *
+     * The query is never executed: with tags it compiles to multi-argument COUNT(DISTINCT …) subqueries
+     * that only MySQL and PostgreSQL support, not the sqlite the test database uses. Asserting on the
+     * filter the integration constructs is this unit's responsibility; turning it into SQL is ipl-orm's.
+     *
+     * @param array<string, ?string> $tags
+     */
+    private function builtFilter(array $tags): Chain
+    {
+        $incidents = new Incidents($tags, $this->db);
+
+        /** @var Query $query */
+        $query = (new ReflectionMethod($incidents, 'buildQuery'))->invoke($incidents);
+
+        return $query->getFilter();
+    }
+
+    /**
+     * Reduce a filter chain to a list of [operator class, column, value] triples for order-independent assertions
+     *
+     * @return list<array{class-string, string|array<string>, mixed}>
+     */
+    private function conditions(Chain $chain): array
+    {
+        $conditions = [];
+        foreach ($chain as $rule) {
+            $this->assertInstanceOf(Condition::class, $rule);
+            $conditions[] = [$rule::class, $rule->getColumn(), $rule->getValue()];
+        }
+
+        return $conditions;
+    }
+
+    /**
+     * Stand up an in-memory SQLite database with the incident, object and object_id_tag tables that
+     * {@see Incidents} reads from, and return it so tests can seed it and hand it to the unit under test.
+     */
+    private function createDatabase(): RecordingConnection
+    {
+        $db = new RecordingConnection(['db' => 'sqlite', 'dbname' => ':memory:']);
+        $db->exec(
+            'CREATE TABLE object (id BLOB PRIMARY KEY, source_id INTEGER, name VARCHAR, url VARCHAR);'
+        );
+        $db->exec(
+            'CREATE TABLE object_id_tag (object_id BLOB, tag VARCHAR, value VARCHAR, PRIMARY KEY (object_id, tag));'
+        );
+        $db->exec(
+            'CREATE TABLE incident (id INTEGER PRIMARY KEY AUTOINCREMENT, object_id BLOB, started_at INTEGER,'
+            . ' recovered_at INTEGER, severity VARCHAR, mute_reason VARCHAR);'
+        );
+
+        return $db;
+    }
+
+    /**
+     * Insert an incident for the object identified by the given source and tags, creating the
+     * object and object_id_tag rows it relates to so the joins in {@see Incidents::buildQuery()} resolve.
+     *
+     * @param array<string, string> $tags
+     * @param ?int $recoveredAt Recovery time in milliseconds; null leaves the incident open
+     */
+    private function seedIncident(int $sourceId, array $tags, ?int $recoveredAt = null): void
+    {
+        $objectId = $this->objectId($sourceId, $tags);
+
+        $this->seedObject($sourceId, $tags, $objectId);
+
+        $this->db->insert('incident', [
+            'object_id'    => hex2bin($objectId),
+            'severity'     => 'crit',
+            'recovered_at' => $recoveredAt,
+        ]);
+    }
+
+    /**
+     * Derive a stable, unique object id for the given source and tags
+     *
+     * Stands in for the daemon's object hashing: the exact algorithm is irrelevant to these tests, it
+     * only has to be deterministic and collision-free across distinct (source, tags) combinations so
+     * the seeded incident and object_id_tag rows share one id while distinct objects differ.
+     *
+     * @param array<string, string> $tags
+     */
+    private function objectId(int $sourceId, array $tags): string
+    {
+        ksort($tags);
+
+        return hash('sha256', $sourceId . "\0" . serialize($tags));
+    }
+
+    /**
+     * Insert the object row and the object_id_tag rows that represent the object for the given tags,
+     * unless they already exist — the same object backs every incident sharing its id.
+     *
+     * The object id is stored as the raw bytes the Binary behavior compares against.
+     *
+     * @param array<string, string> $tags
+     */
+    private function seedObject(int $sourceId, array $tags, string $objectId): void
+    {
+        if (isset($this->seededObjects[$objectId])) {
+            return;
+        }
+
+        $this->seededObjects[$objectId] = true;
+
+        $rawId = hex2bin($objectId);
+
+        $this->db->insert('object', [
+            'id'        => $rawId,
+            'source_id' => $sourceId,
+            'name'      => implode(', ', $tags),
+        ]);
+
+        foreach ($tags as $tag => $value) {
+            $this->db->insert('object_id_tag', [
+                'object_id' => $rawId,
+                'tag'       => $tag,
+                'value'     => $value,
+            ]);
+        }
+    }
+}

--- a/test/php/library/Notifications/Integrations/IncidentsTest.php
+++ b/test/php/library/Notifications/Integrations/IncidentsTest.php
@@ -1,0 +1,167 @@
+<?php
+
+// SPDX-FileCopyrightText: 2026 Icinga GmbH <https://icinga.com>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+namespace Tests\Icinga\Module\Notifications\Integrations;
+
+use Icinga\Module\Notifications\Common\Database;
+use Icinga\Module\Notifications\Integrations\Incidents;
+use InvalidArgumentException;
+use ipl\Orm\Query;
+use ipl\Sql\Connection;
+use ipl\Stdlib\Filter;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+
+class IncidentsTest extends TestCase
+{
+    private ?Connection $previousDatabaseInstance = null;
+
+    /**
+     * Snapshots the {@see Database} singleton so wiring tests can inject a stub {@see Connection}
+     * without leaking state into the next test.
+     */
+    protected function setUp(): void
+    {
+        $instance = (new ReflectionClass(Database::class))->getProperty('instance');
+        $this->previousDatabaseInstance = $instance->getValue();
+    }
+
+    /**
+     * Restores the {@see Database} singleton to whatever it was before this test ran.
+     */
+    protected function tearDown(): void
+    {
+        $instance = (new ReflectionClass(Database::class))->getProperty('instance');
+        $instance->setValue(null, $this->previousDatabaseInstance);
+        $this->previousDatabaseInstance = null;
+    }
+
+    /**
+     * Pinned vectors taken from an actual daemon's writes to a notifications database; each
+     * `(source_id, tags) => hex` row was confirmed against the stored object.id. If a test here
+     * fails, either the PHP hash function drifted or the daemon's hash function changed —
+     * investigate which before "fixing" either side, because the stored object.id values in
+     * production databases depend on this.
+     *
+     * @return array<string, array{0: int, 1: array<string, string>, 2: string}>
+     */
+    public static function knownHashVectors(): array
+    {
+        return [
+            'single tag (host only)'    => [
+                1,
+                ['host' => 'icinga2'],
+                'f2c11c8086bacbc6674b5e9e68fa5e7c9f8200be1e2e50825ee08a86bb301d13'
+            ],
+            'multiple tags (http svc)'  => [
+                1,
+                ['host' => 'icinga2', 'service' => 'http'],
+                '58a0b5785f2ae8974f1c698ff0eb579b8b63c4110f991ce6286caa60d041c056'
+            ],
+            'multiple tags (procs svc)' => [
+                1,
+                ['host' => 'icinga2', 'service' => 'procs'],
+                '7ecdee4e3dd82abc27aab1661b776b611c1a65a02594c423a1868daba8c99e8b'
+            ],
+        ];
+    }
+
+    /**
+     * @param array<string, string> $tags
+     */
+    #[DataProvider('knownHashVectors')]
+    public function testObjectIdMatchesDaemonHash(int $sourceId, array $tags, string $expectedHex): void
+    {
+        $this->assertSame($expectedHex, Incidents::objectId($sourceId, $tags));
+    }
+
+    public function testObjectIdIsIndependentOfTagInsertionOrder(): void
+    {
+        $a = Incidents::objectId(1, ['host' => 'icinga2', 'service' => 'http']);
+        $b = Incidents::objectId(1, ['service' => 'http', 'host' => 'icinga2']);
+
+        $this->assertSame($a, $b);
+    }
+
+    public function testObjectIdThrowsForNegativeSourceId(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        Incidents::objectId(-1, ['host' => 'icinga2']);
+    }
+
+    public function testBuildQueryFiltersOnObjectIdWithComputedHash(): void
+    {
+        $this->injectDatabase($this->createStub(Connection::class));
+
+        $sourceId = 1;
+        $tags = ['host' => 'icinga2', 'service' => 'http'];
+        $expectedHash = Incidents::objectId($sourceId, $tags);
+
+        $query = $this->inspectableIncidents($sourceId, $tags)->exposedBuildQuery();
+        $equals = self::flattenEqualRules($query->getFilter());
+
+        $matched = false;
+        foreach ($equals as $rule) {
+            if ($rule->getColumn() === 'object_id' && $rule->getValue() === $expectedHash) {
+                $matched = true;
+                break;
+            }
+        }
+
+        $this->assertTrue(
+            $matched,
+            'Expected the built query to carry a Filter\Equal on object_id with the computed hash'
+        );
+    }
+
+    /**
+     * Recursively collect every {@see Filter\Equal} rule below the given rule.
+     *
+     * @return Filter\Equal[]
+     */
+    private static function flattenEqualRules(Filter\Rule $rule): array
+    {
+        if ($rule instanceof Filter\Equal) {
+            return [$rule];
+        }
+
+        $collected = [];
+        if ($rule instanceof Filter\Chain) {
+            foreach ($rule as $child) {
+                $collected = array_merge($collected, self::flattenEqualRules($child));
+            }
+        }
+
+        return $collected;
+    }
+
+    /**
+     * Build an Incidents instance that exposes its protected {@see Incidents::buildQuery()} via a
+     * public passthrough, so the test can inspect the resulting query without running it.
+     *
+     * @param array<string, string> $tags
+     */
+    private function inspectableIncidents(int $sourceId, array $tags): Incidents
+    {
+        return new class ($sourceId, $tags) extends Incidents {
+            public function exposedBuildQuery(): Query
+            {
+                return $this->buildQuery();
+            }
+        };
+    }
+
+    /**
+     * Replace the {@see Database} singleton with the given connection so the unit under test hits
+     * the stub. Restored by tearDown via the snapshot taken in setUp.
+     */
+    private function injectDatabase(Connection $db): void
+    {
+        $instance = (new ReflectionClass(Database::class))->getProperty('instance');
+        $instance->setValue(null, $db);
+    }
+}


### PR DESCRIPTION
resolve #464
resolve #220 

Add the class `Incidents` which finds incidents that match a given array of tags independant of the source.

Each yielded `Incident` allows basic read/write operations.

The tests are written by claude.