### PR TITLE
Add write support for models

### DIFF
--- a/application/forms/ContactGroupForm.php
+++ b/application/forms/ContactGroupForm.php
@@ -356,7 +356,7 @@ class ContactGroupForm extends CompatForm
 
                 /** @var Rotation $rotation */
                 foreach ($rotations as $rotation) {
-                    $rotation->delete();
+                    $rotation->deleteRotation();
                 }
             }
         }

--- a/application/forms/RotationConfigForm.php
+++ b/application/forms/RotationConfigForm.php
@@ -574,7 +574,7 @@ class RotationConfigForm extends CompatForm
             ->filter(Filter::equal('id', $id))
             ->first();
 
-        $rotation->delete();
+        $rotation->deleteRotation();
 
         if ($transactionStarted) {
             $this->db->commitTransaction();
@@ -609,7 +609,7 @@ class RotationConfigForm extends CompatForm
 
         /** @var Rotation $rotation */
         foreach ($rotations as $rotation) {
-            $rotation->delete();
+            $rotation->deleteRotation();
         }
 
         if ($transactionStarted) {

--- a/application/forms/ScheduleForm.php
+++ b/application/forms/ScheduleForm.php
@@ -135,7 +135,7 @@ class ScheduleForm extends CompatForm
 
         /** @var Rotation $rotation */
         foreach ($rotations as $rotation) {
-            $rotation->delete();
+            $rotation->deleteRotation();
         }
 
         $markAsDeleted = ['changed_at' => (int) (new DateTime())->format("Uv"), 'deleted' => 'y'];

--- a/library/Notifications/Api/V1/ContactGroups.php
+++ b/library/Notifications/Api/V1/ContactGroups.php
@@ -523,7 +523,7 @@ class ContactGroups extends ApiV1 implements RequestHandlerInterface, EndpointIn
 
                 /** @var Rotation $rotation */
                 foreach ($rotations as $rotation) {
-                    $rotation->delete();
+                    $rotation->deleteRotation();
                 }
             }
         }

--- a/library/Notifications/Api/V1/Contacts.php
+++ b/library/Notifications/Api/V1/Contacts.php
@@ -810,7 +810,7 @@ class Contacts extends ApiV1 implements RequestHandlerInterface, EndpointInterfa
 
                 /** @var Rotation $rotation */
                 foreach ($rotations as $rotation) {
-                    $rotation->delete();
+                    $rotation->deleteRotation();
                 }
             }
         }

--- a/library/Notifications/Common/Collection.php
+++ b/library/Notifications/Common/Collection.php
@@ -1,0 +1,318 @@
+<?php
+
+// SPDX-FileCopyrightText: 2026 Icinga GmbH <https://icinga.com>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+namespace Icinga\Module\Notifications\Common;
+
+use ArrayIterator;
+use Countable;
+use ipl\Orm\Query;
+use IteratorAggregate;
+use LogicException;
+use Traversable;
+
+/**
+ * Container for members of a to-many relation
+ *
+ * For a HasMany relation, {@see self::attach()} and {@see self::detach()} insert/delete the database rows
+ * of the given models.
+ * For a BelongsToMany, only the links from the source model will be inserted/deleted, the target itself remains
+ * untouched.
+ *
+ * By default, rows that are not included in {@see self::$attach} or {@see self::$detach} remain untouched.
+ * Calling {@see self::sync()} will put the collection into replace mode, which will delete what is not contained
+ * in {@see self::$attach}
+ *
+ * Members may also be edited in place and will be cascaded by {@see EntityManager::save()} if they have
+ * been modified.
+ */
+class Collection implements IteratorAggregate, Countable
+{
+    /**
+     * Stored members, still as the unread {@see Query}
+     *
+     * Drained into {@see self::$base} once on first read, so the query is not run eagerly.
+     *
+     * @var ?Query
+     */
+    private ?Query $source = null;
+
+    /**
+     * Stored members once {@see self::$source} has been read, cached for repeated reads
+     *
+     * @var ?array<string, Model>
+     */
+    private ?array $base = null;
+
+    /** @var array<string, Model> Models whose links/rows must exist after the next {@see EntityManager::save()} */
+    private array $attach = [];
+
+    /** @var array<string, Model> Models whose links/rows must be removed on the next {@see EntityManager::save()} */
+    private array $detach = [];
+
+    /** @var bool Whether {@see self::sync()} requested a replace (remove whatever is not in {@see self::$attach}) */
+    private bool $replace = false;
+
+    /**
+     * Create a collection whose members are merged with existing ones on the next save
+     *
+     * @param iterable $values
+     *
+     * @return static
+     */
+    public static function create(iterable $values): static
+    {
+        $collection = new static();
+        foreach ($values as $model) {
+            $collection->attach($model);
+        }
+
+        return $collection;
+    }
+
+    /**
+     * Create a collection from members who are treated as already existing db rows
+     *
+     * @param Query $source
+     *
+     * @return static
+     */
+    public static function fromLoaded(Query $source): static
+    {
+        $collection = new static();
+        $collection->source = $source;
+
+        return $collection;
+    }
+
+    /**
+     * Get the {@see Query} the Collection was created from
+     *
+     * The query may be modified e.g. by calling {@see Query::filter()} on it, but only before the collection
+     * itself is iterated or {@see self::count()} is called.
+     *
+     * Modifications made to a Model yielded by the query will NOT be persisted by {@see EntityManager::save()}.
+     * Traverse the collection and modify models in place, or pass a modified {@see Model} to {@see self::attach()}
+     * if changes should be persisted.
+     *
+     * @return Query
+     *
+     * @throws LogicException If the collection was not created from a query, or the query has already been read
+     */
+    public function query(): Query
+    {
+        if ($this->source === null) {
+            throw new LogicException('Collection was created without a query, or the query was already read');
+        }
+
+        return $this->source;
+    }
+
+    /**
+     * Additively register the given model as a member of this relation
+     *
+     * @param Model $model
+     *
+     * @return $this
+     */
+    public function attach(Model $model): static
+    {
+        $id = $this->identify($model);
+        unset($this->detach[$id]);
+        if (! isset($this->base[$id])) {
+            $this->attach[$id] = $model;
+        } elseif ($model !== $this->base[$id]) {
+            throw new LogicException(
+                'Collection already contains a different model with the same primary key'
+            );
+        }
+
+        return $this;
+    }
+
+    /**
+     * Register the given model to be removed from this relation
+     *
+     * @param Model $model
+     *
+     * @return $this
+     */
+    public function detach(Model $model): static
+    {
+        $id = $this->identify($model);
+        unset($this->attach[$id]);
+        $this->detach[$id] = $model;
+
+        return $this;
+    }
+
+    /**
+     * Replace this relation's members with exactly the given models
+     *
+     * Anything currently stored that is not in $models is removed on save.
+     *
+     * @param iterable<Model> $models
+     *
+     * @return $this
+     */
+    public function sync(iterable $models): static
+    {
+        $this->attach = [];
+        $this->detach = [];
+        $this->replace = true;
+        foreach ($models as $model) {
+            $this->attach($model);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Get whether {@see self::sync()} put this collection into replace mode
+     *
+     * @return bool
+     */
+    public function isReplacing(): bool
+    {
+        return $this->replace;
+    }
+
+    /**
+     * Get the members to persist on save: staged attachments plus in-place-modified loaded members
+     *
+     * @return Model[]
+     */
+    public function getMembersToSave(): array
+    {
+        if ($this->replace) {
+            return array_values($this->attach);
+        }
+
+        return array_values(array_merge($this->base ?? [], $this->attach));
+    }
+
+    /**
+     * Get the models to delete/unlink on save
+     *
+     * @return Model[]
+     */
+    public function getDetachments(): array
+    {
+        return array_values($this->detach);
+    }
+
+    /**
+     * Whether anything must be persisted on the next save
+     *
+     * @return bool
+     */
+    public function hasPendingChanges(): bool
+    {
+        if ($this->replace || ! empty($this->attach) || ! empty($this->detach)) {
+            return true;
+        }
+
+        foreach ($this->base ?? [] as $model) {
+            if ($model->isModified()) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Reset the pending write state after the collection has been persisted
+     *
+     * @return void
+     */
+    public function clearPendingChanges(): void
+    {
+        $this->attach = [];
+        $this->detach = [];
+        $this->replace = false;
+    }
+
+    /**
+     * @return Traversable<Model>
+     */
+    public function getIterator(): Traversable
+    {
+        return new ArrayIterator($this->all());
+    }
+
+    public function count(): int
+    {
+        return count($this->all());
+    }
+
+    /**
+     * The staged members: base merged with attachments, minus detachments
+     *
+     * @return Model[]
+     */
+    private function all(): array
+    {
+        if ($this->replace) {
+            return array_values($this->attach);
+        }
+
+        $members = [];
+        foreach ($this->materializeBase() as $id => $model) {
+            if (isset($this->attach[$id]) && $this->attach[$id] !== $model) {
+                throw new LogicException(
+                    'Collection already contains a different model with the same primary key'
+                );
+            }
+
+            $members[$id] = $model;
+        }
+
+        foreach ($this->detach as $id => $_) {
+            unset($members[$id]);
+        }
+
+        return array_values(array_merge($members, $this->attach));
+    }
+
+    /**
+     * The stored members, read from the source query once and cached
+     *
+     * @return array<string, Model>
+     */
+    private function materializeBase(): array
+    {
+        if ($this->base === null) {
+            $this->base = [];
+            foreach ($this->source ?? [] as $model) {
+                $this->base[$this->identify($model)] = $model->setNew(false);
+            }
+
+            $this->source = null;
+        }
+
+        return $this->base;
+    }
+
+    /**
+     * Return the primary key of the model, or an object hash if it is not set
+     *
+     * @param Model $model
+     *
+     * @return string
+     */
+    private function identify(Model $model): string
+    {
+        $values = [];
+        foreach ((array) $model->getKeyName() as $column) {
+            if (! $model->hasProperty($column) || $model->$column === null) {
+                return 'obj#' . spl_object_id($model);
+            }
+
+            $values[] = $model->$column;
+        }
+
+        return 'pk#' . implode('|', $values);
+    }
+}

--- a/library/Notifications/Common/EntityManager.php
+++ b/library/Notifications/Common/EntityManager.php
@@ -1,0 +1,1034 @@
+<?php
+
+// SPDX-FileCopyrightText: 2026 Icinga GmbH <https://icinga.com>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+namespace Icinga\Module\Notifications\Common;
+
+use DateTime;
+use ipl\Orm\Behaviors;
+use ipl\Orm\Query;
+use ipl\Orm\Relation;
+use ipl\Orm\Relation\BelongsTo;
+use ipl\Orm\Relation\BelongsToMany;
+use ipl\Orm\Resolver;
+use ipl\Sql\Connection;
+use ipl\Sql\Expression;
+use ipl\Sql\Select;
+use PDO;
+use RuntimeException;
+use SplObjectStorage;
+
+/**
+ * Persists models and their related models to the database.
+ *
+ * The EntityManager is the write-side counterpart to {@see Query}. Whereas a query is bound to a model
+ * class and operates on rows matching a filter, the EntityManager operates on concrete {@see Model} instances.
+ *
+ * ```
+ * $em = new EntityManager($db);
+ * $em->save($car);                 // INSERT or UPDATE, depending on whether the model is new
+ * $em->save($car->delete());       // DELETE or soft-delete, depending on the model
+ * ```
+ *
+ * Whether {@see self::save()} inserts or updates is decided by {@see Model::isNew()}. Updates only write the
+ * properties changed since the model was loaded ({@see Model::getModifiedProperties()}). Set relations are cascaded
+ * (parents first, then the model, then children and many-to-many links), all within a single transaction.
+ *
+ * Calling {@see Model::delete()} on a model and passing it to {@see self::save()} will soft or hard delete the
+ * model according to whether its table has a {@see Model::DELETED} column.
+ *
+ * In case a model supports tracking of modification times ({@see Model::getChangedAtColumn()}), the EntityManager
+ * will stamp the resulting record with the current time when it is persisted. This is done in a way that phantom
+ * reads by the daemon are avoided by locking related rows using a range lock, given the current transaction isolation
+ * level is serializable.
+ *
+ * The optional baseline time and date is used to verify that no related database record exceeds it as if that's
+ * the case, it is considered a parallel update that would be overwritten by the save. This is a simple form of
+ * optimistic locking, and is used to prevent overwriting changes made by other processes since the data was loaded.
+ * This is limited to relation models supporting tracking of modification times. For a base model the caller is
+ * responsible to detect conflicts. This is independent of the used driver or transaction isolation level.
+ *
+ * Limitations:
+ * - Saving two separate model instances that map to the same db row will result in the second save overwriting the
+ *   changes of the first
+ * - {@see self::saveGraph()} does not support cyclic graphs, passing a cyclic graph like:
+ *   ```
+ *   $parent->children = [$child];
+ *   $child->parent = $parent;
+ *   $em->save($parent);
+ *   ```
+ *   will throw a {@see RuntimeException}
+ */
+class EntityManager
+{
+    /** @var Connection The database connection to persist to */
+    protected Connection $db;
+
+    /** @var ?DateTime Baseline which no relation record must exceed */
+    protected ?DateTime $baselineAt;
+
+    /**
+     * The models currently being saved by {@see self::saveGraph()}, used to detect cyclic graphs
+     *
+     * @var SplObjectStorage<Model, null>
+     */
+    private SplObjectStorage $activeSaves;
+
+    /**
+     * Cache of table column maps populated by {@see self::getTableColumnMap()}, keyed by model class
+     *
+     * @var array<class-string, array<string, true>>
+     */
+    private array $tableColumnCache = [];
+
+    /**
+     * The resolver shared across all models
+     *
+     * @var Resolver
+     */
+    private Resolver $resolver;
+
+    /**
+     * Create a new EntityManager for the given database connection
+     *
+     * @param Connection $db
+     * @param ?DateTime $baselineAt Baseline which no relation record must exceed
+     */
+    public function __construct(Connection $db, ?DateTime $baselineAt = null)
+    {
+        $this->db = $db;
+        $this->baselineAt = $baselineAt;
+        $this->activeSaves = new SplObjectStorage();
+        $this->resolver = (new Query())
+            ->setDb($db)
+            ->getResolver();
+    }
+
+    /**
+     * Persist the given model and its set relations
+     *
+     * @param Model $model
+     *
+     * @return void
+     *
+     * @throws RuntimeException
+     */
+    public function save(Model $model): void
+    {
+        if ($this->db->inTransaction()) {
+            $this->saveGraph($model);
+        } else {
+            $this->db->transaction(function () use ($model): void {
+                $this->saveGraph($model);
+            });
+        }
+    }
+
+    /**
+     * Delete the given model's row and reset it to a fresh state
+     *
+     * Soft-deletes when the model's table has a {@see Model::DELETED} column, otherwise hard-deletes
+     * the row. Does nothing if the model is new.
+     *
+     * @param Model $model
+     *
+     * @return void
+     *
+     * @throws RuntimeException If the given model has no (complete) primary key value
+     */
+    protected function delete(Model $model): void
+    {
+        if ($model->isNew()) {
+            return;
+        }
+
+        $behaviors = $this->resolver->getBehaviors($model);
+
+        if ($model->isSoftDeletable()) {
+            $model->{$model::DELETED} = true;
+            $this->persist($model, $behaviors);
+
+            return;
+        }
+
+        $condition = $this->createPrimaryKeyCondition($model, $behaviors);
+        if ($condition === null) {
+            throw new RuntimeException(
+                sprintf(
+                    'Cannot delete %s without a primary key value',
+                    get_class($model)
+                )
+            );
+        }
+
+        $this->ensureOlderThanBaseline($model);
+        $this->db->delete($model->getTableName(), $condition);
+        foreach ((array) $model->getKeyName() as $k) {
+            unset($model->$k);
+        }
+
+        $model->clearModifiedProperties();
+        $model->setNew();
+    }
+
+    /**
+     * Recursively persist the given model and its set relations
+     *
+     * @param Model $model
+     *
+     * @return void
+     */
+    protected function saveGraph(Model $model): void
+    {
+        if (! $model->isMutable()) {
+            throw new RuntimeException(sprintf(
+                'setNew() must be called on a model of type %s before saving it',
+                get_class($model)
+            ));
+        }
+
+        if ($this->activeSaves->offsetExists($model)) {
+            throw new RuntimeException('Reference loop detected, failed to save');
+        }
+
+        $this->activeSaves->offsetSet($model);
+
+        // Snapshot what to cascade before persisting, since persisting resets change tracking. Only
+        // explicitly set relations are considered (lazy loaders are closures, skipped by the iterator).
+        // A relation is cascaded when the caller (re)assigned it, or when its already-materialized value
+        // has pending changes of its own.
+        $set = iterator_to_array($model);
+        $isNew = $model->isNew();
+        $modifiedRelations = $isNew ? [] : $model->getModifiedProperties();
+
+        /** @var array<string, BelongsTo> $dependencies */
+        $dependencies = [];
+        /** @var array<string, Relation> $children */
+        $children = [];
+        /** @var array<string, BelongsToMany> $manyToMany */
+        $manyToMany = [];
+        foreach ($this->resolver->getRelations($model) as $name => $relation) {
+            if (
+                ! array_key_exists($name, $set)
+                || (! $isNew && ! isset($modifiedRelations[$name]) && ! $this->hasPendingChanges($set[$name]))
+            ) {
+                // The relation has no changes to persist
+                continue;
+            }
+
+            if ($relation instanceof BelongsTo) {
+                $dependencies[$name] = $relation;
+            } elseif ($relation instanceof BelongsToMany) {
+                $manyToMany[$name] = $relation;
+            } else {
+                $children[$name] = $relation;
+            }
+        }
+
+        if ($model->isMarkedForDeletion()) {
+            // Delete path
+            $this->saveManyToMany($model, $manyToMany, $set);
+            $this->saveChildren($model, $children, $set);
+            $this->delete($model);
+            $this->saveChangedParents($dependencies, $set);
+        } else {
+            // Insert / Update
+            $this->saveParents($model, $dependencies, $set);
+            $this->persist($model, $this->resolver->getBehaviors($model));
+            $this->saveChildren($model, $children, $set);
+            $this->saveManyToMany($model, $manyToMany, $set);
+        }
+
+        $this->activeSaves->offsetUnset($model);
+    }
+
+    /**
+     * Persist the model's BelongsTo parents and copy their keys into the model's foreign keys
+     *
+     * Parents are persisted before the model so the foreign key on this (source) table points at an
+     * existing row. An explicitly assigned `null` clears the foreign key instead.
+     *
+     * @param Model $model
+     * @param array<string, BelongsTo> $dependencies
+     * @param array<string, mixed> $set
+     *
+     * @return void
+     */
+    private function saveParents(Model $model, array $dependencies, array $set): void
+    {
+        foreach ($dependencies as $name => $relation) {
+            $related = $set[$name];
+            if ($related === null) {
+                foreach ($relation->determineKeys($model) as $sourceColumn) {
+                    $model->$sourceColumn = null;
+                }
+
+                continue;
+            }
+
+            if (! $related instanceof Model) {
+                continue;
+            }
+
+            if ($related->isMutable()) {
+                $this->saveGraph($related);
+            }
+
+            foreach ($relation->determineKeys($model) as $targetColumn => $sourceColumn) {
+                $model->$sourceColumn = $related->$targetColumn;
+            }
+        }
+    }
+
+    /**
+     * Persist the model's HasOne/HasMany children, copying the model's key into each child's foreign key
+     *
+     * Children are persisted after the model so its (possibly generated) key is known and can be copied in.
+     * When the relation's collection is in replace mode ({@see Collection::sync()}), any stored child no longer
+     * in the desired set is removed afterwards via {@see self::reconcileChildren()}. In merge mode, explicitly
+     * detached children are deleted.
+     *
+     * @param Model $model
+     * @param array<string, Relation> $children
+     * @param array<string, mixed> $set
+     *
+     * @return void
+     */
+    private function saveChildren(Model $model, array $children, array $set): void
+    {
+        foreach ($children as $name => $relation) {
+            $keys = $relation->determineKeys($model);
+            $value = $set[$name];
+            $desired = [];
+            foreach ($this->childrenOf($value) as $child) {
+                foreach ($keys as $targetColumn => $sourceColumn) {
+                    $child->$targetColumn = $model->$sourceColumn;
+                }
+
+                $this->saveGraph($child);
+                $desired[] = $child;
+            }
+
+            if ($value instanceof Collection) {
+                if ($value->isReplacing()) {
+                    if ($model->isMarkedForDeletion() && ! empty($desired)) {
+                        throw new RuntimeException(
+                            'A relation of a deleted model in replace mode should not carry attachments'
+                        );
+                    }
+
+                    $this->reconcileChildren($relation, $model, $keys, $desired);
+                } else {
+                    foreach ($value->getDetachments() as $child) {
+                        $this->delete($child);
+                    }
+                }
+
+                $value->clearPendingChanges();
+            }
+        }
+    }
+
+    /**
+     * Remove the stored children of a HasOne/HasMany relation that are absent from the desired set
+     *
+     * Only invoked for a collection in replace mode
+     *
+     * @param Relation $relation The HasOne/HasMany relation being reconciled
+     * @param Model $model The source model whose key scopes the children
+     * @param array<string, string> $keys The relation's foreign => source key map ({@see Relation::determineKeys()})
+     * @param Model[] $desired The children that should remain, already persisted
+     *
+     * @return void
+     */
+    private function reconcileChildren(Relation $relation, Model $model, array $keys, array $desired): void
+    {
+        $targetClass = $relation->getTargetClass();
+        $childModel = new $targetClass();
+        $childBehaviors = $this->resolver->getBehaviors($childModel);
+        $keyColumns = (array) $childModel->getKeyName();
+
+        // Restrict to the children sharing this model's key, persisted with the child's behaviors
+        $condition = [];
+        foreach ($keys as $foreignColumn => $sourceColumn) {
+            $condition[$foreignColumn] = $childBehaviors->persistProperty($model->$sourceColumn, $foreignColumn);
+        }
+
+        // The in-memory identities of the children that should remain
+        $desiredKeys = [];
+        foreach ($desired as $child) {
+            $identity = $this->childIdentity($child, $keyColumns);
+            if ($identity !== null) {
+                $desiredKeys[$identity] = true;
+            }
+        }
+
+        $isSoftDeletable = $childModel->isSoftDeletable();
+        $changedAtColumn = $childModel->getChangedAtColumn();
+        $columns = $keyColumns;
+        if ($isSoftDeletable) {
+            $columns[] = $childModel::DELETED;
+        }
+
+        if ($changedAtColumn !== null) {
+            $columns[] = $changedAtColumn;
+        }
+
+        $select = (new Select())
+            ->from($childModel->getTableName())
+            ->columns($columns)
+            ->where($this->createCondition($condition));
+
+        foreach ($this->db->select($select)->fetchAll(PDO::FETCH_ASSOC) as $row) {
+            if ($isSoftDeletable && $row[$childModel::DELETED] === 'y') {
+                continue;
+            }
+
+            // Rebuild the stored child in its in-memory form, so its identity is comparable to the desired
+            // set and delete() re-persists it identically; then let delete() pick hard vs soft
+            $orphan = new $targetClass();
+            foreach ($keyColumns as $keyColumn) {
+                $orphan->$keyColumn = $childBehaviors->retrieveProperty($row[$keyColumn], $keyColumn);
+            }
+
+            if ($changedAtColumn !== null) {
+                $orphan->$changedAtColumn = $childBehaviors->retrieveProperty($row[$changedAtColumn], $changedAtColumn);
+            }
+
+            $orphan->setNew(false);
+
+            if (! isset($desiredKeys[$this->childIdentity($orphan, $keyColumns)])) {
+                $this->delete($orphan);
+            }
+        }
+    }
+
+    /**
+     * Build the composite identity of the given child from its in-memory primary key
+     *
+     * This only serves as helper so {@see self::reconcileChildren()} can tell children apart,
+     * it is never handed to the database
+     *
+     * @param Model $child
+     * @param string[] $keyColumns
+     *
+     * @return ?string
+     */
+    private function childIdentity(Model $child, array $keyColumns): ?string
+    {
+        $parts = [];
+        foreach ($keyColumns as $keyColumn) {
+            if (! $child->hasProperty($keyColumn)) {
+                return null;
+            }
+
+            $parts[] = (string) $child->$keyColumn;
+        }
+
+        return implode("\0", $parts);
+    }
+
+    /**
+     * Persist the changed BelongsTo parents of a model that is being deleted
+     *
+     * A parent is independent of the model and outlives it, so an explicit deletion or in-place edit of a
+     * parent is still applied — after the model is gone, since the model references the parent. A newly
+     * created parent is left untouched ({@see Model::isModified()} is false for it), as persisting it for a
+     * model that is being deleted would be meaningless.
+     *
+     * @param array<string, BelongsTo> $dependencies
+     * @param array<string, mixed> $set
+     *
+     * @return void
+     */
+    private function saveChangedParents(array $dependencies, array $set): void
+    {
+        foreach ($dependencies as $name => $relation) {
+            $related = $set[$name];
+            if ($related instanceof Model && ($related->isMarkedForDeletion() || $related->isModified())) {
+                $this->saveGraph($related);
+            }
+        }
+    }
+
+    /**
+     * Save the targets of the given many-to-many relations and reconcile each junction
+     *
+     * @param Model $model The source model
+     * @param array<string, BelongsToMany> $manyToMany The many-to-many relations to persist, keyed by name
+     * @param array<string, mixed> $set The model's set properties, as snapshotted by {@see self::saveGraph()}
+     *
+     * @return void
+     */
+    private function saveManyToMany(Model $model, array $manyToMany, array $set): void
+    {
+        foreach ($manyToMany as $name => $relation) {
+            $collection = $set[$name];
+            if (! $collection instanceof Collection) {
+                continue;
+            }
+
+            $attach = [];
+            foreach ($collection->getMembersToSave() as $target) {
+                // Models are marked as new when they are hard deleted, so cache the value before saving
+                $isDeleted = $target->isMarkedForDeletion();
+
+                if ($target->isMutable()) {
+                    $this->saveGraph($target);
+                }
+
+                if (! $isDeleted) {
+                    $attach[] = $target;
+                }
+            }
+
+            $this->reconcileJunction(
+                $relation,
+                $model,
+                $attach,
+                $collection->getDetachments(),
+                $collection->isReplacing()
+            );
+
+            $collection->clearPendingChanges();
+        }
+    }
+
+    /**
+     * Get whether the given relation value carries unsaved changes that should be cascaded
+     *
+     * @param mixed $value A relation value as snapshotted in the set (a model, a collection, or null)
+     *
+     * @return bool
+     */
+    private function hasPendingChanges(mixed $value): bool
+    {
+        if ($value instanceof Collection) {
+            return $value->hasPendingChanges();
+        }
+
+        if ($value instanceof Model) {
+            return $value->isMutable() && ($value->isNew() || $value->isModified() || $value->isMarkedForDeletion());
+        }
+
+        return false;
+    }
+
+    /**
+     * Insert or update the given model's own row
+     *
+     * @param Model $model
+     * @param Behaviors $behaviors
+     *
+     * @return void
+     */
+    protected function persist(Model $model, Behaviors $behaviors): void
+    {
+        if (! $model->isNew() && ! $model->isModified()) {
+            return;
+        }
+
+        $this->ensureOlderThanBaseline($model);
+
+        // Insert case
+        if ($model->isNew()) {
+            $this->stampChangedAt($model);
+            $this->db->insert($model->getTableName(), $this->extract($model, $behaviors));
+
+            $keyName = $model->getKeyName();
+            if (is_string($keyName) && ! $model->hasProperty($keyName)) {
+                // Single auto-increment key that wasn't assigned by the application
+                $id = $this->db->lastInsertId();
+                if ($id !== false) {
+                    $model->$keyName = $behaviors->retrieveProperty((int) $id, $keyName);
+                }
+            }
+
+            $model->clearModifiedProperties();
+            $model->setNew(false);
+
+            return;
+        }
+
+        foreach ((array) $model->getKeyName() as $key) {
+            if ($model->isModified($key)) {
+                throw new RuntimeException(sprintf(
+                    'Cannot update %s: primary key column "%s" was modified',
+                    get_class($model),
+                    $key
+                ));
+            }
+        }
+
+        if (empty(array_intersect_key($model->getModifiedProperties(), $this->getTableColumnMap($model)))) {
+            // Only relations changed; there is nothing to update on this row
+            $model->clearModifiedProperties();
+
+            return;
+        }
+
+        $condition = $this->createPrimaryKeyCondition($model, $behaviors);
+        if ($condition === null) {
+            throw new RuntimeException(
+                sprintf(
+                    'Cannot update %s without a primary key value',
+                    get_class($model)
+                )
+            );
+        }
+
+        // Stamp only now that we know an UPDATE will actually go out. The stamp adds
+        // the changedAtColumn to the modified set, so re-extract to pick it up.
+        $this->stampChangedAt($model);
+        $data = $this->extract($model, $behaviors, $model->getModifiedProperties());
+
+        $this->db->update($model->getTableName(), $data, $condition);
+
+        $model->clearModifiedProperties();
+    }
+
+    /**
+     * Stamp the model's {@see Model::getChangedAtColumn()} column with the current time if it has one
+     *
+     * `changed_at` must be strictly increasing, so the stamped value is {@see self::now()} or the current
+     * maximum plus one, whichever is greater. Otherwise the daemon would ignore the change.
+     *
+     * Reading `MAX(changed_at)` under {@see self::$db}'s serializable isolation prevents a phantom read
+     *
+     * @param Model $model
+     *
+     * @return void
+     */
+    protected function stampChangedAt(Model $model): void
+    {
+        $column = $model->getChangedAtColumn();
+        if ($column === null) {
+            return;
+        }
+
+        $currentMax = $this->db->select(
+            (new Select())
+                ->from($model->getTableName())
+                ->columns([$column => new Expression("MAX($column)")])
+        )->fetchColumn();
+
+        $next = max($this->now(), (int) $currentMax + 1);
+        $model->$column = $this->resolver->getBehaviors($model)->retrieveProperty($next, $column);
+    }
+
+    /**
+     * Get the current time used for {@see self::stampChangedAt()}
+     *
+     * @return int
+     */
+    protected function now(): int
+    {
+        return (int) (microtime(true) * 1000);
+    }
+
+    /**
+     * Verify the model has not been changed after {@see self::$baselineAt}
+     *
+     * A {@see RuntimeException} is thrown if the model's {@see Model::getChangedAtColumn()} is younger than
+     * {@see self::$baselineAt}.
+     *
+     * Does nothing if {@see self::$baselineAt} is null, {@see Model::getChangedAtColumn()} is null
+     * or if the model is new.
+     *
+     * @param Model $model
+     *
+     * @return void
+     *
+     * @throws RuntimeException If the model changed after the baseline, or its changed_at was not loaded
+     */
+    protected function ensureOlderThanBaseline(Model $model): void
+    {
+        if ($this->baselineAt === null || $model->isNew()) {
+            return;
+        }
+
+        $column = $model->getChangedAtColumn();
+        if ($column === null) {
+            return;
+        }
+
+        if (! $model->hasProperty($column)) {
+            throw new RuntimeException(
+                sprintf('Cannot verify baseline: %s was loaded without its %s column', get_class($model), $column)
+            );
+        }
+
+        if ($model->$column > $this->baselineAt) {
+            throw new RuntimeException(
+                sprintf('Failed to save: %s has changed after baseline', get_class($model))
+            );
+        }
+    }
+
+    /**
+     * Build the column => value data for the given model, converting values for persistence
+     *
+     * @param Model $model
+     * @param Behaviors $behaviors
+     * @param ?array<string, true> $only Restrict to this set of property names, or `null` for all
+     *
+     * @return array<string, mixed>
+     */
+    protected function extract(Model $model, Behaviors $behaviors, ?array $only = null): array
+    {
+        $columns = $this->getTableColumnMap($model);
+        $data = [];
+
+        // Restrict to the given property set (e.g. the modified set) or fall back to all set properties.
+        $properties = $only ?? $model;
+        foreach ($properties as $property => $_) {
+            if (! isset($columns[$property])) {
+                continue;
+            }
+
+            $data[$property] = $behaviors->persistProperty($model->$property, $property);
+        }
+
+        return $data;
+    }
+
+    /**
+     * Build a WHERE condition matching the given model by its primary key, converting values for persistence
+     *
+     * @param Model $model
+     * @param Behaviors $behaviors
+     *
+     * @return ?array<string, mixed> Null if the model has no value for (part of) its primary key
+     */
+    protected function createPrimaryKeyCondition(Model $model, Behaviors $behaviors): ?array
+    {
+        $columns = [];
+
+        foreach ((array) $model->getKeyName() as $key) {
+            if (! $model->hasProperty($key)) {
+                return null;
+            }
+
+            $columns[$key] = $behaviors->persistProperty($model->$key, $key);
+        }
+
+        return $this->createCondition($columns);
+    }
+
+    /**
+     * Reconcile the junction rows of a many-to-many relation against the collection's pending changes
+     *
+     * Missing links are inserted (and soft-deleted ones revived), detached links are removed, and in replace
+     * mode any stored link absent from the desired set is removed too. Removal soft-deletes when the junction
+     * model has a {@see Model::DELETED} column, otherwise deletes the row.
+     *
+     * @param BelongsToMany $relation
+     * @param Model $source
+     * @param Model[] $attach Targets whose links must exist
+     * @param Model[] $detach Targets whose links must be removed
+     * @param bool $replace Whether to remove stored links absent from $attach
+     *
+     * @return void
+     */
+    protected function reconcileJunction(
+        BelongsToMany $relation,
+        Model $source,
+        array $attach,
+        array $detach,
+        bool $replace
+    ): void {
+        [$sourceToJunction, $junctionToTarget] = iterator_to_array(
+            $relation->setSource($source)->resolve(),
+            false
+        );
+
+        $sourceBehaviors = $this->resolver->getBehaviors($source);
+
+        $junction = $sourceToJunction[1];
+        $sourceColumns = [];
+        foreach ($sourceToJunction[2] as $sourceJunctionColumn => $sourceColumn) {
+            $sourceColumns[$sourceJunctionColumn] =
+                $sourceBehaviors->persistProperty($source->$sourceColumn, $sourceColumn);
+        }
+
+        $targetKeys = $junctionToTarget[2];
+        $targetColumn = array_key_first($targetKeys);
+        $junctionColumn = $targetKeys[$targetColumn];
+
+        $desired = $this->junctionIdentities($attach, $targetColumn);
+        $toDetach = $this->junctionIdentities($detach, $targetColumn);
+
+        if ($junction instanceof Model && $junction->isSoftDeletable()) {
+            $this->reconcileSoftDeleteJunction(
+                $junction,
+                $sourceColumns,
+                $junctionColumn,
+                $desired,
+                $toDetach,
+                $replace
+            );
+
+            return;
+        }
+
+        $table = $junction->getTableName();
+        $stored = $this->fetchJunctionRows($table, $sourceColumns, $junctionColumn);
+
+        foreach ($desired as $identity => $value) {
+            if (! array_key_exists($identity, $stored)) {
+                $this->db->insert($table, array_merge($sourceColumns, [$junctionColumn => $value]));
+            }
+        }
+
+        $removals = $replace ? array_diff_key($stored, $desired) : array_intersect_key($toDetach, $stored);
+        foreach ($removals as $value) {
+            $this->db->delete($table, $this->createCondition(array_merge($sourceColumns, [$junctionColumn => $value])));
+        }
+    }
+
+    /**
+     * Reconcile a soft-delete junction: insert/revive desired links and mark removed links deleted
+     *
+     * @param Model $junction A junction model
+     * @param array<string, mixed> $sourceColumns
+     * @param string $junctionColumn
+     * @param array<string, mixed> $desired Target values keyed by identity
+     * @param array<string, mixed> $toDetach Target values keyed by identity
+     * @param bool $replace
+     *
+     * @return void
+     */
+    private function reconcileSoftDeleteJunction(
+        Model $junction,
+        array $sourceColumns,
+        string $junctionColumn,
+        array $desired,
+        array $toDetach,
+        bool $replace
+    ): void {
+        $behaviors = $this->resolver->getBehaviors($junction);
+        $deletedColumn = $junction::DELETED;
+        $changedAtColumn = $junction->getChangedAtColumn();
+        $keyColumns = (array) $junction->getKeyName();
+        $columns = array_unique(array_merge($keyColumns, [$junctionColumn, $deletedColumn]));
+        if ($changedAtColumn !== null) {
+            $columns[] = $changedAtColumn;
+        }
+
+        $select = (new Select())
+            ->from($junction->getTableName())
+            ->columns($columns)
+            ->where($this->createCondition($sourceColumns));
+
+        $stored = [];
+        $storedValues = [];
+        $storedChangedAt = [];
+        $storedKeys = [];
+        foreach ($this->db->select($select)->fetchAll(PDO::FETCH_ASSOC) as $row) {
+            $identity = (string) $row[$junctionColumn];
+            $stored[$identity] = $row[$deletedColumn] === 'y';
+            $storedValues[$identity] = $row[$junctionColumn];
+            if ($changedAtColumn !== null) {
+                $storedChangedAt[$identity] = $row[$changedAtColumn];
+            }
+
+            $keyValues = [];
+            foreach ($keyColumns as $keyColumn) {
+                $keyValues[$keyColumn] = $behaviors->retrieveProperty($row[$keyColumn], $keyColumn);
+            }
+
+            $storedKeys[$identity] = $keyValues;
+        }
+
+        foreach ($desired as $identity => $value) {
+            // In case the link exists, but is marked as deleted, marking the model as not `new` ensures the
+            // `delete` flag of the existing row is updated and no insert with an existing PK is attempted
+            $isNew = ! isset($stored[$identity]);
+            if (! $isNew && ! $stored[$identity]) {
+                continue;
+            }
+
+            $link = $this->makeJunctionLink(
+                get_class($junction),
+                $sourceColumns,
+                $junctionColumn,
+                $value,
+                $isNew,
+                $storedKeys[$identity] ?? []
+            );
+            if (! $isNew && $changedAtColumn !== null) {
+                $link->$changedAtColumn = $behaviors->retrieveProperty($storedChangedAt[$identity], $changedAtColumn);
+            }
+
+            $link->{$deletedColumn} = false;
+            $this->persist($link, $behaviors);
+        }
+
+        // Of the currently-stored, still-live links, remove those absent from the desired set (replace mode)
+        // or explicitly detached (merge mode). Both keep the stored value, so persist() re-derives the same row.
+        $toRemove = [];
+        foreach ($stored as $identity => $isDeleted) {
+            if ($isDeleted) {
+                continue;
+            }
+
+            $shouldRemove = $replace ? ! isset($desired[$identity]) : isset($toDetach[$identity]);
+            if ($shouldRemove) {
+                $toRemove[$identity] = $storedValues[$identity];
+            }
+        }
+
+        foreach ($toRemove as $identity => $value) {
+            $link = $this->makeJunctionLink(
+                get_class($junction),
+                $sourceColumns,
+                $junctionColumn,
+                $value,
+                false,
+                $storedKeys[$identity]
+            );
+            if ($changedAtColumn !== null) {
+                $link->$changedAtColumn = $behaviors->retrieveProperty($storedChangedAt[$identity], $changedAtColumn);
+            }
+
+            $link->{$deletedColumn} = true;
+            $this->persist($link, $behaviors);
+        }
+    }
+
+    /**
+     * Read the identities of the links currently stored for the given source
+     *
+     * @param string $table
+     * @param array<string, mixed> $sourceColumns
+     * @param string $junctionColumn The junction's target-side column to read back
+     *
+     * @return array<string, mixed> The stored target values, keyed by identity
+     */
+    private function fetchJunctionRows(string $table, array $sourceColumns, string $junctionColumn): array
+    {
+        $select = (new Select())
+            ->from($table)
+            ->columns($junctionColumn)
+            ->where($this->createCondition($sourceColumns));
+
+        $stored = [];
+        foreach ($this->db->select($select)->fetchAll(PDO::FETCH_ASSOC) as $row) {
+            $stored[(string) $row[$junctionColumn]] = $row[$junctionColumn];
+        }
+
+        return $stored;
+    }
+
+    /**
+     * Build the target identities of the given models keyed by string identity, converting for persistence
+     *
+     * @param Model[] $targets
+     * @param string $targetColumn The target's key column
+     *
+     * @return array<string, mixed> The persisted target values keyed by identity
+     */
+    private function junctionIdentities(array $targets, string $targetColumn): array
+    {
+        $identities = [];
+        foreach ($targets as $target) {
+            $behaviors = $this->resolver->getBehaviors($target);
+            $value = $behaviors->persistProperty($target->$targetColumn, $targetColumn);
+            $identities[(string) $value] = $value;
+        }
+
+        return $identities;
+    }
+
+    /**
+     * Build a junction link model for one link, with its source and target key columns set
+     *
+     * @param class-string<Model> $model
+     * @param array<string, mixed> $sourceColumns
+     * @param string $junctionColumn
+     * @param mixed $targetValue
+     * @param bool $isNew
+     *
+     * @return Model
+     */
+    private function makeJunctionLink(
+        string $model,
+        array $sourceColumns,
+        string $junctionColumn,
+        mixed $targetValue,
+        bool $isNew,
+        array $keyColumns
+    ): Model {
+        $link = new $model();
+        foreach ($sourceColumns as $column => $value) {
+            $link->$column = $value;
+        }
+
+        $link->$junctionColumn = $targetValue;
+        foreach ($keyColumns as $column => $value) {
+            $link->$column = $value;
+        }
+
+        $link->setNew($isNew);
+
+        return $link;
+    }
+
+    /**
+     * Build an equality WHERE condition (`column = ?`) from a column => value map, as ipl-sql expects
+     *
+     * @param array<string, mixed> $columns
+     *
+     * @return array<string, mixed>
+     */
+    private function createCondition(array $columns): array
+    {
+        $condition = [];
+        foreach ($columns as $column => $value) {
+            $condition[$column . ' = ?'] = $value;
+        }
+
+        return $condition;
+    }
+
+    /**
+     * Get the model's table columns and cache them per model class
+     *
+     * @param Model $model
+     *
+     * @return array<string, true>
+     */
+    protected function getTableColumnMap(Model $model): array
+    {
+        $class = get_class($model);
+        if (isset($this->tableColumnCache[$class])) {
+            return $this->tableColumnCache[$class];
+        }
+
+        $columns = array_fill_keys($model->getTableColumns(), true);
+        $this->tableColumnCache[$class] = $columns;
+
+        return $columns;
+    }
+
+    /**
+     * Yield the child models to persist for a HasOne/HasMany relation value
+     *
+     * @param mixed $value A model (HasOne), a collection (HasMany) or null
+     *
+     * @return iterable<Model>
+     */
+    private function childrenOf(mixed $value): iterable
+    {
+        if ($value instanceof Model) {
+            return [$value];
+        }
+
+        if ($value instanceof Collection) {
+            return $value->getMembersToSave();
+        }
+
+        return [];
+    }
+}

--- a/library/Notifications/Common/Model.php
+++ b/library/Notifications/Common/Model.php
@@ -1,0 +1,259 @@
+<?php
+
+// SPDX-FileCopyrightText: 2026 Icinga GmbH <https://icinga.com>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+namespace Icinga\Module\Notifications\Common;
+
+use ipl\Orm\Query;
+use LogicException;
+use RuntimeException;
+
+/**
+ * Base class for all module models that tracks the changes made to a model
+ *
+ * Records which properties have changed since the model was loaded, and whether the model has been
+ * persisted yet, so the {@see EntityManager} can store a model and write only what actually changed.
+ *
+ * {@see self::setNew()} must be called explicitly when creating a new instance, it tells the {@see EntityManager}
+ * whether to insert or update
+ */
+abstract class Model extends \ipl\Orm\Model
+{
+    /** @var string The column used for soft deletes */
+    public const DELETED = 'deleted';
+
+    /** @var string The column that holds the timestamp of the most recent modification */
+    public const CHANGED_AT = 'changed_at';
+
+    /** @var ?bool Whether this model is newly created and does not yet exist in the database */
+    private ?bool $isNew = null;
+
+    /** @var bool Whether the model is marked for deletion on the next {@see EntityManager::save()} */
+    private bool $markedForDeletion = false;
+
+    /** @var array<string, true> Names of properties modified since the model was loaded */
+    private array $modifiedProperties = [];
+
+    /**
+     * Get whether this object's properties are mutable
+     *
+     * @return bool
+     */
+    public function isMutable(): bool
+    {
+        return isset($this->isNew);
+    }
+
+    /**
+     * Get whether this entity is newly created and does not yet exist in the database
+     *
+     * @return bool
+     *
+     * @throws RuntimeException In case the model is not mutable
+     */
+    public function isNew(): bool
+    {
+        if (! $this->isMutable()) {
+            throw new RuntimeException('Model is not mutable');
+        }
+
+        return $this->isNew;
+    }
+
+    /**
+     * Set whether this entity is newly created and does not yet exist in the database
+     *
+     * @param bool $new
+     *
+     * @return $this
+     *
+     * @throws LogicException In case the model is marked for deletion
+     */
+    public function setNew(bool $new = true): static
+    {
+        if ($this->isMarkedForDeletion()) {
+            throw new LogicException('Model is marked for deletion');
+        }
+
+        $this->isNew = $new;
+
+        return $this;
+    }
+
+    /**
+     * Get whether the entity, or the given property, has unsaved modifications
+     *
+     * Always returns false for new entities, which carry no change tracking.
+     *
+     * @param ?string $property The property to check, or null to check the whole entity
+     *
+     * @return bool
+     *
+     * @throws RuntimeException In case the model is not mutable
+     */
+    public function isModified(?string $property = null): bool
+    {
+        if (! $this->isMutable()) {
+            throw new RuntimeException('Model is not mutable');
+        }
+
+        if ($property === null) {
+            return ! empty($this->modifiedProperties);
+        }
+
+        return isset($this->modifiedProperties[$property]);
+    }
+
+    /**
+     * Get the names of all properties modified since the entity was loaded as a set keyed by name
+     *
+     * The keys may be columns or relations.
+     *
+     * @return array<string, true>
+     *
+     * @throws RuntimeException In case the model is not mutable
+     */
+    public function getModifiedProperties(): array
+    {
+        if (! $this->isMutable()) {
+            throw new RuntimeException('Model is not mutable');
+        }
+
+        return $this->modifiedProperties;
+    }
+
+    /**
+     * Reset change tracking and accept the current values as the new baseline
+     *
+     * @return $this
+     *
+     * @throws RuntimeException In case the model is not mutable
+     */
+    public function clearModifiedProperties(): static
+    {
+        if (! $this->isMutable()) {
+            throw new RuntimeException('Model is not mutable');
+        }
+
+        $this->modifiedProperties = [];
+        $this->markedForDeletion = false;
+
+        return $this;
+    }
+
+    /**
+     * Get whether the model's table uses soft deletes
+     *
+     * @return bool
+     */
+    public function isSoftDeletable(): bool
+    {
+        return in_array(static::DELETED, $this->getTableColumns(), true);
+    }
+
+    /**
+     * Mark the model for deletion on the next {@see EntityManager::save()} and return it
+     *
+     * If the model uses soft deletes this function must set the {@see static::DELETED} property
+     *
+     * @return $this
+     *
+     * @throws LogicException In case the model is new
+     */
+    public function delete(): static
+    {
+        if ($this->isNew()) {
+            throw new LogicException('Model is marked as new and cannot be deleted');
+        }
+
+        $this->markedForDeletion = true;
+        if ($this->isSoftDeletable()) {
+            $this->{static::DELETED} = true;
+        }
+
+        return $this;
+    }
+
+    /**
+     * Get whether the model is marked for deletion on the next {@see EntityManager::save()}
+     *
+     * @return bool
+     */
+    public function isMarkedForDeletion(): bool
+    {
+        return $this->markedForDeletion;
+    }
+
+    /**
+     * Get all columns of the model's table, including the primary key
+     *
+     * @return string[]
+     */
+    public function getTableColumns(): array
+    {
+        return array_merge((array) $this->getKeyName(), $this->getColumns());
+    }
+
+    /**
+     * Get the column used to store the timestamp of the most recent modification to the row
+     *
+     * `changed_at` is the schema-wide convention, returns null if the model has no such column
+     *
+     * @return ?string
+     */
+    public function getChangedAtColumn(): ?string
+    {
+        return in_array(static::CHANGED_AT, $this->getTableColumns(), true) ? static::CHANGED_AT : null;
+    }
+
+    protected function setProperty(string $key, mixed $value): static
+    {
+        if ($this->isMutable()) {
+            $original = null;
+            if ($this->hasProperty($key)) {
+                if ($value instanceof Query) {
+                    // Queries are accepted since the only justifiable reason
+                    // to expect them is when a closure is being resolved
+                    if (! $this->isAToOneRelation($value, $key)) {
+                        $value = Collection::fromLoaded($value);
+                    }
+
+                    return parent::setProperty($key, $value);
+                }
+
+                $original = $this->getProperty($key);
+                if ($original instanceof Collection) {
+                    // Interpret assignments to a collection as synchronization
+                    $original->sync($value);
+
+                    return $this;
+                }
+            }
+
+            if (! $this->isNew() && ! isset($this->modifiedProperties[$key]) && $value !== $original) {
+                $this->modifiedProperties[$key] = true;
+            }
+        }
+
+        return parent::setProperty($key, $value);
+    }
+
+    /**
+     * Get whether the given relation is a to-one relation
+     *
+     * In the far future this should be easier to detect as the model
+     * should not be responsible for collection transformation anymore.
+     *
+     * @param Query $query
+     * @param string $relationName
+     *
+     * @return bool
+     */
+    private function isAToOneRelation(Query $query, string $relationName): bool
+    {
+        $relations = $query->getResolver()->getRelations($this);
+
+        return $relations->has($relationName) && $relations->get($relationName)->isOne();
+    }
+}

--- a/library/Notifications/Model/AvailableChannelType.php
+++ b/library/Notifications/Model/AvailableChannelType.php
@@ -5,7 +5,7 @@
 
 namespace Icinga\Module\Notifications\Model;
 
-use ipl\Orm\Model;
+use Icinga\Module\Notifications\Common\Model;
 use ipl\Orm\Query;
 use ipl\Orm\Relations;
 

--- a/library/Notifications/Model/BrowserSession.php
+++ b/library/Notifications/Model/BrowserSession.php
@@ -6,9 +6,9 @@
 namespace Icinga\Module\Notifications\Model;
 
 use DateTime;
+use Icinga\Module\Notifications\Common\Model;
 use ipl\Orm\Behavior\MillisecondTimestamp;
 use ipl\Orm\Behaviors;
-use ipl\Orm\Model;
 
 /**
  * @property string $php_session_id

--- a/library/Notifications/Model/Channel.php
+++ b/library/Notifications/Model/Channel.php
@@ -6,10 +6,10 @@
 namespace Icinga\Module\Notifications\Model;
 
 use DateTime;
+use Icinga\Module\Notifications\Common\Model;
 use ipl\Orm\Behavior\BoolCast;
 use ipl\Orm\Behavior\MillisecondTimestamp;
 use ipl\Orm\Behaviors;
-use ipl\Orm\Model;
 use ipl\Orm\Query;
 use ipl\Orm\Relations;
 use ipl\Web\Widget\Icon;

--- a/library/Notifications/Model/Contact.php
+++ b/library/Notifications/Model/Contact.php
@@ -6,10 +6,10 @@
 namespace Icinga\Module\Notifications\Model;
 
 use DateTime;
+use Icinga\Module\Notifications\Common\Model;
 use ipl\Orm\Behavior\BoolCast;
 use ipl\Orm\Behavior\MillisecondTimestamp;
 use ipl\Orm\Behaviors;
-use ipl\Orm\Model;
 use ipl\Orm\Query;
 use ipl\Orm\Relations;
 
@@ -87,7 +87,7 @@ class Contact extends Model
             ->setCandidateKey('default_channel_id');
 
         $relations->belongsToMany('incident', Incident::class)
-            ->through('incident_contact')
+            ->through(IncidentContact::class)
             ->setJoinType('LEFT');
 
         $relations->hasMany('incident_contact', IncidentContact::class);
@@ -101,7 +101,11 @@ class Contact extends Model
         $relations->hasMany('contactgroup_member', ContactgroupMember::class);
 
         $relations->belongsToMany('contactgroup', Contactgroup::class)
-            ->through('contactgroup_member')
+            ->through(ContactgroupMember::class)
+            ->setJoinType('LEFT');
+
+        $relations->belongsToMany('rule_escalation', RuleEscalation::class)
+            ->through(RuleEscalationRecipient::class)
             ->setJoinType('LEFT');
     }
 }

--- a/library/Notifications/Model/ContactAddress.php
+++ b/library/Notifications/Model/ContactAddress.php
@@ -6,10 +6,10 @@
 namespace Icinga\Module\Notifications\Model;
 
 use DateTime;
+use Icinga\Module\Notifications\Common\Model;
 use ipl\Orm\Behavior\BoolCast;
 use ipl\Orm\Behavior\MillisecondTimestamp;
 use ipl\Orm\Behaviors;
-use ipl\Orm\Model;
 use ipl\Orm\Query;
 use ipl\Orm\Relations;
 

--- a/library/Notifications/Model/Contactgroup.php
+++ b/library/Notifications/Model/Contactgroup.php
@@ -6,10 +6,10 @@
 namespace Icinga\Module\Notifications\Model;
 
 use DateTime;
+use Icinga\Module\Notifications\Common\Model;
 use ipl\Orm\Behavior\BoolCast;
 use ipl\Orm\Behavior\MillisecondTimestamp;
 use ipl\Orm\Behaviors;
-use ipl\Orm\Model;
 use ipl\Orm\Query;
 use ipl\Orm\Relations;
 
@@ -76,7 +76,7 @@ class Contactgroup extends Model
         $relations->hasMany('contactgroup_member', ContactgroupMember::class);
         $relations
             ->belongsToMany('contact', Contact::class)
-            ->through('contactgroup_member')
+            ->through(ContactgroupMember::class)
             ->setJoinType('LEFT');
     }
 }

--- a/library/Notifications/Model/ContactgroupMember.php
+++ b/library/Notifications/Model/ContactgroupMember.php
@@ -6,10 +6,10 @@
 namespace Icinga\Module\Notifications\Model;
 
 use DateTime;
+use Icinga\Module\Notifications\Common\Model;
 use ipl\Orm\Behavior\BoolCast;
 use ipl\Orm\Behavior\MillisecondTimestamp;
 use ipl\Orm\Behaviors;
-use ipl\Orm\Model;
 use ipl\Orm\Query;
 use ipl\Orm\Relations;
 

--- a/library/Notifications/Model/Incident.php
+++ b/library/Notifications/Model/Incident.php
@@ -7,12 +7,12 @@ namespace Icinga\Module\Notifications\Model;
 
 use DateTime;
 use Icinga\Module\Notifications\Common\Database;
+use Icinga\Module\Notifications\Common\Model;
 use Icinga\Module\Notifications\Common\Severity;
 use ipl\Orm\Behavior\Binary;
 use ipl\Orm\Behavior\EnumCast;
 use ipl\Orm\Behavior\MillisecondTimestamp;
 use ipl\Orm\Behaviors;
-use ipl\Orm\Model;
 use ipl\Orm\Query;
 use ipl\Orm\Relations;
 use ipl\Sql\Connection;
@@ -107,7 +107,7 @@ class Incident extends Model
         $relations->belongsTo('object', Objects::class);
 
         $relations->belongsToMany('contact', Contact::class)
-            ->through('incident_contact');
+            ->through(IncidentContact::class);
 
         $relations->hasMany('incident_contact', IncidentContact::class);
         $relations->hasMany('incident_history', IncidentHistory::class);

--- a/library/Notifications/Model/IncidentContact.php
+++ b/library/Notifications/Model/IncidentContact.php
@@ -5,7 +5,7 @@
 
 namespace Icinga\Module\Notifications\Model;
 
-use ipl\Orm\Model;
+use Icinga\Module\Notifications\Common\Model;
 use ipl\Orm\Query;
 use ipl\Orm\Relations;
 

--- a/library/Notifications/Model/IncidentHistory.php
+++ b/library/Notifications/Model/IncidentHistory.php
@@ -7,11 +7,11 @@ namespace Icinga\Module\Notifications\Model;
 
 use DateTime;
 use Icinga\Module\Notifications\Common\Database;
+use Icinga\Module\Notifications\Common\Model;
 use Icinga\Module\Notifications\Common\Severity;
 use ipl\Orm\Behavior\EnumCast;
 use ipl\Orm\Behavior\MillisecondTimestamp;
 use ipl\Orm\Behaviors;
-use ipl\Orm\Model;
 use ipl\Orm\Query;
 use ipl\Orm\Relations;
 use ipl\Sql\Connection;

--- a/library/Notifications/Model/ObjectIdTag.php
+++ b/library/Notifications/Model/ObjectIdTag.php
@@ -5,10 +5,10 @@
 
 namespace Icinga\Module\Notifications\Model;
 
+use Icinga\Module\Notifications\Common\Model;
 use ipl\Orm\Behavior\Binary;
 use ipl\Orm\Behaviors;
 use ipl\Orm\Contract\RewriteFilterBehavior;
-use ipl\Orm\Model;
 use ipl\Orm\Relations;
 use ipl\Stdlib\Filter;
 use ipl\Stdlib\Filter\Condition;

--- a/library/Notifications/Model/Objects.php
+++ b/library/Notifications/Model/Objects.php
@@ -5,12 +5,12 @@
 
 namespace Icinga\Module\Notifications\Model;
 
+use Icinga\Module\Notifications\Common\Model;
 use Icinga\Module\Notifications\Hook\ObjectsRendererHook;
 use Icinga\Module\Notifications\Model\Behavior\IdTagAggregator;
 use ipl\Html\ValidHtml;
 use ipl\Orm\Behavior\Binary;
 use ipl\Orm\Behaviors;
-use ipl\Orm\Model;
 use ipl\Orm\Query;
 use ipl\Orm\Relations;
 

--- a/library/Notifications/Model/Rotation.php
+++ b/library/Notifications/Model/Rotation.php
@@ -7,13 +7,13 @@ namespace Icinga\Module\Notifications\Model;
 
 use DateTime;
 use Icinga\Module\Notifications\Common\Database;
+use Icinga\Module\Notifications\Common\Model;
 use Icinga\Module\Notifications\Forms\RotationConfigForm;
 use Icinga\Util\Json;
 use ipl\Orm\Behavior\BoolCast;
 use ipl\Orm\Behavior\MillisecondTimestamp;
 use ipl\Orm\Behaviors;
 use ipl\Orm\Contract\RetrieveBehavior;
-use ipl\Orm\Model;
 use ipl\Orm\Query;
 use ipl\Orm\Relations;
 use ipl\Sql\Expression;
@@ -95,7 +95,7 @@ class Rotation extends Model
         ]));
         $behaviors->add(new BoolCast(['deleted']));
         $behaviors->add(new class implements RetrieveBehavior {
-            public function retrieve(Model $model): void
+            public function retrieve(\ipl\Orm\Model $model): void
             {
                 /** @var Rotation $model */
                 if (isset($model->options) && is_string($model->options)) {

--- a/library/Notifications/Model/Rotation.php
+++ b/library/Notifications/Model/Rotation.php
@@ -110,7 +110,7 @@ class Rotation extends Model
      *
      * @return void
      */
-    public function delete(): void
+    public function deleteRotation(): void
     {
         $db = Database::get();
         $transactionStarted = false;

--- a/library/Notifications/Model/RotationMember.php
+++ b/library/Notifications/Model/RotationMember.php
@@ -6,10 +6,10 @@
 namespace Icinga\Module\Notifications\Model;
 
 use DateTime;
+use Icinga\Module\Notifications\Common\Model;
 use ipl\Orm\Behavior\BoolCast;
 use ipl\Orm\Behavior\MillisecondTimestamp;
 use ipl\Orm\Behaviors;
-use ipl\Orm\Model;
 use ipl\Orm\Query;
 use ipl\Orm\Relations;
 

--- a/library/Notifications/Model/Rule.php
+++ b/library/Notifications/Model/Rule.php
@@ -6,10 +6,10 @@
 namespace Icinga\Module\Notifications\Model;
 
 use DateTime;
+use Icinga\Module\Notifications\Common\Model;
 use ipl\Orm\Behavior\BoolCast;
 use ipl\Orm\Behavior\MillisecondTimestamp;
 use ipl\Orm\Behaviors;
-use ipl\Orm\Model;
 use ipl\Orm\Query;
 use ipl\Orm\Relations;
 

--- a/library/Notifications/Model/RuleEscalation.php
+++ b/library/Notifications/Model/RuleEscalation.php
@@ -6,10 +6,10 @@
 namespace Icinga\Module\Notifications\Model;
 
 use DateTime;
+use Icinga\Module\Notifications\Common\Model;
 use ipl\Orm\Behavior\BoolCast;
 use ipl\Orm\Behavior\MillisecondTimestamp;
 use ipl\Orm\Behaviors;
-use ipl\Orm\Model;
 use ipl\Orm\Query;
 use ipl\Orm\Relations;
 
@@ -93,7 +93,7 @@ class RuleEscalation extends Model
 
         $relations
             ->belongsToMany('contact', Contact::class)
-            ->through('rule_escalation_recipient')
+            ->through(RuleEscalationRecipient::class)
             ->setJoinType('LEFT');
 
         $relations->hasMany('rule_escalation_recipient', RuleEscalationRecipient::class)

--- a/library/Notifications/Model/RuleEscalationRecipient.php
+++ b/library/Notifications/Model/RuleEscalationRecipient.php
@@ -6,10 +6,10 @@
 namespace Icinga\Module\Notifications\Model;
 
 use DateTime;
+use Icinga\Module\Notifications\Common\Model;
 use ipl\Orm\Behavior\BoolCast;
 use ipl\Orm\Behavior\MillisecondTimestamp;
 use ipl\Orm\Behaviors;
-use ipl\Orm\Model;
 use ipl\Orm\Query;
 use ipl\Orm\Relations;
 

--- a/library/Notifications/Model/Schedule.php
+++ b/library/Notifications/Model/Schedule.php
@@ -6,10 +6,10 @@
 namespace Icinga\Module\Notifications\Model;
 
 use DateTime;
+use Icinga\Module\Notifications\Common\Model;
 use ipl\Orm\Behavior\BoolCast;
 use ipl\Orm\Behavior\MillisecondTimestamp;
 use ipl\Orm\Behaviors;
-use ipl\Orm\Model;
 use ipl\Orm\Query;
 use ipl\Orm\Relations;
 

--- a/library/Notifications/Model/Source.php
+++ b/library/Notifications/Model/Source.php
@@ -7,12 +7,12 @@ namespace Icinga\Module\Notifications\Model;
 
 use DateTime;
 use Icinga\Application\Logger;
+use Icinga\Module\Notifications\Common\Model;
 use Icinga\Module\Notifications\Common\SourceHookLocator;
 use Icinga\Module\Notifications\Hook\V2\SourceHook;
 use ipl\Orm\Behavior\BoolCast;
 use ipl\Orm\Behavior\MillisecondTimestamp;
 use ipl\Orm\Behaviors;
-use ipl\Orm\Model;
 use ipl\Orm\Query;
 use ipl\Orm\Relations;
 use ipl\Web\Widget\Icon;

--- a/library/Notifications/Model/Timeperiod.php
+++ b/library/Notifications/Model/Timeperiod.php
@@ -6,10 +6,10 @@
 namespace Icinga\Module\Notifications\Model;
 
 use DateTime;
+use Icinga\Module\Notifications\Common\Model;
 use ipl\Orm\Behavior\BoolCast;
 use ipl\Orm\Behavior\MillisecondTimestamp;
 use ipl\Orm\Behaviors;
-use ipl\Orm\Model;
 use ipl\Orm\Query;
 use ipl\Orm\Relations;
 

--- a/library/Notifications/Model/TimeperiodEntry.php
+++ b/library/Notifications/Model/TimeperiodEntry.php
@@ -6,10 +6,10 @@
 namespace Icinga\Module\Notifications\Model;
 
 use DateTime;
+use Icinga\Module\Notifications\Common\Model;
 use ipl\Orm\Behavior\BoolCast;
 use ipl\Orm\Behavior\MillisecondTimestamp;
 use ipl\Orm\Behaviors;
-use ipl\Orm\Model;
 use ipl\Orm\Query;
 use ipl\Orm\Relations;
 use Recurr\Frequency;

--- a/library/Notifications/Web/Form/ContactForm.php
+++ b/library/Notifications/Web/Form/ContactForm.php
@@ -360,7 +360,7 @@ class ContactForm extends CompatForm
 
                 /** @var Rotation $rotation */
                 foreach ($rotations as $rotation) {
-                    $rotation->delete();
+                    $rotation->deleteRotation();
                 }
             }
         }

--- a/test/php/Lib/EntityManager/Badge.php
+++ b/test/php/Lib/EntityManager/Badge.php
@@ -1,0 +1,34 @@
+<?php
+
+// SPDX-FileCopyrightText: 2026 Icinga GmbH <https://icinga.com>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+namespace Tests\Icinga\Module\Notifications\Lib\EntityManager;
+
+use Icinga\Module\Notifications\Common\Model;
+use ipl\Orm\Relations;
+
+class Badge extends Model
+{
+    public function getTableName(): string
+    {
+        return 'badge';
+    }
+
+    public function getKeyName(): string
+    {
+        return 'id';
+    }
+
+    public function getColumns(): array
+    {
+        return ['name'];
+    }
+
+    public function createRelations(Relations $relations): void
+    {
+        // Reciprocal of Gadget->badge, named after Gadget's table (see the note on Tag->gadget)
+        $relations->belongsToMany('gadget', Gadget::class)
+            ->through(GadgetBadge::class);
+    }
+}

--- a/test/php/Lib/EntityManager/Charm.php
+++ b/test/php/Lib/EntityManager/Charm.php
@@ -1,0 +1,39 @@
+<?php
+
+// SPDX-FileCopyrightText: 2026 Icinga GmbH <https://icinga.com>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+namespace Tests\Icinga\Module\Notifications\Lib\EntityManager;
+
+use Icinga\Module\Notifications\Common\Model;
+use ipl\Orm\Behavior\Binary;
+use ipl\Orm\Behaviors;
+use ipl\Orm\Relations;
+
+class Charm extends Model
+{
+    public function getTableName(): string
+    {
+        return 'charm';
+    }
+
+    public function getKeyName(): string
+    {
+        return 'id';
+    }
+
+    public function getColumns(): array
+    {
+        return ['trinket_id', 'label'];
+    }
+
+    public function createBehaviors(Behaviors $behaviors): void
+    {
+        $behaviors->add(new Binary(['trinket_id']));
+    }
+
+    public function createRelations(Relations $relations): void
+    {
+        $relations->belongsTo('trinket', Trinket::class);
+    }
+}

--- a/test/php/Lib/EntityManager/Flag.php
+++ b/test/php/Lib/EntityManager/Flag.php
@@ -1,0 +1,33 @@
+<?php
+
+// SPDX-FileCopyrightText: 2026 Icinga GmbH <https://icinga.com>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+namespace Tests\Icinga\Module\Notifications\Lib\EntityManager;
+
+use Icinga\Module\Notifications\Common\Model;
+use ipl\Orm\Behavior\BoolCast;
+use ipl\Orm\Behaviors;
+
+class Flag extends Model
+{
+    public function getTableName(): string
+    {
+        return 'flag';
+    }
+
+    public function getKeyName(): string
+    {
+        return 'id';
+    }
+
+    public function getColumns(): array
+    {
+        return ['label', 'enabled'];
+    }
+
+    public function createBehaviors(Behaviors $behaviors): void
+    {
+        $behaviors->add(new BoolCast(['enabled']));
+    }
+}

--- a/test/php/Lib/EntityManager/Gadget.php
+++ b/test/php/Lib/EntityManager/Gadget.php
@@ -1,0 +1,45 @@
+<?php
+
+// SPDX-FileCopyrightText: 2026 Icinga GmbH <https://icinga.com>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+namespace Tests\Icinga\Module\Notifications\Lib\EntityManager;
+
+use Icinga\Module\Notifications\Common\Model;
+use ipl\Orm\Relations;
+
+class Gadget extends Model
+{
+    public function getTableName(): string
+    {
+        return 'gadget';
+    }
+
+    public function getKeyName(): string
+    {
+        return 'id';
+    }
+
+    public function getColumns(): array
+    {
+        return ['workshop_id', 'name'];
+    }
+
+    public function createRelations(Relations $relations): void
+    {
+        $relations->belongsTo('workshop', Workshop::class);
+
+        $relations->belongsToMany('sticker', Sticker::class)
+            ->through('gadget_sticker');
+
+        // Declared through a junction model that carries a `deleted` column, so the EntityManager
+        // syncs these links with soft-deletes and revives instead of hard deletes.
+        $relations->belongsToMany('tag', Tag::class)
+            ->through(GadgetTag::class);
+
+        // Like `tag`, but its junction model is keyed by a surrogate `id` rather than the natural
+        // gadget_id/badge_id pair, mirroring the real rule_escalation_recipient table.
+        $relations->belongsToMany('badge', Badge::class)
+            ->through(GadgetBadge::class);
+    }
+}

--- a/test/php/Lib/EntityManager/GadgetBadge.php
+++ b/test/php/Lib/EntityManager/GadgetBadge.php
@@ -1,0 +1,48 @@
+<?php
+
+// SPDX-FileCopyrightText: 2026 Icinga GmbH <https://icinga.com>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+namespace Tests\Icinga\Module\Notifications\Lib\EntityManager;
+
+use Icinga\Module\Notifications\Common\Model;
+use ipl\Orm\Behavior\BoolCast;
+use ipl\Orm\Behavior\MillisecondTimestamp;
+use ipl\Orm\Behaviors;
+
+/**
+ * Soft-delete junction model linking {@see Gadget} and {@see Badge} through a surrogate primary key.
+ *
+ * Unlike {@see GadgetTag} (whose primary key is the natural pair of foreign keys, mirroring
+ * contactgroup_member), this junction is keyed by a standalone `id` and carries a `deleted` column,
+ * mirroring the real rule_escalation_recipient table. The surrogate key is not part of the source or
+ * target columns, so reviving or soft-deleting a link must load and carry it to scope the UPDATE.
+ */
+class GadgetBadge extends Model
+{
+    public function getTableName(): string
+    {
+        return 'gadget_badge';
+    }
+
+    public function getKeyName(): string
+    {
+        return 'id';
+    }
+
+    public function getColumns(): array
+    {
+        return ['gadget_id', 'badge_id', 'changed_at', 'deleted'];
+    }
+
+    public function createBehaviors(Behaviors $behaviors): void
+    {
+        $behaviors->add(new MillisecondTimestamp(['changed_at']));
+        $behaviors->add(new BoolCast(['deleted']));
+    }
+
+    public function isSoftDeletable(): bool
+    {
+        return true;
+    }
+}

--- a/test/php/Lib/EntityManager/GadgetTag.php
+++ b/test/php/Lib/EntityManager/GadgetTag.php
@@ -1,0 +1,47 @@
+<?php
+
+// SPDX-FileCopyrightText: 2026 Icinga GmbH <https://icinga.com>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+namespace Tests\Icinga\Module\Notifications\Lib\EntityManager;
+
+use Icinga\Module\Notifications\Common\Model;
+use ipl\Orm\Behavior\BoolCast;
+use ipl\Orm\Behavior\MillisecondTimestamp;
+use ipl\Orm\Behaviors;
+
+/**
+ * Soft-delete junction model linking {@see Gadget} and {@see Tag}.
+ *
+ * Carries a `deleted` column (and `changed_at`), so the EntityManager syncs the link table with
+ * soft-deletes and revives rather than hard deletes — mirroring the real contactgroup_member and
+ * rule_escalation_recipient junctions.
+ */
+class GadgetTag extends Model
+{
+    public function getTableName(): string
+    {
+        return 'gadget_tag';
+    }
+
+    public function getKeyName(): array
+    {
+        return ['gadget_id', 'tag_id'];
+    }
+
+    public function getColumns(): array
+    {
+        return ['gadget_id', 'tag_id', 'changed_at', 'deleted'];
+    }
+
+    public function createBehaviors(Behaviors $behaviors): void
+    {
+        $behaviors->add(new MillisecondTimestamp(['changed_at']));
+        $behaviors->add(new BoolCast(['deleted']));
+    }
+
+    public function isSoftDeletable(): bool
+    {
+        return true;
+    }
+}

--- a/test/php/Lib/EntityManager/Pairing.php
+++ b/test/php/Lib/EntityManager/Pairing.php
@@ -1,0 +1,26 @@
+<?php
+
+// SPDX-FileCopyrightText: 2026 Icinga GmbH <https://icinga.com>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+namespace Tests\Icinga\Module\Notifications\Lib\EntityManager;
+
+use Icinga\Module\Notifications\Common\Model;
+
+class Pairing extends Model
+{
+    public function getTableName(): string
+    {
+        return 'pairing';
+    }
+
+    public function getKeyName(): array
+    {
+        return ['left_id', 'right_id'];
+    }
+
+    public function getColumns(): array
+    {
+        return ['left_id', 'right_id', 'label'];
+    }
+}

--- a/test/php/Lib/EntityManager/RecordingConnection.php
+++ b/test/php/Lib/EntityManager/RecordingConnection.php
@@ -1,0 +1,72 @@
+<?php
+
+// SPDX-FileCopyrightText: 2026 Icinga GmbH <https://icinga.com>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+namespace Tests\Icinga\Module\Notifications\Lib\EntityManager;
+
+use ipl\Sql\Connection;
+use ipl\Sql\Sql;
+use PDOStatement;
+
+/**
+ * Test double for {@see Connection} that records every write call and forwards to the real parent.
+ *
+ * Lets tests assert that the EntityManager issues the *exact* set of writes expected — and skips
+ * the ones it shouldn't — without giving up the real sqlite-backed end-to-end execution.
+ */
+class RecordingConnection extends Connection
+{
+    /**
+     * Each entry is one recorded write keyed by `method` ('insert'|'update'|'delete'), plus `table`,
+     * `data` (for insert/update), and `condition` (for update/delete).
+     *
+     * @var list<array<string, mixed>>
+     */
+    public array $calls = [];
+
+    public function insert(string $table, iterable $data): PDOStatement
+    {
+        $data = is_array($data) ? $data : iterator_to_array($data);
+        $this->calls[] = ['method' => 'insert', 'table' => $table, 'data' => $data];
+
+        return parent::insert($table, $data);
+    }
+
+    public function update(
+        string|array $table,
+        iterable $data,
+        string|array|null $condition = null,
+        string $operator = Sql::ALL
+    ): PDOStatement {
+        $data = is_array($data) ? $data : iterator_to_array($data);
+        $this->calls[] = [
+            'method'    => 'update',
+            'table'     => $table,
+            'data'      => $data,
+            'condition' => $condition,
+        ];
+
+        return parent::update($table, $data, $condition, $operator);
+    }
+
+    public function delete(
+        string|array $table,
+        string|array|null $condition = null,
+        string $operator = Sql::ALL
+    ): PDOStatement {
+        $this->calls[] = ['method' => 'delete', 'table' => $table, 'condition' => $condition];
+
+        return parent::delete($table, $condition, $operator);
+    }
+
+    /**
+     * Drop the recorded calls so subsequent assertions only see writes from the next action
+     *
+     * @return void
+     */
+    public function resetCalls(): void
+    {
+        $this->calls = [];
+    }
+}

--- a/test/php/Lib/EntityManager/Stamped.php
+++ b/test/php/Lib/EntityManager/Stamped.php
@@ -1,0 +1,39 @@
+<?php
+
+// SPDX-FileCopyrightText: 2026 Icinga GmbH <https://icinga.com>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+namespace Tests\Icinga\Module\Notifications\Lib\EntityManager;
+
+use Icinga\Module\Notifications\Common\Model;
+use ipl\Orm\Behavior\MillisecondTimestamp;
+use ipl\Orm\Behaviors;
+use ipl\Orm\Relations;
+
+class Stamped extends Model
+{
+    public function getTableName(): string
+    {
+        return 'stamped';
+    }
+
+    public function getKeyName(): string
+    {
+        return 'id';
+    }
+
+    public function getColumns(): array
+    {
+        return ['name', 'changed_at'];
+    }
+
+    public function createBehaviors(Behaviors $behaviors): void
+    {
+        $behaviors->add(new MillisecondTimestamp(['changed_at']));
+    }
+
+    public function createRelations(Relations $relations): void
+    {
+        $relations->hasMany('stamped_note', StampedNote::class);
+    }
+}

--- a/test/php/Lib/EntityManager/StampedNote.php
+++ b/test/php/Lib/EntityManager/StampedNote.php
@@ -1,0 +1,46 @@
+<?php
+
+// SPDX-FileCopyrightText: 2026 Icinga GmbH <https://icinga.com>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+namespace Tests\Icinga\Module\Notifications\Lib\EntityManager;
+
+use Icinga\Module\Notifications\Common\Model;
+use ipl\Orm\Behavior\BoolCast;
+use ipl\Orm\Behavior\MillisecondTimestamp;
+use ipl\Orm\Behaviors;
+use ipl\Orm\Relations;
+
+/**
+ * HasMany child of {@see Stamped} that carries a `deleted` column, so the EntityManager soft-deletes
+ * an orphaned note (via sync()) or a detached note rather than removing the row. It also carries a
+ * `changed_at` column so the baseline (optimistic locking) check has a modification time to compare.
+ */
+class StampedNote extends Model
+{
+    public function getTableName(): string
+    {
+        return 'stamped_note';
+    }
+
+    public function getKeyName(): string
+    {
+        return 'id';
+    }
+
+    public function getColumns(): array
+    {
+        return ['stamped_id', 'text', 'changed_at', 'deleted'];
+    }
+
+    public function createBehaviors(Behaviors $behaviors): void
+    {
+        $behaviors->add(new MillisecondTimestamp(['changed_at']));
+        $behaviors->add(new BoolCast(['deleted']));
+    }
+
+    public function createRelations(Relations $relations): void
+    {
+        $relations->belongsTo('stamped', Stamped::class);
+    }
+}

--- a/test/php/Lib/EntityManager/Sticker.php
+++ b/test/php/Lib/EntityManager/Sticker.php
@@ -1,0 +1,33 @@
+<?php
+
+// SPDX-FileCopyrightText: 2026 Icinga GmbH <https://icinga.com>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+namespace Tests\Icinga\Module\Notifications\Lib\EntityManager;
+
+use Icinga\Module\Notifications\Common\Model;
+use ipl\Orm\Relations;
+
+class Sticker extends Model
+{
+    public function getTableName(): string
+    {
+        return 'sticker';
+    }
+
+    public function getKeyName(): string
+    {
+        return 'id';
+    }
+
+    public function getColumns(): array
+    {
+        return ['label'];
+    }
+
+    public function createRelations(Relations $relations): void
+    {
+        $relations->belongsToMany('gadget', Gadget::class)
+            ->through('gadget_sticker');
+    }
+}

--- a/test/php/Lib/EntityManager/Tag.php
+++ b/test/php/Lib/EntityManager/Tag.php
@@ -1,0 +1,36 @@
+<?php
+
+// SPDX-FileCopyrightText: 2026 Icinga GmbH <https://icinga.com>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+namespace Tests\Icinga\Module\Notifications\Lib\EntityManager;
+
+use Icinga\Module\Notifications\Common\Model;
+use ipl\Orm\Relations;
+
+class Tag extends Model
+{
+    public function getTableName(): string
+    {
+        return 'tag';
+    }
+
+    public function getKeyName(): string
+    {
+        return 'id';
+    }
+
+    public function getColumns(): array
+    {
+        return ['name'];
+    }
+
+    public function createRelations(Relations $relations): void
+    {
+        // Reciprocal of Gadget->tag, named after Gadget's table so the many-to-many relation is lazily
+        // readable from a loaded Tag: Query::derive() joins the target back through a relation named
+        // after the source's table.
+        $relations->belongsToMany('gadget', Gadget::class)
+            ->through(GadgetTag::class);
+    }
+}

--- a/test/php/Lib/EntityManager/TickingEntityManager.php
+++ b/test/php/Lib/EntityManager/TickingEntityManager.php
@@ -1,0 +1,24 @@
+<?php
+
+// SPDX-FileCopyrightText: 2026 Icinga GmbH <https://icinga.com>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+namespace Tests\Icinga\Module\Notifications\Lib\EntityManager;
+
+use Icinga\Module\Notifications\Common\EntityManager;
+
+/**
+ * Test double for {@see EntityManager} whose {@see now()} returns a deterministic, monotonically
+ * increasing tick (1000, 2000, 3000, … ms) instead of the wall clock, so `changed_at`-stamping
+ * assertions can use exact values.
+ */
+class TickingEntityManager extends EntityManager
+{
+    /** @var int Ticks elapsed; the next {@see now()} returns (this + 1) * 1000. Reset per test. */
+    public static int $tick = 0;
+
+    protected function now(): int
+    {
+        return ++static::$tick * 1000;
+    }
+}

--- a/test/php/Lib/EntityManager/Trinket.php
+++ b/test/php/Lib/EntityManager/Trinket.php
@@ -1,0 +1,39 @@
+<?php
+
+// SPDX-FileCopyrightText: 2026 Icinga GmbH <https://icinga.com>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+namespace Tests\Icinga\Module\Notifications\Lib\EntityManager;
+
+use Icinga\Module\Notifications\Common\Model;
+use ipl\Orm\Behavior\Binary;
+use ipl\Orm\Behaviors;
+use ipl\Orm\Relations;
+
+class Trinket extends Model
+{
+    public function getTableName(): string
+    {
+        return 'trinket';
+    }
+
+    public function getKeyName(): string
+    {
+        return 'id';
+    }
+
+    public function getColumns(): array
+    {
+        return ['name'];
+    }
+
+    public function createBehaviors(Behaviors $behaviors): void
+    {
+        $behaviors->add(new Binary(['id']));
+    }
+
+    public function createRelations(Relations $relations): void
+    {
+        $relations->hasMany('charm', Charm::class);
+    }
+}

--- a/test/php/Lib/EntityManager/Workshop.php
+++ b/test/php/Lib/EntityManager/Workshop.php
@@ -1,0 +1,32 @@
+<?php
+
+// SPDX-FileCopyrightText: 2026 Icinga GmbH <https://icinga.com>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+namespace Tests\Icinga\Module\Notifications\Lib\EntityManager;
+
+use Icinga\Module\Notifications\Common\Model;
+use ipl\Orm\Relations;
+
+class Workshop extends Model
+{
+    public function getTableName(): string
+    {
+        return 'workshop';
+    }
+
+    public function getKeyName(): string
+    {
+        return 'id';
+    }
+
+    public function getColumns(): array
+    {
+        return ['name'];
+    }
+
+    public function createRelations(Relations $relations): void
+    {
+        $relations->hasMany('gadget', Gadget::class);
+    }
+}

--- a/test/php/library/Notifications/Common/EntityManagerTest.php
+++ b/test/php/library/Notifications/Common/EntityManagerTest.php
@@ -1,0 +1,1356 @@
+<?php
+
+// SPDX-FileCopyrightText: 2026 Icinga GmbH <https://icinga.com>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+namespace Tests\Icinga\Module\Notifications\Common;
+
+use DateTime;
+use DateTimeInterface;
+use Exception;
+use Icinga\Module\Notifications\Common\Collection;
+use Icinga\Module\Notifications\Common\EntityManager;
+use Icinga\Module\Notifications\Common\Model;
+use LogicException;
+use PDO;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+use Tests\Icinga\Module\Notifications\Lib\EntityManager\Badge;
+use Tests\Icinga\Module\Notifications\Lib\EntityManager\Charm;
+use Tests\Icinga\Module\Notifications\Lib\EntityManager\Flag;
+use Tests\Icinga\Module\Notifications\Lib\EntityManager\Gadget;
+use Tests\Icinga\Module\Notifications\Lib\EntityManager\GadgetBadge;
+use Tests\Icinga\Module\Notifications\Lib\EntityManager\GadgetTag;
+use Tests\Icinga\Module\Notifications\Lib\EntityManager\Pairing;
+use Tests\Icinga\Module\Notifications\Lib\EntityManager\RecordingConnection;
+use Tests\Icinga\Module\Notifications\Lib\EntityManager\Stamped;
+use Tests\Icinga\Module\Notifications\Lib\EntityManager\StampedNote;
+use Tests\Icinga\Module\Notifications\Lib\EntityManager\Sticker;
+use Tests\Icinga\Module\Notifications\Lib\EntityManager\Tag;
+use Tests\Icinga\Module\Notifications\Lib\EntityManager\TickingEntityManager;
+use Tests\Icinga\Module\Notifications\Lib\EntityManager\Trinket;
+use Tests\Icinga\Module\Notifications\Lib\EntityManager\Workshop;
+use ipl\Stdlib\Filter;
+
+/**
+ * End-to-end tests for the {@see EntityManager} write path.
+ *
+ * Each test runs against a fresh in-memory sqlite schema (see {@see self::setUp()}) through a
+ * {@see RecordingConnection}, so an assertion can inspect both the resulting rows and the exact set of
+ * writes issued. The EntityManager is a {@see TickingEntityManager}, whose clock returns 1s, 2s, 3s, …
+ * on successive `changed_at` stamps, so those stamps can be asserted by value.
+ *
+ * The fixtures model the relation shapes the real schema uses: HasMany ({@see Workshop}->gadget),
+ * BelongsTo ({@see Gadget}->workshop), a plain many-to-many ({@see Gadget}->sticker) and a soft-delete
+ * many-to-many through a junction model ({@see Gadget}->tag via {@see GadgetTag}), plus models exercising
+ * compound keys ({@see Pairing}), binary keys ({@see Trinket}/{@see Charm}) and column behaviors
+ * ({@see Flag}, {@see Stamped}).
+ */
+class EntityManagerTest extends TestCase
+{
+    /** @var RecordingConnection The sqlite-backed connection recording every write of the test */
+    protected $db;
+
+    /**
+     * Create the in-memory schema and reset the deterministic clock before each test
+     */
+    protected function setUp(): void
+    {
+        $this->db = $this->connect();
+        TickingEntityManager::$tick = 0;
+    }
+
+    /**
+     * Open a fresh in-memory sqlite connection and create the fixture schema on it
+     *
+     * @param array<int, mixed> $pdoOptions Extra PDO options, e.g. to reproduce driver quirks
+     *
+     * @return RecordingConnection
+     */
+    protected function connect(array $pdoOptions = []): RecordingConnection
+    {
+        $config = ['db' => 'sqlite', 'dbname' => ':memory:'];
+        if ($pdoOptions) {
+            $config['options'] = $pdoOptions;
+        }
+
+        $db = new RecordingConnection($config);
+        $db->exec(
+            'CREATE TABLE workshop (id INTEGER PRIMARY KEY AUTOINCREMENT, name VARCHAR NOT NULL);'
+            . 'CREATE TABLE gadget (id INTEGER PRIMARY KEY AUTOINCREMENT, workshop_id INTEGER, name VARCHAR NOT NULL);'
+            . 'CREATE TABLE sticker (id INTEGER PRIMARY KEY AUTOINCREMENT, label VARCHAR NOT NULL);'
+            . 'CREATE TABLE gadget_sticker (gadget_id INTEGER NOT NULL, sticker_id INTEGER NOT NULL);'
+            . 'CREATE TABLE flag (id INTEGER PRIMARY KEY AUTOINCREMENT,
+                label VARCHAR NOT NULL, enabled VARCHAR NOT NULL);'
+            . 'CREATE TABLE stamped (id INTEGER PRIMARY KEY AUTOINCREMENT, name VARCHAR NOT NULL, changed_at INTEGER);'
+            . 'CREATE TABLE stamped_note ('
+            . 'id INTEGER PRIMARY KEY AUTOINCREMENT, stamped_id INTEGER NOT NULL, text VARCHAR NOT NULL,'
+            . " changed_at INTEGER, deleted VARCHAR NOT NULL DEFAULT 'n');"
+            . 'CREATE TABLE trinket (id BLOB PRIMARY KEY, name VARCHAR NOT NULL);'
+            . 'CREATE TABLE charm (id INTEGER PRIMARY KEY AUTOINCREMENT,
+                trinket_id BLOB NOT NULL, label VARCHAR NOT NULL);'
+            . 'CREATE TABLE pairing ('
+            . 'left_id INTEGER NOT NULL, right_id INTEGER NOT NULL, label VARCHAR NOT NULL,'
+            . ' PRIMARY KEY (left_id, right_id));'
+            . 'CREATE TABLE tag (id INTEGER PRIMARY KEY AUTOINCREMENT, name VARCHAR NOT NULL);'
+            . 'CREATE TABLE gadget_tag ('
+            . 'gadget_id INTEGER NOT NULL, tag_id INTEGER NOT NULL,'
+            . " changed_at INTEGER NOT NULL, deleted VARCHAR NOT NULL DEFAULT 'n',"
+            . ' PRIMARY KEY (gadget_id, tag_id));'
+            . 'CREATE TABLE badge (id INTEGER PRIMARY KEY AUTOINCREMENT, name VARCHAR NOT NULL);'
+            . 'CREATE TABLE gadget_badge ('
+            . 'id INTEGER PRIMARY KEY AUTOINCREMENT,'
+            . ' gadget_id INTEGER NOT NULL, badge_id INTEGER NOT NULL,'
+            . " changed_at INTEGER NOT NULL, deleted VARCHAR NOT NULL DEFAULT 'n');"
+        );
+
+        return $db;
+    }
+
+    /**
+     * Get a fresh EntityManager bound to the test connection, with a deterministic clock
+     *
+     * @return EntityManager
+     */
+    protected function em(): EntityManager
+    {
+        return new TickingEntityManager($this->db);
+    }
+
+    /**
+     * Run a SELECT and return its rows as plain associative arrays
+     *
+     * @param string $sql
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    protected function rows(string $sql): array
+    {
+        return $this->db->prepexec($sql)->fetchAll(PDO::FETCH_ASSOC);
+    }
+
+    /**
+     * Get the recorded writes (insert/update/delete) that targeted the given table
+     *
+     * Handy for asserting that the EntityManager left a table completely untouched.
+     *
+     * @param string $table
+     *
+     * @return list<array<string, mixed>>
+     */
+    protected function writesTo(string $table): array
+    {
+        return array_values(array_filter($this->db->calls, fn (array $c): bool => $c['table'] === $table));
+    }
+
+    /**
+     * Build and persist a workshop with the given name
+     *
+     * @param string $name
+     *
+     * @return Workshop
+     */
+    protected function savedWorkshop(string $name = 'Acme'): Workshop
+    {
+        $workshop = (new Workshop())->setNew();
+        $workshop->name = $name;
+        $this->em()->save($workshop);
+
+        return $workshop;
+    }
+
+    // -----------------------------------------------------------------------------------------------------
+    // Single-row lifecycle: insert, update, no-op, delete
+    // -----------------------------------------------------------------------------------------------------
+
+    public function testInsertAssignsGeneratedKeyMarksModelLoadedAndEmitsExactlyOneInsert()
+    {
+        $workshop = (new Workshop())->setNew();
+        $this->assertTrue(
+            $workshop->isNew(),
+            'A model flagged with setNew() should report as new before its first save'
+        );
+        $workshop->name = 'Acme';
+
+        $this->em()->save($workshop);
+
+        $this->assertFalse($workshop->isNew(), 'A saved model should no longer be new');
+        $this->assertFalse($workshop->isModified(), 'A saved model should carry no pending changes');
+        $this->assertSame(1, $workshop->id, 'The generated primary key should be written back to the model');
+        $this->assertSame(
+            [['method' => 'insert', 'table' => 'workshop', 'data' => ['name' => 'Acme']]],
+            $this->db->calls,
+            'Inserting a new model should emit exactly one INSERT for that row and nothing else'
+        );
+        $this->assertSame([['id' => 1, 'name' => 'Acme']], $this->rows('SELECT * FROM workshop'));
+    }
+
+    public function testUpdateWritesOnlyTheChangedColumnScopedByPrimaryKey()
+    {
+        $gadget = (new Gadget())->setNew();
+        $gadget->workshop_id = 5;
+        $gadget->name = 'Spanner';
+        $this->em()->save($gadget);
+
+        $this->db->resetCalls();
+        $gadget->name = 'Wrench';
+        $this->assertSame(
+            ['name' => true],
+            $gadget->getModifiedProperties(),
+            'Only the changed column should be tracked as modified'
+        );
+
+        $this->em()->save($gadget);
+
+        $this->assertFalse($gadget->isModified(), 'The model should be unmodified after an update');
+        $this->assertSame(
+            [[
+                'method'    => 'update',
+                'table'     => 'gadget',
+                'data'      => ['name' => 'Wrench'],
+                'condition' => ['id = ?' => $gadget->id],
+            ]],
+            $this->db->calls,
+            'The update should touch only the changed column and match the row by its primary key'
+        );
+        $this->assertSame(
+            [['workshop_id' => 5, 'name' => 'Wrench']],
+            $this->rows('SELECT workshop_id, name FROM gadget'),
+            'The unchanged column should be preserved'
+        );
+    }
+
+    public function testResavingAnUnchangedModelWhetherHydratedOrNotIssuesNoWrites()
+    {
+        $this->savedWorkshop('Acme');
+
+        $loaded = Workshop::on($this->db)->first()->setNew(false);
+        $this->assertNotNull($loaded);
+        $this->assertFalse($loaded->isNew(), 'A hydrated model should not be new');
+        $this->assertFalse($loaded->isModified(), 'A freshly hydrated model should have no changes');
+
+        $this->db->resetCalls();
+        $this->em()->save($loaded);
+        $this->assertSame([], $this->db->calls, 'Saving an unchanged hydrated model should issue no writes');
+    }
+
+    public function testHardDeleteRemovesTheRowClearsTheKeyAndAllowsAFreshReinsert()
+    {
+        $workshop = $this->savedWorkshop('Acme');
+        $oldId = $workshop->id;
+
+        // workshop has no `deleted` column, so this is a hard delete, not a soft delete.
+        $this->db->resetCalls();
+        $this->em()->save($workshop->delete());
+
+        $this->assertSame(
+            [['method' => 'delete', 'table' => 'workshop', 'condition' => ['id = ?' => $oldId]]],
+            $this->db->calls,
+            'A model without a deleted column should be removed with a single DELETE scoped by its primary key'
+        );
+        $this->assertSame([], $this->rows('SELECT * FROM workshop'), 'The row should be gone');
+        $this->assertTrue($workshop->isNew(), 'A deleted model should be treated as new again');
+        $this->assertFalse($workshop->isModified(), 'A deleted model should carry no pending changes');
+        $this->assertFalse($workshop->hasProperty('id'), 'The auto-increment key should be cleared on delete');
+
+        $workshop->name = 'Acme 2';
+        $this->em()->save($workshop);
+        $this->assertNotSame($oldId, $workshop->id, 'A save after delete should receive a fresh auto-increment id');
+        $this->assertSame([['name' => 'Acme 2']], $this->rows('SELECT name FROM workshop'));
+    }
+
+    public function testSoftDeleteKeepsTheRowMarksItDeletedAndRestampsChangedAt()
+    {
+        // gadget_tag carries a `deleted` column, so delete() keeps the row and flips deleted to 'y'
+        // rather than removing it, re-stamping changed_at in the process.
+        $link = (new GadgetTag())->setNew();
+        $link->gadget_id = 1;
+        $link->tag_id = 1;
+        $this->em()->save($link);                       // insert -> changed_at 1000
+
+        $this->em()->save($link->delete());             // soft-deleted -> changed_at 2000
+
+        $this->assertSame(
+            [['gadget_id' => 1, 'tag_id' => 1, 'deleted' => 'y', 'changed_at' => 2000]],
+            $this->rows('SELECT gadget_id, tag_id, deleted, changed_at FROM gadget_tag'),
+            'A model with a deleted column should be kept, marked deleted = y and re-stamped, not removed'
+        );
+    }
+
+    public function testDeletingANewModelThrowsAnException()
+    {
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('Model is marked as new and cannot be deleted');
+
+        $workshop = (new Workshop())->setNew();
+        $workshop->name = 'Acme';
+        $this->em()->save($workshop->delete());
+    }
+
+    public function testChangingMutabilityThrowsAnException()
+    {
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('Model is marked for deletion');
+
+        $link = (new GadgetTag())->setNew(false)->delete();
+        $link->setNew();
+    }
+
+    // -----------------------------------------------------------------------------------------------------
+    // Compound and binary primary keys
+    // -----------------------------------------------------------------------------------------------------
+
+    public function testCompoundKeyIsWrittenScopedAndClearedAcrossItsLifecycle()
+    {
+        // Two rows sharing left_id but differing in right_id: every WHERE has to include *both* key
+        // columns to target exactly one of them.
+        $a = (new Pairing())->setNew();
+        $a->left_id = 1;
+        $a->right_id = 1;
+        $a->label = 'A';
+        $this->em()->save($a);
+
+        $b = (new Pairing())->setNew();
+        $b->left_id = 1;
+        $b->right_id = 2;
+        $b->label = 'B';
+        $this->em()->save($b);
+
+        $this->assertFalse($b->isNew(), 'A saved compound-key model should no longer be new');
+        $this->assertFalse($b->isModified(), 'A saved compound-key model should carry no pending changes');
+        $this->assertSame(1, $b->left_id, 'left_id should not be overwritten by a lastInsertId fetch');
+        $this->assertSame(2, $b->right_id, 'right_id should not be overwritten by a lastInsertId fetch');
+
+        $this->db->resetCalls();
+        $b->label = 'B2';
+        $this->em()->save($b);
+        $this->assertSame(
+            ['left_id = ?' => 1, 'right_id = ?' => 2],
+            $this->db->calls[0]['condition'],
+            'Both key columns should scope the UPDATE'
+        );
+
+        $this->em()->save($b->delete());
+        $this->assertFalse($b->hasProperty('left_id'), 'Each part of a compound key should be cleared on delete');
+        $this->assertFalse($b->hasProperty('right_id'), 'Each part of a compound key should be cleared on delete');
+        $this->assertSame(
+            [['left_id' => 1, 'right_id' => 1, 'label' => 'A']],
+            $this->rows('SELECT left_id, right_id, label FROM pairing'),
+            'Only the row matching all key columns should be updated then deleted; the sibling stays intact'
+        );
+    }
+
+    public function testBinaryKeyRoundTripsThroughInsertUpdateDeleteAndCascade()
+    {
+        $id = hex2bin('deadbeefcafebabe1234567890abcdef');
+
+        $trinket = (new Trinket())->setNew();
+        $trinket->id = $id;
+        $trinket->name = 'Amulet';
+
+        $charm = (new Charm())->setNew();
+        $charm->label = 'rune';
+        $trinket->charm = Collection::create([$charm]);
+
+        $this->em()->save($trinket);
+
+        $this->assertSame($id, $trinket->id, 'The binary key should be unchanged on the model after insert');
+        $this->assertSame($id, $charm->trinket_id, 'The parent binary key should be copied into the child');
+        $this->assertSame(
+            [['id' => $id, 'name' => 'Amulet']],
+            $this->rows('SELECT id, name FROM trinket'),
+            'The binary key should be stored byte-for-byte'
+        );
+        $this->assertSame(
+            [['trinket_id' => $id, 'label' => 'rune']],
+            $this->rows('SELECT trinket_id, label FROM charm'),
+            'The child row should carry the parent binary key'
+        );
+
+        // Update and delete must both match the row by its binary primary key.
+        $trinket->name = 'Charm';
+        $this->em()->save($trinket);
+        $this->assertSame(
+            [['id' => $id, 'name' => 'Charm']],
+            $this->rows('SELECT id, name FROM trinket'),
+            'The UPDATE should match the row by its binary primary key'
+        );
+
+        $loaded = Trinket::on($this->db)->first()->setNew(false);
+        $this->em()->save($loaded->delete());
+        $this->assertSame(
+            [],
+            $this->rows('SELECT id FROM trinket'),
+            'The DELETE should match the row by its binary key'
+        );
+        $this->assertFalse(
+            $loaded->hasProperty('id'),
+            'The application-assigned binary key should be cleared on delete'
+        );
+    }
+
+    // -----------------------------------------------------------------------------------------------------
+    // Cascading a graph in one save()
+    // -----------------------------------------------------------------------------------------------------
+
+    public function testSavingADeepGraphCascadesEveryRelationInOneCall()
+    {
+        // A single cascading save covering, in one go:
+        //   - HasMany:              Workshop->gadget   (the parent key is copied into each child)
+        //   - BelongsToMany (hard): Gadget->sticker    (linked through the plain gadget_sticker table)
+        //   - BelongsToMany (soft): Gadget->tag        (linked through the GadgetTag junction model)
+        // The sticker is shared between both gadgets, so its row is inserted once and linked twice.
+        $spanner = (new Gadget())->setNew();
+        $spanner->name = 'Spanner';
+        $wrench = (new Gadget())->setNew();
+        $wrench->name = 'Wrench';
+
+        $shared = (new Sticker())->setNew();
+        $shared->label = 'fragile';
+        $sharp = (new Tag())->setNew();
+        $sharp->name = 'sharp';
+
+        $spanner->sticker = Collection::create([$shared]);
+        $spanner->tag = Collection::create([$sharp]);
+        $wrench->sticker = Collection::create([$shared]);
+
+        $workshop = (new Workshop())->setNew();
+        $workshop->name = 'Acme';
+        $workshop->gadget = Collection::create([$spanner, $wrench]);
+
+        $this->em()->save($workshop);
+
+        $this->assertSame($workshop->id, $spanner->workshop_id, 'The parent key should be copied into each child');
+        $this->assertSame($workshop->id, $wrench->workshop_id, 'The parent key should be copied into each child');
+        $this->assertFalse($shared->isNew(), 'A cascaded many-to-many target should be persisted');
+        $this->assertFalse(
+            $shared->hasProperty('gadget_id'),
+            'A many-to-many target must not carry the junction foreign key as a stray property'
+        );
+
+        $this->assertSame('workshop', $this->db->calls[0]['table'], 'The parent should be inserted first');
+        $this->assertSame(
+            ['insert'],
+            array_values(array_unique(array_column($this->db->calls, 'method'))),
+            'A fresh graph should be persisted purely with inserts'
+        );
+
+        $this->assertCount(2, $this->writesTo('gadget'), 'Both children should be inserted');
+        $this->assertCount(1, $this->writesTo('sticker'), 'The shared target should be inserted exactly once');
+        $this->assertCount(2, $this->writesTo('gadget_sticker'), 'Each link should be its own junction insert');
+        $this->assertCount(1, $this->writesTo('tag'), 'The tag target should be inserted');
+        $this->assertCount(1, $this->writesTo('gadget_tag'), 'The soft-delete junction row should be inserted');
+
+        $this->assertSame(
+            [['gadget_id' => $spanner->id], ['gadget_id' => $wrench->id]],
+            $this->rows('SELECT gadget_id FROM gadget_sticker ORDER BY gadget_id'),
+            'The shared sticker should be linked to both gadgets'
+        );
+    }
+
+    public function testBelongsToSavesTheParentFirstAndAssigningNullClearsTheForeignKey()
+    {
+        $gadget = (new Gadget())->setNew();
+        $gadget->name = 'Spanner';
+
+        $workshop = (new Workshop())->setNew();
+        $workshop->name = 'Acme';
+        $gadget->workshop = $workshop;
+
+        $this->em()->save($gadget);
+
+        $this->assertFalse($workshop->isNew(), 'The parent should be persisted before the model that references it');
+        $this->assertSame($workshop->id, $gadget->workshop_id, 'The parent key should be copied into the foreign key');
+
+        // Load fresh and clear the relation by assigning null. The property then holds null (not a lazy-loader
+        // closure), so saveGraph sees an explicit assignment and nulls the foreign key.
+        $loaded = Gadget::on($this->db)->first()->setNew(false);
+        $loaded->workshop = null;
+        $this->em()->save($loaded);
+
+        $this->assertSame(
+            [['name' => 'Spanner', 'workshop_id' => null]],
+            $this->rows('SELECT name, workshop_id FROM gadget'),
+            'Assigning null to a BelongsTo should null the foreign key on update'
+        );
+    }
+
+    // -----------------------------------------------------------------------------------------------------
+    // Many-to-many: the Collection API and its persistence semantics
+    // -----------------------------------------------------------------------------------------------------
+
+    public function testCollectionExposesTheStagedManyToManyMembership()
+    {
+        // Seed a gadget linked to two stickers, so reading the relation yields a lazily-loaded Collection.
+        $gadget = (new Gadget())->setNew();
+        $gadget->name = 'Spanner';
+        $fragile = (new Sticker())->setNew();
+        $fragile->label = 'fragile';
+        $heavy = (new Sticker())->setNew();
+        $heavy->label = 'heavy';
+        $gadget->sticker = Collection::create([$fragile, $heavy]);
+        $this->em()->save($gadget);
+
+        $loaded = Gadget::on($this->db)->first()->setNew(false);
+        $stickers = $loaded->sticker;
+        $this->assertInstanceOf(Collection::class, $stickers, 'A to-many relation should read back as a Collection');
+        $this->assertCount(2, $stickers, 'count() should reflect the two loaded members');
+        $this->assertFalse($stickers->isReplacing(), 'A freshly loaded collection should be in merge mode');
+        $this->assertFalse(
+            $stickers->hasPendingChanges(),
+            'A freshly loaded collection should have nothing to persist'
+        );
+        $this->assertFalse($loaded->isModified(), 'Reading a relation must not mark the model modified');
+
+        foreach ($stickers as $sticker) {
+            match ($sticker->label) {
+                'fragile' => $fragile = $sticker,
+                'heavy' => $heavy = $sticker
+            };
+        }
+
+        $shiny = (new Sticker())->setNew();
+        $shiny->label = 'shiny';
+        $stickers->attach($shiny);
+        $this->assertCount(3, $stickers, 'Attaching a new member should add it to the loaded base');
+        $this->assertTrue($stickers->hasPendingChanges(), 'A staged attach should count as a pending change');
+
+        $stickers->detach($fragile);
+        $this->assertCount(2, $stickers, 'A detached member should drop out of the staged view');
+        $this->assertContains(
+            $fragile,
+            $stickers->getDetachments(),
+            'The detached member should be staged for removal'
+        );
+        $stickers->attach($fragile);
+        $this->assertCount(3, $stickers, 'Re-attaching should restore the member');
+        $this->assertSame([], $stickers->getDetachments(), 'Re-attaching a member should cancel its pending detach');
+
+        $only = (new Sticker())->setNew();
+        $only->label = 'only';
+        $stickers->sync([$only]);
+        $this->assertTrue($stickers->isReplacing(), 'sync() puts the collection into replace mode');
+        $this->assertCount(1, $stickers, 'Replace mode should count exactly the synced members, ignoring the base');
+
+        $stickers->clearPendingChanges();
+        $this->assertFalse($stickers->hasPendingChanges(), 'clearPendingChanges() drops the staged writes');
+        $this->assertFalse($stickers->isReplacing(), 'clearPendingChanges() leaves merge mode behind');
+
+        $fresh = (new Workshop())->setNew();
+        $this->assertFalse(isset($fresh->gadget), 'A non-hydrated model should have no collections by default');
+    }
+
+    public function testManyToManyPersistenceIsAdditiveAndDeduplicatesLinks()
+    {
+        $gadget = (new Gadget())->setNew();
+        $gadget->name = 'Spanner';
+        $fragile = (new Sticker())->setNew();
+        $fragile->label = 'fragile';
+        $gadget->sticker = Collection::create([$fragile]);
+        $this->em()->save($gadget);
+
+        $this->assertFalse($fragile->isNew(), 'The target should be persisted');
+        $this->assertSame(
+            [['gadget_id' => $gadget->id, 'sticker_id' => $fragile->id]],
+            $this->rows('SELECT gadget_id, sticker_id FROM gadget_sticker'),
+            'A many-to-many assignment should write the junction row'
+        );
+
+        $loaded = Gadget::on($this->db)->first()->setNew(false);
+        $loaded->sticker = Collection::create([$fragile]);
+        $this->db->resetCalls();
+        $this->em()->save($loaded);
+        $this->assertSame(
+            [],
+            $this->writesTo('gadget_sticker'),
+            'Re-saving an unchanged link must issue no junction write'
+        );
+
+        $heavy = (new Sticker())->setNew();
+        $heavy->label = 'heavy';
+        $loaded = Gadget::on($this->db)->first()->setNew(false);
+        $loaded->sticker = Collection::create([$heavy]);
+        $this->em()->save($loaded);
+        $this->assertSame(
+            [['sticker_id' => $heavy->id]],
+            $this->rows('SELECT sticker_id FROM gadget_sticker ORDER BY sticker_id'),
+            'Overriding the default collection must reconcile the junction'
+        );
+
+        $loaded = Gadget::on($this->db)->first()->setNew(false);
+        $loaded->sticker = [];
+        $this->db->resetCalls();
+        $this->em()->save($loaded);
+        $this->assertCount(
+            1,
+            $this->writesTo('gadget_sticker'),
+            'A bare array assignment must reconcile the junction'
+        );
+        $this->assertCount(0, $this->rows('SELECT * FROM gadget_sticker'), 'Both links must be dropped');
+    }
+
+    public function testManyToManyReconciliationTreatsStringKeysAsEqualToIntKeys()
+    {
+        // Production drivers (MySQL/PgSQL) return keys as strings while persisted models hold them as ints,
+        // so sync must treat those as the same link — re-saving an unchanged relation must stay a no-op,
+        // not delete-and-reinsert. STRINGIFY_FETCHES reproduces that boundary; sqlite otherwise returns
+        // ints on both sides and never exercises it.
+        $db = $this->connect([PDO::ATTR_STRINGIFY_FETCHES => true]);
+
+        $gadget = (new Gadget())->setNew();
+        $gadget->name = 'Spanner';
+        $sticker = (new Sticker())->setNew();
+        $sticker->label = 'fragile';
+        $gadget->sticker = Collection::create([$sticker]);
+        (new TickingEntityManager($db))->save($gadget);
+
+        $loaded = Gadget::on($db)->first()->setNew(false);
+        $loaded->sticker = Collection::create([$sticker]);
+
+        $db->resetCalls();
+        (new TickingEntityManager($db))->save($loaded);
+
+        $this->assertSame(
+            [],
+            array_filter($db->calls, fn ($call) => $call['table'] === 'gadget_sticker'),
+            'An unchanged link must trigger no insert or delete even when keys come back as strings'
+        );
+        $this->assertSame(
+            [['gadget_id' => '1', 'sticker_id' => '1']],
+            $db->prepexec('SELECT gadget_id, sticker_id FROM gadget_sticker')->fetchAll(PDO::FETCH_ASSOC),
+            'The single link should be left intact'
+        );
+    }
+
+    public function testSoftDeleteJunctionDetachesRevivesAndLeavesUnchangedLinksUntouched()
+    {
+        // gadget->tag is linked through GadgetTag, which carries a `deleted` column: removals soft-delete
+        // and re-adds revive the tombstoned row instead of hard-deleting or duplicating it.
+        $gadget = (new Gadget())->setNew();
+        $gadget->name = 'Spanner';
+        $sharp = (new Tag())->setNew();
+        $sharp->name = 'sharp';
+        $heavy = (new Tag())->setNew();
+        $heavy->name = 'heavy';
+        $gadget->tag = Collection::create([$sharp, $heavy]);
+        $this->em()->save($gadget);                     // two links inserted -> changed_at 1000, 2000
+
+        $loaded = Gadget::on($this->db)->first()->setNew(false);
+        $loaded->tag = Collection::create([$sharp, $heavy]);
+        $this->db->resetCalls();
+        $this->em()->save($loaded);
+        $this->assertSame([], $this->writesTo('gadget_tag'), 'Re-saving an unchanged active link should write nothing');
+
+        $link = GadgetTag::on($this->db)->filter(
+            Filter::all(Filter::equal('gadget_id', $gadget->id), Filter::equal('tag_id', $heavy->id))
+        )->first()->setNew(false);
+        $this->em()->save($link->delete());             // soft-deleted -> changed_at 3000
+
+        $this->assertSame(
+            [
+                ['tag_id' => $sharp->id, 'deleted' => 'n', 'changed_at' => 1000],
+                ['tag_id' => $heavy->id, 'deleted' => 'y', 'changed_at' => 3000],
+            ],
+            $this->rows('SELECT tag_id, deleted, changed_at FROM gadget_tag ORDER BY tag_id'),
+            'Detaching a soft-delete link should mark it deleted and re-stamp changed_at, leaving the other link alone'
+        );
+
+        $readded = Gadget::on($this->db)->first()->setNew(false);
+        $readded->tag = Collection::create([$sharp, $heavy]);
+        $this->em()->save($readded);                    // revived -> changed_at 4000
+
+        $this->assertSame(
+            [
+                ['tag_id' => $sharp->id, 'deleted' => 'n', 'changed_at' => 1000],
+                ['tag_id' => $heavy->id, 'deleted' => 'n', 'changed_at' => 4000],
+            ],
+            $this->rows('SELECT tag_id, deleted, changed_at FROM gadget_tag ORDER BY tag_id'),
+            'Re-adding a detached link should revive the existing row'
+        );
+    }
+
+    public function testSoftDeleteJunctionWithSurrogateKeyRevivesAndDetachesThroughReconcile()
+    {
+        $gadget = (new Gadget())->setNew();
+        $gadget->name = 'Spanner';
+        $sharp = (new Badge())->setNew();
+        $sharp->name = 'sharp';
+        $heavy = (new Badge())->setNew();
+        $heavy->name = 'heavy';
+        $gadget->badge = Collection::create([$sharp, $heavy]);
+        $this->em()->save($gadget);                     // two links inserted -> changed_at 1000, 2000
+
+        $heavyLinkId = GadgetBadge::on($this->db)
+            ->filter(Filter::all(Filter::equal('gadget_id', $gadget->id), Filter::equal('badge_id', $heavy->id)))
+            ->first()
+            ->id;
+
+        // Sync the membership down to just "sharp"; reconcile must soft-delete heavy's link scoped by its
+        // surrogate id, not by gadget_id/badge_id
+        $loaded = Gadget::on($this->db)->first()->setNew(false);
+        $loaded->badge = Collection::create([$sharp]);
+        $this->em()->save($loaded);                     // heavy soft-deleted -> changed_at 3000
+
+        $this->assertSame(
+            [
+                ['badge_id' => $sharp->id, 'deleted' => 'n', 'changed_at' => 1000],
+                ['badge_id' => $heavy->id, 'deleted' => 'y', 'changed_at' => 3000],
+            ],
+            $this->rows('SELECT badge_id, deleted, changed_at FROM gadget_badge ORDER BY badge_id'),
+            'Removing a surrogate-keyed soft-delete link should mark it deleted and re-stamp changed_at'
+        );
+
+        // Re-add heavy; reconcile must revive the tombstoned row, again scoped by its surrogate id
+        $readded = Gadget::on($this->db)->first()->setNew(false);
+        $readded->badge = Collection::create([$sharp, $heavy]);
+        $this->em()->save($readded);                    // heavy revived -> changed_at 4000
+
+        $this->assertSame(
+            [
+                ['badge_id' => $sharp->id, 'deleted' => 'n', 'changed_at' => 1000],
+                ['badge_id' => $heavy->id, 'deleted' => 'n', 'changed_at' => 4000],
+            ],
+            $this->rows('SELECT badge_id, deleted, changed_at FROM gadget_badge ORDER BY badge_id'),
+            'Re-adding a detached surrogate-keyed link should revive the existing row'
+        );
+
+        $this->assertSame(
+            [['id' => $heavyLinkId, 'c' => 1]],
+            $this->rows(
+                'SELECT id, COUNT(*) AS c FROM gadget_badge WHERE badge_id = ' . $heavy->id . ' GROUP BY id'
+            ),
+            'Reviving must reuse the original junction row, keeping its surrogate id instead of inserting a duplicate'
+        );
+    }
+
+    public function testSoftDeleteHasManyChildrenAreSoftDeletedOnSyncAndDetach()
+    {
+        // stamped_note is a HasMany child carrying a `deleted` column, so removing a note keeps its row and
+        // marks deleted = 'y' rather than hard-deleting it.
+        $stamped = (new Stamped())->setNew();
+        $stamped->name = 'Manual';
+        $first = (new StampedNote())->setNew();
+        $first->text = 'first';
+        $second = (new StampedNote())->setNew();
+        $second->text = 'second';
+        $stamped->stamped_note = Collection::create([$first, $second]);
+        $this->em()->save($stamped);
+
+        $loaded = Stamped::on($this->db)->first()->setNew(false);
+        $loaded->stamped_note = (new Collection())->sync([]);
+        $this->em()->save($loaded);
+        $this->assertSame(
+            [
+                ['text' => 'first', 'deleted' => 'y'],
+                ['text' => 'second', 'deleted' => 'y'],
+            ],
+            $this->rows('SELECT text, deleted FROM stamped_note ORDER BY id'),
+            'sync([]) should soft-delete every orphaned child rather than removing its row'
+        );
+
+        $third = (new StampedNote())->setNew();
+        $third->text = 'third';
+        $loaded->stamped_note = Collection::create([$third]);
+        $this->em()->save($loaded);
+        $this->assertSame(
+            'n',
+            $this->rows("SELECT deleted FROM stamped_note WHERE text = 'third'")[0]['deleted'],
+            'A newly attached child should be inserted active'
+        );
+
+        // Detaching soft-deletes the child rather than removing it, since a HasMany link is the child row itself.
+        $loaded->stamped_note = (new Collection())->detach($third);
+        $this->em()->save($loaded);
+        $this->assertSame(
+            'y',
+            $this->rows("SELECT deleted FROM stamped_note WHERE text = 'third'")[0]['deleted'],
+            'Detaching a soft-delete child should mark it deleted rather than removing its row'
+        );
+    }
+
+    // -----------------------------------------------------------------------------------------------------
+    // Column behaviors and the changed_at stamp
+    // -----------------------------------------------------------------------------------------------------
+
+    public function testColumnBehaviorConvertsValuesOnInsertAndUpdate()
+    {
+        $flag = (new Flag())->setNew();
+        $flag->label = 'shiny';
+        $flag->enabled = true;
+        $this->em()->save($flag);
+
+        $this->assertTrue($flag->enabled, 'The model value should remain in its PHP form after save');
+        $this->assertSame(
+            [['label' => 'shiny', 'enabled' => 'y']],
+            $this->rows('SELECT label, enabled FROM flag'),
+            'BoolCast should convert true to its database value on insert'
+        );
+
+        $flag->enabled = false;
+        $this->em()->save($flag);
+        $this->assertSame(
+            [['enabled' => 'n']],
+            $this->rows('SELECT enabled FROM flag'),
+            'BoolCast should convert the new value on update'
+        );
+    }
+
+    public function testChangedAtIsStampedOnEveryWriteButNotWhenNothingChanged()
+    {
+        $stamped = (new Stamped())->setNew();
+        $stamped->name = 'Widget';
+        $this->em()->save($stamped);                    // insert -> changed_at 1s
+        $this->assertInstanceOf(
+            DateTimeInterface::class,
+            $stamped->changed_at,
+            'The stamp should be a DateTime on the model'
+        );
+        $this->assertSame(1, $stamped->changed_at->getTimestamp(), 'The insert should stamp changed_at');
+        $this->assertSame(
+            [['name' => 'Widget', 'changed_at' => 1000]],
+            $this->rows('SELECT name, changed_at FROM stamped'),
+            'The DateTime should be converted to a millisecond timestamp on the way to the database'
+        );
+
+        $stamped->name = 'Gizmo';
+        $this->em()->save($stamped);                    // update -> changed_at 2s
+        $this->assertSame(2, $stamped->changed_at->getTimestamp(), 'An update should re-stamp changed_at');
+
+        $this->db->resetCalls();
+        $this->em()->save($stamped);
+        $this->assertSame(2, $stamped->changed_at->getTimestamp(), 'An unchanged save must not re-stamp changed_at');
+        $this->assertSame([], $this->writesTo('stamped'), 'An unchanged save must not write the row');
+
+        // Reassigning only a relation leaves the parent row's own data untouched, so it is neither
+        // re-stamped nor re-written.
+        $loaded = Stamped::on($this->db)->first()->setNew(false);
+        $loaded->stamped_note = new Collection();
+        $this->db->resetCalls();
+        $this->em()->save($loaded);
+        $this->assertSame(
+            [],
+            $this->writesTo('stamped'),
+            'A relation-only reassignment must not UPDATE the parent row'
+        );
+    }
+
+    // -----------------------------------------------------------------------------------------------------
+    // "Dumb" delete: no implicit cascade, explicit intent honoured
+    // -----------------------------------------------------------------------------------------------------
+
+    public function testDeletingAModelNeverCascadesToItsAssignedParentOrChildrenAndLeavesJunctionsIntact()
+    {
+        // A gadget linked to a sticker. Assign a brand-new BelongsTo parent, then delete the gadget. The
+        // parent is independent and unmodified, so it must not be persisted, and the existing junction row
+        // must be left in place (orphaned, not purged) — deletion does not touch junctions.
+        $gadget = (new Gadget())->setNew();
+        $gadget->name = 'Spanner';
+        $sticker = (new Sticker())->setNew();
+        $sticker->label = 'fragile';
+        $gadget->sticker = Collection::create([$sticker]);
+        $this->em()->save($gadget);
+        $gadgetId = $gadget->id;
+
+        $newParent = (new Workshop())->setNew();
+        $newParent->name = 'Acme';
+
+        /** @var Model $loadedGadget */
+        $loadedGadget = Gadget::on($this->db)->first()->setNew(false);
+        $loadedGadget->workshop = $newParent;
+
+        $this->db->resetCalls();
+        $this->em()->save($loadedGadget->delete());
+
+        $this->assertSame(
+            [['method' => 'delete', 'table' => 'gadget', 'condition' => ['id = ?' => $gadgetId]]],
+            $this->db->calls,
+            'A deleted model should issue only its own DELETE; an assigned parent must not be cascaded'
+        );
+        $this->assertTrue($newParent->isNew(), 'An assigned parent must not be persisted while deleting');
+        $this->assertSame(
+            [['gadget_id' => $gadgetId, 'sticker_id' => $sticker->id]],
+            $this->rows('SELECT gadget_id, sticker_id FROM gadget_sticker'),
+            'Deleting the owner must leave its existing junction rows untouched (orphaned)'
+        );
+
+        // A workshop with a brand-new assigned HasMany child, deleted in one save. The child is not marked
+        // for deletion, so it must not be persisted onto a foreign key that is about to vanish.
+        $workshop = $this->savedWorkshop('Globex');
+        $workshopId = $workshop->id;
+        $orphan = (new Gadget())->setNew();
+        $orphan->name = 'Orphan';
+
+        /** @var Model $loadedWorkshop */
+        $loadedWorkshop = Workshop::on($this->db)->filter(Filter::equal('name', 'Globex'))->first()->setNew(false);
+        $loadedWorkshop->gadget = Collection::create([$orphan]);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('should not carry attachments');
+        $this->em()->save($loadedWorkshop->delete());
+    }
+
+    public function testAssigningANewManyToManyTargetWhileDeletingTheOwnerStillLinksIt()
+    {
+        // The EntityManager is "dumb": an explicitly assigned many-to-many link is honoured even while the
+        // owner is being deleted. The target is persisted and its junction row written before the owner's
+        // DELETE, leaving the link orphaned. Removing a source's links is a separate, explicit operation.
+        $gadget = (new Gadget())->setNew();
+        $gadget->name = 'Spanner';
+        $this->em()->save($gadget);
+        $gadgetId = $gadget->id;
+
+        $late = (new Sticker())->setNew();
+        $late->label = 'late';
+
+        /** @var Model $loaded */
+        $loaded = Gadget::on($this->db)->first()->setNew(false);
+        $loaded->sticker = Collection::create([$late]);
+
+        $this->db->resetCalls();
+        $this->em()->save($loaded->delete());
+
+        $this->assertFalse($late->isNew(), 'The explicitly assigned target should still be persisted');
+        $this->assertSame(
+            ['sticker', 'gadget_sticker', 'gadget'],
+            array_column($this->db->calls, 'table'),
+            'The link should be written before the owner is deleted'
+        );
+        $this->assertSame(
+            ['insert', 'insert', 'delete'],
+            array_column($this->db->calls, 'method'),
+            'The target and its junction row should be inserted before the owner is deleted'
+        );
+        $this->assertSame([], $this->rows('SELECT * FROM gadget'), 'The owner itself should be gone');
+        $this->assertSame(
+            [['gadget_id' => $gadgetId, 'sticker_id' => $late->id]],
+            $this->rows('SELECT gadget_id, sticker_id FROM gadget_sticker'),
+            'The honoured link should remain behind as an orphaned junction row'
+        );
+    }
+
+    public function testExplicitDeletionsAndInPlaceEditsAcrossAGraphAreAllApplied()
+    {
+        // A gadget that owns a workshop (BelongsTo) and is linked to a tag through the soft-delete junction.
+        $gadget = (new Gadget())->setNew();
+        $gadget->name = 'Spanner';
+        $workshop = (new Workshop())->setNew();
+        $workshop->name = 'Acme';
+        $gadget->workshop = $workshop;
+        $tag = (new Tag())->setNew();
+        $tag->name = 'sharp';
+        $gadget->tag = Collection::create([$tag]);
+        $this->em()->save($gadget);                     // link inserted -> changed_at 1000
+        $gadgetId = $gadget->id;
+        $workshopId = $workshop->id;
+        $tagId = $tag->id;
+
+        // Detach the link out of band, soft-deleting the junction row.
+        $link = GadgetTag::on($this->db)->filter(Filter::equal('gadget_id', $gadget->id))->first()->setNew(false);
+        $this->em()->save($link->delete());             // soft-deleted -> changed_at 2000
+
+        // In one save: edit the (independent) parent in place, mark the target deleted and delete the gadget.
+        // The parent outlives the gadget, so its edit is still applied — after the gadget is gone. The target
+        // is explicitly deleted, so it is removed too. The soft-deleted junction row is left as a tombstone.
+        $loaded = Gadget::on($this->db)->with('workshop')->first()->setNew(false);
+        $loaded->workshop->setNew(false);
+        $loaded->workshop->name = 'Globex';
+        $loaded->tag = Collection::create([$tag->delete()]);
+        $this->em()->save($loaded->delete());
+
+        $this->assertSame([], $this->rows('SELECT * FROM gadget'), 'The explicitly deleted gadget should be gone');
+        $this->assertSame([], $this->rows('SELECT * FROM tag'), 'The explicitly deleted target should be gone');
+        $this->assertSame(
+            [['id' => $workshopId, 'name' => 'Globex']],
+            $this->rows('SELECT id, name FROM workshop'),
+            'An in-place edit to an independent parent should be applied even as its owner is deleted'
+        );
+        $this->assertSame(
+            [['gadget_id' => $gadgetId, 'tag_id' => $tagId, 'deleted' => 'y', 'changed_at' => 2000]],
+            $this->rows('SELECT gadget_id, tag_id, deleted, changed_at FROM gadget_tag'),
+            'The soft-deleted junction row should remain as an untouched tombstone'
+        );
+    }
+
+    public function testDeletingAModelAlsoDeletesAChildExplicitlyMarkedDeleted()
+    {
+        $workshop = (new Workshop())->setNew();
+        $workshop->name = 'Acme';
+        $gadget = (new Gadget())->setNew();
+        $gadget->name = 'Spanner';
+        $workshop->gadget = Collection::create([$gadget]);
+        $this->em()->save($workshop);
+        $this->assertNotEmpty($this->rows('SELECT * FROM gadget'), 'precondition: the child exists');
+
+        $loadedWorkshop = Workshop::on($this->db)->first()->setNew(false);
+        $loadedGadget = Gadget::on($this->db)->first()->setNew(false);
+        $loadedWorkshop->gadget = Collection::create([$loadedGadget->delete()]);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('should not carry attachments');
+        $this->em()->save($loadedWorkshop->delete());
+    }
+
+    public function testModifyDeletedRelation()
+    {
+        $stamped = (new Stamped())->setNew();
+        $stamped->name = 'Manual';
+        $note = (new StampedNote())->setNew();
+        $note->text = 'initial';
+        $stamped->stamped_note = Collection::create([$note]);
+        (new TickingEntityManager($this->db))->save($stamped);
+        $this->em()->save($stamped);
+
+        $loadedStamped = Stamped::on($this->db)->first()->setNew(false);
+        foreach ($loadedStamped->stamped_note as $note) {
+            $note->text = 'modified';
+            $note->delete();
+        }
+
+        $loadedStamped->delete();
+        $this->em()->save($loadedStamped);
+
+        $this->assertSame(
+            [['text' => 'modified', 'deleted' => 'y']],
+            $this->rows('SELECT text, deleted FROM stamped_note'),
+            'The explicitly deleted child must be soft deleted and its modifications persisted'
+        );
+        $this->assertSame([], $this->rows('SELECT * FROM stamped'), 'The parent should be gone');
+    }
+
+    // -----------------------------------------------------------------------------------------------------
+    // Change tracking, transactions and graph guards
+    // -----------------------------------------------------------------------------------------------------
+
+    public function testReassigningALoadedRelationTracksPendingChanges()
+    {
+        $this->savedWorkshop('Acme');
+        $loaded = Workshop::on($this->db)->first()->setNew(false);
+
+        // Replace the (still-Closure) relation without first reading it, so its loader never runs.
+        $loaded->gadget = Collection::create([(new Gadget())->setNew()]);
+
+        $this->assertTrue(
+            $loaded->gadget->hasPendingChanges(),
+            'Reassigning a relation should mark it modified so saveGraph cascades the new value'
+        );
+    }
+
+    public function testUpdatingOnlyAChildDoesNotRewriteTheParent()
+    {
+        $workshop = (new Workshop())->setNew();
+        $workshop->name = 'Acme';
+        $gadget = (new Gadget())->setNew();
+        $gadget->name = 'Spanner';
+        $workshop->gadget = Collection::create([$gadget]);
+        $this->em()->save($workshop);
+
+        $this->db->resetCalls();
+        $gadget->name = 'Wrench';
+        $this->em()->save($gadget);
+
+        $this->assertSame([], $this->writesTo('workshop'), 'Updating only a child must not re-write its parent');
+        $this->assertSame(
+            [[
+                'method'    => 'update',
+                'table'     => 'gadget',
+                'data'      => ['name' => 'Wrench'],
+                'condition' => ['id = ?' => $gadget->id],
+            ]],
+            $this->db->calls,
+            'Only the child should be written'
+        );
+    }
+
+    public function testSaveJoinsAnOuterTransactionInsteadOfNesting()
+    {
+        $a = (new Workshop())->setNew();
+        $a->name = 'Acme';
+        $b = (new Workshop())->setNew();
+        $b->name = 'Globex';
+
+        $em = $this->em();
+        $this->db->transaction(function () use ($em, $a, $b): void {
+            $em->save($a);
+            $em->save($b);
+        });
+
+        $this->assertSame(
+            [['name' => 'Acme'], ['name' => 'Globex']],
+            $this->rows('SELECT name FROM workshop ORDER BY id'),
+            'Both rows should be persisted by the outer transaction; save() should join it rather than nesting'
+        );
+    }
+
+    public function testAFailedCascadeRollsBackTheWholeGraph()
+    {
+        $workshop = (new Workshop())->setNew();
+        $workshop->name = 'Acme';
+
+        // A gadget without a name violates the NOT NULL constraint and fails mid-cascade.
+        $workshop->gadget = Collection::create([(new Gadget())->setNew()]);
+
+        try {
+            $this->em()->save($workshop);
+            $this->fail('Expected the failing save to throw');
+        } catch (Exception $e) {
+            // expected
+        }
+
+        $this->assertSame(
+            [],
+            $this->rows('SELECT * FROM workshop'),
+            'The parent insert should be rolled back with the child'
+        );
+    }
+
+    public function testSavingACyclicGraphThrows()
+    {
+        $workshop = (new Workshop())->setNew();
+        $workshop->name = 'Acme';
+        $gadget = (new Gadget())->setNew();
+        $gadget->name = 'Spanner';
+
+        // Build a cycle: the workshop owns the gadget and the gadget points back at the same instance.
+        $workshop->gadget = Collection::create([$gadget]);
+        $gadget->workshop = $workshop;
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('loop detected');
+
+        $this->em()->save($workshop);
+    }
+
+    public function testDeletingALoadedModelLeavesItsEagerLoadedRelationIntact()
+    {
+        // Deleting a model does not cascade to its relations, not even one eagerly loaded alongside it.
+        $gadget = (new Gadget())->setNew();
+        $gadget->name = 'Spanner';
+        $workshop = (new Workshop())->setNew();
+        $workshop->name = 'Acme';
+        $gadget->workshop = $workshop;
+        $this->em()->save($gadget);
+        $workshopId = $workshop->id;
+
+        $loaded = Gadget::on($this->db)->with('workshop')->first()->setNew(false);
+        $this->em()->save($loaded->delete());
+
+        $this->assertSame([], $this->rows('SELECT * FROM gadget'), 'The deleted model should be removed');
+        $this->assertSame(
+            [['id' => $workshopId, 'name' => 'Acme']],
+            $this->rows('SELECT id, name FROM workshop'),
+            'An eagerly-loaded relation of a deleted model must be left intact'
+        );
+    }
+
+    public function testSaveRejectsARowThatChangedSinceTheBaseline()
+    {
+        $writer = new TickingEntityManager($this->db);
+        $stamped = (new Stamped())->setNew();
+        $stamped->name = 'stamped';
+        $writer->save($stamped);                                // changed_at -> 1000
+
+        // The state Actor A sees when the edit form is rendered
+        $formState = Stamped::on($this->db)->first()->setNew(false);
+        $baseline = $formState->changed_at;
+
+        // Actor B concurrently updates the same row, bumping its changed_at past the baseline
+        $concurrent = new TickingEntityManager($this->db);
+        $editedByB = Stamped::on($this->db)->first()->setNew(false);
+        $editedByB->name = 'edited by B';
+        $concurrent->save($editedByB);                          // changed_at -> 2000
+
+        // Actor A submits: the controller reloads the current row and applies A's change onto it. Since the
+        // reloaded row now carries B's newer changed_at, saving it against A's baseline must throw.
+        $em = new TickingEntityManager($this->db, $baseline);
+        $editedByA = Stamped::on($this->db)->first()->setNew(false);
+        $editedByA->name = 'edited by A';
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('has changed after baseline');
+        $em->save($editedByA);
+    }
+
+    public function testSaveRejectsSoftDeletingAJunctionLinkAddedSinceTheBaseline()
+    {
+        $gadget = (new Gadget())->setNew();
+        $gadget->name = 'Spanner';
+        $sharp = (new Tag())->setNew();
+        $sharp->name = 'sharp';
+        $gadget->tag = Collection::create([$sharp]);
+        (new TickingEntityManager($this->db))->save($gadget);   // link (gadget, sharp) stamped
+
+        // The state Actor A sees: the newest junction changed_at across the gadget's links
+        $storedLink = GadgetTag::on($this->db)->first();
+        $baseline = $storedLink->changed_at;
+
+        // Actor B concurrently links a second tag, adding a junction row A never saw
+        $heavy = (new Tag())->setNew();
+        $heavy->name = 'heavy';
+        $editedByB = Gadget::on($this->db)->first()->setNew(false);
+        $editedByB->tag = (new Collection())->attach($heavy);
+        (new TickingEntityManager($this->db))->save($editedByB);
+
+        // Actor A submits, syncing the gadget's tags down to just "sharp"; reconcile hits B's newer link
+        $em = new TickingEntityManager($this->db, $baseline);
+        $editedByA = Gadget::on($this->db)->first()->setNew(false);
+        $editedByA->tag = (new Collection())->sync([$sharp]);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('has changed after baseline');
+        $em->save($editedByA);
+    }
+
+    public function testSaveRejectsSoftDeletingAHasManyChildAddedSinceTheBaseline()
+    {
+        $stamped = (new Stamped())->setNew();
+        $stamped->name = 'Manual';
+        $first = (new StampedNote())->setNew();
+        $first->text = 'first';
+        $stamped->stamped_note = Collection::create([$first]);
+        (new TickingEntityManager($this->db))->save($stamped);  // note "first" stamped
+
+        // The state Actor A sees: the newest note changed_at
+        $storedNote = StampedNote::on($this->db)->first();
+        $baseline = $storedNote->changed_at;
+
+        // Actor B concurrently adds a second note A never saw
+        $second = (new StampedNote())->setNew();
+        $second->text = 'second';
+        $editedByB = Stamped::on($this->db)->first()->setNew(false);
+        $editedByB->stamped_note = (new Collection())->attach($second);
+        (new TickingEntityManager($this->db))->save($editedByB);
+
+        // Actor A submits, syncing the notes down to just "first"; reconcile hits B's newer note
+        $em = new TickingEntityManager($this->db, $baseline);
+        $editedByA = Stamped::on($this->db)->first()->setNew(false);
+        $editedByA->stamped_note = (new Collection())->sync([$first]);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('has changed after baseline');
+        $em->save($editedByA);
+    }
+
+    // -----------------------------------------------------------------------------------------------------
+    // In-place modification of loaded members and the query() accessor
+    // -----------------------------------------------------------------------------------------------------
+
+    public function testInPlaceEditOfAMaterializedChildIsPersisted()
+    {
+        // No attach/detach/sync — just materialize the children and edit one in place. hasPendingChanges()
+        // must detect it and getMembersToSave() must cascade it.
+        $stamped = (new Stamped())->setNew();
+        $stamped->name = 'Manual';
+        $note = (new StampedNote())->setNew();
+        $note->text = 'original';
+        $stamped->stamped_note = Collection::create([$note]);
+        $this->em()->save($stamped);
+
+        $loaded = Stamped::on($this->db)->first()->setNew(false);
+        foreach ($loaded->stamped_note as $child) {   // materializes the collection, marking members loaded
+            $child->text = 'edited';
+        }
+
+        $this->em()->save($loaded);
+
+        $this->assertSame(
+            [['text' => 'edited', 'deleted' => 'n']],
+            $this->rows('SELECT text, deleted FROM stamped_note'),
+            'An in-place edit to a materialized child must be persisted without any attach/detach'
+        );
+    }
+
+    public function testSavingAMaterializedButUnmodifiedChildCollectionWritesNothing()
+    {
+        $stamped = (new Stamped())->setNew();
+        $stamped->name = 'Manual';
+        $note = (new StampedNote())->setNew();
+        $note->text = 'original';
+        $stamped->stamped_note = Collection::create([$note]);
+        $this->em()->save($stamped);
+
+        $loaded = Stamped::on($this->db)->first()->setNew(false);
+        $this->assertCount(1, $loaded->stamped_note, 'precondition: the child collection is materialized');
+
+        $this->db->resetCalls();
+        $this->em()->save($loaded);
+
+        $this->assertSame(
+            [],
+            $this->writesTo('stamped_note'),
+            'Unmodified materialized children must not be rewritten'
+        );
+        $this->assertSame([], $this->writesTo('stamped'), 'An unmodified parent must not be rewritten');
+    }
+
+    public function testDeletingAnOwnerSoftDeletesADetachedChild()
+    {
+        $stamped = (new Stamped())->setNew();
+        $stamped->name = 'Manual';
+        $keep = (new StampedNote())->setNew();
+        $keep->text = 'keep';
+        $drop = (new StampedNote())->setNew();
+        $drop->text = 'drop';
+        $stamped->stamped_note = Collection::create([$keep, $drop]);
+        $this->em()->save($stamped);
+
+        // Detach one child and delete the owner in a single save; the detached child must still be removed.
+        $loadedDrop = StampedNote::on($this->db)->filter(Filter::equal('text', 'drop'))->first()->setNew(false);
+        $loaded = Stamped::on($this->db)->first()->setNew(false);
+        $loaded->stamped_note->detach($loadedDrop);
+        $this->em()->save($loaded->delete());
+
+        $this->assertSame([], $this->rows('SELECT * FROM stamped'), 'The owner should be hard-deleted');
+        $this->assertSame(
+            [
+                ['text' => 'keep', 'deleted' => 'n'],
+                ['text' => 'drop', 'deleted' => 'y'],
+            ],
+            $this->rows('SELECT text, deleted FROM stamped_note ORDER BY id'),
+            'A detached child must be soft-deleted even while its owner is being deleted'
+        );
+    }
+
+    public function testDeletingAnOwnerSoftDeletesEveryChildOfARelationSyncedToAnEmptySet()
+    {
+        $stamped = (new Stamped())->setNew();
+        $stamped->name = 'Manual';
+        $first = (new StampedNote())->setNew();
+        $first->text = 'first';
+        $second = (new StampedNote())->setNew();
+        $second->text = 'second';
+        $stamped->stamped_note = Collection::create([$first, $second]);
+        $this->em()->save($stamped);
+
+        // Sync the children down to nothing and delete the owner in a single save.
+        $loaded = Stamped::on($this->db)->first()->setNew(false);
+        $loaded->stamped_note->sync([]);
+        $this->em()->save($loaded->delete());
+
+        $this->assertSame([], $this->rows('SELECT * FROM stamped'), 'The owner should be hard-deleted');
+        $this->assertSame(
+            [
+                ['text' => 'first', 'deleted' => 'y'],
+                ['text' => 'second', 'deleted' => 'y'],
+            ],
+            $this->rows('SELECT text, deleted FROM stamped_note ORDER BY id'),
+            'Every stored child must be removed when the owner of an empty-synced relation is deleted'
+        );
+    }
+
+    public function testQueryReturnsTheSourceQuery()
+    {
+        $query = Stamped::on($this->db);
+
+        $this->assertSame(
+            $query,
+            Collection::fromLoaded($query)->query(),
+            'query() should return the query the collection was created from'
+        );
+    }
+
+    public function testQueryThrowsWhenThereIsNoPendingQuery()
+    {
+        $this->expectException(LogicException::class);
+        (new Collection())->query();
+    }
+}


### PR DESCRIPTION
To support modifying models and then persisting them to the DB, an `EntityManager` is added, which can save and delete any given `Model` and its modified relations.

A new `Model` class is added that serves as parent class for all models in the module, it tracks whether it already exists in the DB, and what columns have been modified.

To manage members of to-many relations `Collection` is added, which exposes `attach()`, `detach()` and `sync()`, and also supports modifying its members in place.
