### PR TITLE
Introduce the ability for source integrations to configure their notifications source

### DIFF
--- a/application/controllers/SourceController.php
+++ b/application/controllers/SourceController.php
@@ -8,57 +8,77 @@ namespace Icinga\Module\Notifications\Controllers;
 use Icinga\Module\Notifications\Common\Database;
 use Icinga\Module\Notifications\Forms\DeleteSourceForm;
 use Icinga\Module\Notifications\Forms\SourceForm;
+use Icinga\Module\Notifications\Model\Source;
+use Icinga\Module\Notifications\Repository\SourceRepository;
 use Icinga\Web\Notification;
 use Icinga\Web\Session;
 use ipl\Html\Contract\Form;
 use ipl\Sql\Connection;
 use ipl\Web\Compat\CompatController;
 use ipl\Web\Url;
+use RuntimeException;
 
 class SourceController extends CompatController
 {
+    private Source $source;
+
     public function init(): void
     {
         $this->assertPermission('config/modules');
+
+        $source = (new SourceRepository(Database::get()))
+            ->find((int) $this->params->getRequired('id'))
+            ?->setNew(false);
+
+        if ($source === null) {
+            $this->httpNotFound($this->translate('Source not found'));
+        }
+
+        $this->source = $source;
     }
 
     public function indexAction(): void
     {
-        $sourceId = (int) $this->params->getRequired('id');
-
-        $form = (new SourceForm(Database::get()))
+        $form = (new SourceForm())
             ->setCsrfCounterMeasureId(Session::getSession()->getId())
-            ->loadSource($sourceId)
+            ->setSource($this->source)
             ->on(Form::ON_SUBMIT, function (SourceForm $form): never {
-                Database::get()->transaction(fn () => $form->editSource());
+                $source = $form->getSource();
+
+                if ($source->locked) {
+                    throw new RuntimeException('Source is locked');
+                }
+
+                Database::get()->transaction(fn (Connection $db) => (new SourceRepository($db))->update($source));
                 Notification::success(sprintf(
                     $this->translate('Updated source "%s" successfully'),
-                    $form->getSourceName()
+                    $source->name
                 ));
 
                 $this->switchToSingleColumnLayout();
             })->handleRequest($this->getServerRequest());
 
-        $this->addTitleTab(sprintf($this->translate('Source: %s'), $form->getSourceName()));
+        $this->addTitleTab(sprintf($this->translate('Source: %s'), $this->source->name));
         $this->addContent($form);
     }
 
     public function deleteAction(): void
     {
-        $sourceId = (int) $this->params->getRequired('id');
+        if ($this->source->locked) {
+            throw new RuntimeException('Source is locked');
+        }
 
         $form = (new DeleteSourceForm())
             ->setCsrfCounterMeasureId(Session::getSession()->getId())
-            ->loadSource($sourceId)
             ->setAction(Url::fromRequest()->getAbsoluteUrl())
-            ->on(Form::ON_SUBMIT, function (DeleteSourceForm $form): never {
-                Database::get()->transaction(fn (Connection $db) => $form->removeSource($db));
+            ->on(Form::ON_SUBMIT, function (): never {
+                Database::get()->transaction(fn (Connection $db) => (new SourceRepository($db))->delete($this->source));
                 Notification::success($this->translate('Deleted source successfully'));
                 $this->switchToSingleColumnLayout();
             })
             ->handleRequest($this->getServerRequest());
 
-        $this->setTitle(sprintf($this->translate('Delete Source: %s'), $form->getSourceName()));
+        $this->setTitle(sprintf($this->translate('Delete Source: %s'), $this->source->name));
         $this->addContent($form);
     }
 }

--- a/application/controllers/SourcesController.php
+++ b/application/controllers/SourcesController.php
@@ -8,6 +8,7 @@ namespace Icinga\Module\Notifications\Controllers;
 use Icinga\Module\Notifications\Common\Database;
 use Icinga\Module\Notifications\Forms\SourceForm;
 use Icinga\Module\Notifications\Model\Source;
+use Icinga\Module\Notifications\Repository\SourceRepository;
 use Icinga\Module\Notifications\View\SourceRenderer;
 use Icinga\Module\Notifications\Web\Control\SearchBar\ObjectSuggestions;
 use Icinga\Module\Notifications\Widget\ItemList\ObjectList;
@@ -15,6 +16,7 @@ use Icinga\Web\Notification;
 use Icinga\Web\Session;
 use Icinga\Web\Widget\Tabs;
 use ipl\Html\Contract\Form;
+use ipl\Sql\Connection;
 use ipl\Web\Compat\CompatController;
 use ipl\Web\Compat\SearchControls;
 use ipl\Web\Control\LimitControl;
@@ -99,11 +101,12 @@ class SourcesController extends CompatController
 
     public function addAction(): void
     {
-        $form = (new SourceForm(Database::get()))
+        $form = (new SourceForm())
             ->setCsrfCounterMeasureId(Session::getSession()->getId())
             ->on(Form::ON_SUBMIT, function (SourceForm $form) {
-                $form->addSource();
-                Notification::success(sprintf(t('Added new source %s successfully'), $form->getSourceName()));
+                $source = $form->getSource();
+                Database::get()->transaction(fn (Connection $db) => (new SourceRepository($db))->create($source));
+                Notification::success(sprintf(t('Added new source %s successfully'), $source->name));
                 $this->switchToSingleColumnLayout();
             })
             ->handleRequest($this->getServerRequest());

--- a/application/forms/DeleteSourceForm.php
+++ b/application/forms/DeleteSourceForm.php
@@ -5,60 +5,14 @@
 
 namespace Icinga\Module\Notifications\Forms;
 
-use DateTime;
-use Icinga\Exception\Http\HttpNotFoundException;
-use Icinga\Module\Notifications\Common\Database;
-use Icinga\Module\Notifications\Model\Rule;
-use Icinga\Module\Notifications\Model\Source;
 use ipl\Html\HtmlElement;
 use ipl\Html\Text;
-use ipl\Sql\Connection;
-use ipl\Stdlib\Filter;
 use ipl\Web\Common\CsrfCounterMeasure;
 use ipl\Web\Compat\CompatForm;
-use RuntimeException;
 
 class DeleteSourceForm extends CompatForm
 {
     use CsrfCounterMeasure;
-
-    /** @var ?Source The source to delete */
-    protected ?Source $source = null;
-
-    /**
-     * Load the source with the given ID from the database
-     *
-     * @param int $id
-     *
-     * @return $this
-     *
-     * @throws HttpNotFoundException
-     */
-    public function loadSource(int $id): static
-    {
-        $source = Source::on(Database::get())
-            ->columns(['id', 'name', 'locked'])
-            ->filter(Filter::equal('id', $id))
-            ->first();
-        /** @var ?Source $source */
-        if ($source === null) {
-            throw new HttpNotFoundException($this->translate('Source not found'));
-        }
-
-        $this->source = $source;
-
-        return $this;
-    }
-
-    /**
-     * Get this source's name
-     *
-     * @return string
-     */
-    public function getSourceName(): string
-    {
-        return $this->source->name;
-    }
 
     protected function assemble(): void
     {
@@ -94,32 +48,5 @@ class DeleteSourceForm extends CompatForm
             'label' => $this->translate('Understood. Delete this source.'),
             'class' => 'btn-remove'
         ]);
-    }
-
-    /**
-     * Delete the source and all associated event rules from the database
-     *
-     * @param Connection $db
-     *
-     * @return void
-     */
-    public function removeSource(Connection $db): void
-    {
-        if ($this->source->locked) {
-            throw new RuntimeException('Source is locked');
-        }
-
-        $rules = Rule::on($db)
-            ->columns('id')
-            ->filter(Filter::equal('source_id', $this->source->id));
-        foreach ($rules as $rule) {
-            EventRuleConfigForm::removeRule($db, $rule);
-        }
-
-        $db->update(
-            'source',
-            ['changed_at' => (int) (new DateTime())->format("Uv"), 'deleted' => 'y', 'listener_username' => null],
-            ['id = ?' => $this->source->id]
-        );
     }
 }

--- a/application/forms/SourceForm.php
+++ b/application/forms/SourceForm.php
@@ -5,14 +5,12 @@
 
 namespace Icinga\Module\Notifications\Forms;
 
-use DateTime;
-use Icinga\Exception\Http\HttpNotFoundException;
+use Icinga\Module\Notifications\Common\Database;
 use Icinga\Module\Notifications\Model\Source;
 use ipl\Html\Attributes;
 use ipl\Html\HtmlDocument;
 use ipl\Html\HtmlElement;
 use ipl\Html\Text;
-use ipl\Sql\Connection;
 use ipl\Stdlib\Filter;
 use ipl\Validator\CallbackValidator;
 use ipl\Web\Common\CalloutType;
@@ -21,34 +19,19 @@ use ipl\Web\Compat\CompatForm;
 use ipl\Web\Url;
 use ipl\Web\Widget\ButtonLink;
 use ipl\Web\Widget\Callout;
-use RuntimeException;
 
 class SourceForm extends CompatForm
 {
     use CsrfCounterMeasure;
 
-    /** @var string|int The used password hash algorithm */
-    public const HASH_ALGORITHM = PASSWORD_BCRYPT;
-
-    /** @var string @var The generic source type */
+    /** @var string The generic source type */
     public const TYPE_GENERIC = 'generic';
 
     /** @var string The type for sources with an integration */
     private const TYPE_INTEGRATED = 'integrated';
 
-    /** @var Connection */
-    private Connection $db;
-
-    /** @var ?int */
-    private ?int $sourceId = null;
-
-    /** @var bool Whether the source is locked for editing */
-    private bool $isLocked = false;
-
-    public function __construct(Connection $db)
-    {
-        $this->db = $db;
-    }
+    /** @var ?Source The source to load */
+    private ?Source $source = null;
 
     protected function assemble(): void
     {
@@ -72,7 +55,7 @@ class SourceForm extends CompatForm
             [
                 'label'     => $this->translate('Source Name'),
                 'required'  => true,
-                'disabled'  => $this->isLocked
+                'disabled'  => $this->source?->locked
             ]
         );
         $this->addElement(
@@ -83,7 +66,7 @@ class SourceForm extends CompatForm
                 'required'  => true,
                 'label'     => $this->translate('Source Type'),
                 'value'     => self::TYPE_GENERIC,
-                'disabled'  => $this->isLocked,
+                'disabled'  => $this->source?->locked,
                 'class'     => 'autosubmit',
                 'options'   => [
                     self::TYPE_GENERIC    => $this->translate('Generic', 'notifications.source.type'),
@@ -112,7 +95,7 @@ class SourceForm extends CompatForm
                 [
                     'required'      => true,
                     'label'         => $this->translate('Source Identifier'),
-                    'disabled'  => $this->isLocked
+                    'disabled'  => $this->source?->locked
                 ]
             );
         }
@@ -138,14 +121,14 @@ class SourceForm extends CompatForm
             [
                 'required' => true,
                 'label' => $this->translate('Username'),
-                'disabled'  => $this->isLocked,
+                'disabled'  => $this->source?->locked,
                 'validators' => [new CallbackValidator(
                     function ($value, CallbackValidator $validator) {
                         // Username must be unique
-                        $source = Source::on($this->db)
+                        $source = Source::on(Database::get())
                             ->filter(Filter::equal('listener_username', $value));
-                        if ($this->sourceId !== null) {
-                            $source->filter(Filter::unequal('id', $this->sourceId));
+                        if ($this->source !== null) {
+                            $source->filter(Filter::unequal('id', $this->source->id));
                         }
 
                         if ($source->first() !== null) {
@@ -159,7 +142,7 @@ class SourceForm extends CompatForm
             ]
         );
 
-        if ($this->isLocked) {
+        if ($this->source?->locked) {
             $this->prependHtml(new Callout(
                 CalloutType::Info,
                 $this->translate('This source is managed by an integration, so changes can only be applied through it.')
@@ -172,8 +155,8 @@ class SourceForm extends CompatForm
             'password',
             'listener_password',
             [
-                'required'      => $this->sourceId === null,
-                'label'         => $this->sourceId !== null
+                'required'      => $this->source === null,
+                'label'         => $this->source !== null
                     ? $this->translate('New Password')
                     : $this->translate('Password'),
                 'autocomplete'  => 'new-password',
@@ -185,7 +168,7 @@ class SourceForm extends CompatForm
             'listener_password_dupe',
             [
                 'ignore'        => true,
-                'required'      => $this->sourceId === null,
+                'required'      => $this->source === null,
                 'label'         => $this->translate('Repeat Password'),
                 'autocomplete'  => 'new-password',
                 'validators'    => [new CallbackValidator(function (string $value, CallbackValidator $validator) {
@@ -204,19 +187,19 @@ class SourceForm extends CompatForm
             'submit',
             'save',
             [
-                'label' => $this->sourceId === null ?
+                'label' => $this->source === null ?
                     $this->translate('Add Source') :
                     $this->translate('Save Changes')
             ]
         );
 
-        if ($this->sourceId !== null) {
+        if ($this->source !== null) {
             $this->getElement('save')->prependWrapper(
                 (new HtmlDocument())
                     ->addHtml(
                         (new ButtonLink(
                             $this->translate('Delete'),
-                            Url::fromPath('notifications/source/delete/', ['id' => $this->sourceId])
+                            Url::fromPath('notifications/source/delete/', ['id' => $this->source->id])
                         ))->openInModal()
                     )
             );
@@ -224,125 +207,47 @@ class SourceForm extends CompatForm
     }
 
     /**
-     * Load the source with given id
+     * Set the source to populate the form with
      *
-     * @param int $id
+     * @param Source $source
      *
      * @return $this
      */
-    public function loadSource(int $id): static
+    public function setSource(Source $source): static
     {
-        $this->sourceId = $id;
+        $this->source = $source;
 
-        $values = $this->fetchDbValues();
-
-        if ($values['type'] === self::TYPE_GENERIC) {
-            unset($values['type']);
-            $values['source_type'] = self::TYPE_GENERIC;
-        } else {
-            $values['source_type'] = self::TYPE_INTEGRATED;
-        }
-
-        $this->populate($values);
+        $this->populate([
+            'name' => $source->name,
+            'type' => $source->type,
+            'source_type' => $source->type === self::TYPE_GENERIC ? self::TYPE_GENERIC : self::TYPE_INTEGRATED,
+            'credentials' => [
+                'listener_username' => $source->listener_username
+            ]
+        ]);
 
         return $this;
     }
 
     /**
-     * Add the new source
-     */
-    public function addSource(): void
-    {
-        $data = $this->getValues();
-
-        $source = [
-            'name' => $data['name'],
-            'type' => $this->getValue('type', self::TYPE_GENERIC),
-            'listener_username' => $data['credentials']['listener_username'],
-            // Not using PASSWORD_DEFAULT, as the used algorithm should
-            // be kept in sync with what the daemon understands
-            'listener_password_hash' => password_hash(
-                $data['credentials']['listener_password'],
-                self::HASH_ALGORITHM
-            ),
-            'changed_at' => (int) (new DateTime())->format("Uv")
-        ];
-
-        $this->db->transaction(function (Connection $db) use ($source): void {
-            $db->insert('source', $source);
-        });
-    }
-
-    /**
-     * Edit the source
+     * Get the source as configured by the user
      *
-     * @return void
+     * @return Source
      */
-    public function editSource(): void
+    public function getSource(): Source
     {
-        if ($this->isLocked) {
-            throw new RuntimeException('Source is locked');
+        if ($this->source === null) {
+            $this->source = (new Source())->setNew();
         }
 
-        $data = $this->getValues();
-
-        $source = [
-            'name' => $data['name'],
-            'type' => $this->getValue('type', self::TYPE_GENERIC),
-            'listener_username' => $data['credentials']['listener_username']
-        ];
-
-        /** @var ?string $listenerPassword */
-        $listenerPassword = $data['credentials']['listener_password'] ?? null;
-
-        if ($listenerPassword) {
-            // Not using PASSWORD_DEFAULT, as the used algorithm should
-            // be kept in sync with what the daemon understands
-            $source['listener_password_hash'] = password_hash($listenerPassword, self::HASH_ALGORITHM);
-        } elseif (empty(array_diff_assoc($source, $this->fetchDbValues()))) {
-            return;
+        $this->source->name = $this->getValue('name');
+        $this->source->type = $this->getValue('type', self::TYPE_GENERIC);
+        $this->source->listener_username = $this->getElement('credentials')->getValue('listener_username');
+        $pwd = $this->getElement('credentials')->getValue('listener_password');
+        if ($pwd) {
+            $this->source->listener_password = $pwd;
         }
 
-        $source['changed_at'] = (int) (new DateTime())->format("Uv");
-        $this->db->update('source', $source, ['id = ?' => $this->sourceId]);
-    }
-
-    /**
-     * Get the source name
-     *
-     * @return string
-     */
-    public function getSourceName(): string
-    {
-        return $this->getValue('name');
-    }
-
-    /**
-     * Fetch the values from the database
-     *
-     * @return array
-     *
-     * @throws HttpNotFoundException
-     */
-    private function fetchDbValues(): array
-    {
-        /** @var ?Source $source */
-        $source = Source::on($this->db)
-            ->filter(Filter::equal('id', $this->sourceId))
-            ->first();
-
-        if ($source === null) {
-            throw new HttpNotFoundException($this->translate('Source not found'));
-        }
-
-        $this->isLocked = $source->locked;
-
-        return [
-            'name' => $source->name,
-            'type' => $source->type,
-            'credentials' => [
-                'listener_username' => $source->listener_username
-            ]
-        ];
+        return $this->source;
     }
 }

--- a/library/Notifications/Integrations/Source.php
+++ b/library/Notifications/Integrations/Source.php
@@ -1,0 +1,147 @@
+<?php
+
+// SPDX-FileCopyrightText: 2026 Icinga GmbH <https://icinga.com>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+namespace Icinga\Module\Notifications\Integrations;
+
+use Icinga\Module\Notifications\Common\Database;
+use Icinga\Module\Notifications\Model\Source as SourceModel;
+use Icinga\Module\Notifications\Repository\SourceRepository;
+use ipl\Sql\Connection;
+use RuntimeException;
+
+/**
+ * Utility class for integrations to manage their sources
+ *
+ * This class allows modifying the underlying source using the setter methods.
+ *
+ * Changes are in memory until persisted by {@see self::save()}.
+ */
+final class Source
+{
+    /**
+     * Create a new source-managing instance
+     *
+     * This allows modifying the underlying source using the setter methods.
+     *
+     * @param SourceModel $source The source to work with
+     * @param Connection $db Database to operate on
+     */
+    public function __construct(
+        private SourceModel $source,
+        private Connection $db
+    ) {
+    }
+
+    /**
+     * Get a source-managing instance with the given username.
+     *
+     * If the source does not exist in the database, a new source is created.
+     * To store the source in the database, {@see self::save()} must be called.
+     *
+     * @param string $username
+     *
+     * @return self
+     */
+    public static function get(string $username): self
+    {
+        $source = (new SourceRepository(Database::get()))
+            ->findByUsername($username);
+
+        if ($source === null) {
+            $source = (new SourceModel())->setNew();
+            $source->listener_username = $username;
+        }
+
+        return new self($source, Database::get());
+    }
+
+    /**
+     * Get the name of the source
+     *
+     * @return ?string
+     */
+    public function getName(): ?string
+    {
+        return $this->source->name ?? null;
+    }
+
+    /**
+     * Set the name of the source
+     *
+     * @param string $name
+     *
+     * @return $this
+     */
+    public function setName(string $name): self
+    {
+        $this->source->name = $name;
+
+        return $this;
+    }
+
+    /**
+     * Set the type of the source
+     *
+     * @param string $type
+     *
+     * @return $this
+     */
+    public function setType(string $type): self
+    {
+        $this->source->type = $type;
+
+        return $this;
+    }
+
+    /**
+     * Set the password for the source
+     *
+     * @param string $password
+     *
+     * @return $this
+     */
+    public function setPassword(string $password): self
+    {
+        $this->source->listener_password = $password;
+
+        return $this;
+    }
+
+    /**
+     * Save the source
+     *
+     * This makes sure the source is locked.
+     *
+     * @return void
+     *
+     * @throws RuntimeException If the source name or type is not set
+     */
+    public function save(): void
+    {
+        if ($this->source->isNew() && (! isset($this->source->name) || ! isset($this->source->type))) {
+            throw new RuntimeException('Source must have a name and type');
+        }
+
+        $this->source->locked = true;
+
+        $this->db->transaction(function () {
+            $this->source->isNew()
+                ? (new SourceRepository($this->db))->create($this->source)
+                : (new SourceRepository($this->db))->update($this->source);
+        });
+    }
+
+    /**
+     * Delete the source
+     *
+     * This will also dereference it from any rules
+     *
+     * @return void
+     */
+    public function delete(): void
+    {
+        $this->db->transaction(fn () => (new SourceRepository($this->db))->delete($this->source));
+    }
+}

--- a/library/Notifications/Model/Source.php
+++ b/library/Notifications/Model/Source.php
@@ -10,6 +10,7 @@ use Icinga\Application\Logger;
 use Icinga\Module\Notifications\Common\Model;
 use Icinga\Module\Notifications\Common\SourceHookLocator;
 use Icinga\Module\Notifications\Hook\V2\SourceHook;
+use Icinga\Module\Notifications\Repository\SourceRepository;
 use ipl\Orm\Behavior\BoolCast;
 use ipl\Orm\Behavior\MillisecondTimestamp;
 use ipl\Orm\Behaviors;
@@ -24,6 +25,10 @@ use Throwable;
  * @property string $name The user-defined name
  * @property ?string $listener_username The username for HTTP authentication
  * @property ?string $listener_password_hash
+ * @property ?string $listener_password Helper property to temporarily store the raw password (not persisted to the
+ *                                      database). The repository hashes it and assigns the result to
+ *                                      {@see self::$listener_password_hash} before saving the source to the database.
+ *                                      See the usage in {@see SourceRepository::upsert()}.
  * @property DateTime $changed_at
  * @property bool $deleted
  * @property bool $locked

--- a/library/Notifications/Repository/SourceRepository.php
+++ b/library/Notifications/Repository/SourceRepository.php
@@ -1,0 +1,147 @@
+<?php
+
+// SPDX-FileCopyrightText: 2026 Icinga GmbH <https://icinga.com>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+namespace Icinga\Module\Notifications\Repository;
+
+use Icinga\Module\Notifications\Common\EntityManager;
+use Icinga\Module\Notifications\Forms\EventRuleConfigForm;
+use Icinga\Module\Notifications\Model\Source;
+use ipl\Sql\Connection;
+use ipl\Stdlib\Filter;
+
+final class SourceRepository
+{
+    /** @var string The used password hash algorithm */
+    public const HASH_ALGORITHM = PASSWORD_BCRYPT;
+
+    /** @var EntityManager The entity manager instance to use */
+    private EntityManager $em;
+
+    /**
+     * Create a `sourceRepository` instance
+     *
+     * @param Connection $db Database to operate on
+     */
+    public function __construct(
+        private Connection $db
+    ) {
+        $this->em = new EntityManager($db);
+    }
+
+    /**
+     * Fetch the source with the given id
+     *
+     * @param int $id
+     *
+     * @return ?Source
+     */
+    public function find(int $id): ?Source
+    {
+        /** @var ?Source $source */
+        $source = Source::on($this->db)
+            ->filter(Filter::equal('source.id', $id))
+            ->first()
+            ?->setNew(false);
+
+        return $source;
+    }
+
+    /**
+     * Fetch the source with the given username
+     *
+     * @param string $username listener_username
+     *
+     * @return ?Source
+     */
+    public function findByUsername(string $username): ?Source
+    {
+        /** @var ?Source $source */
+        $source = Source::on($this->db)
+            ->filter(Filter::equal('source.listener_username', $username))
+            ->first()
+            ?->setNew(false);
+
+        return $source;
+    }
+
+    /**
+     * Create a new source
+     *
+     * @param Source $source
+     *
+     * @return void
+     */
+    public function create(Source $source): void
+    {
+        $this->upsert($source);
+    }
+
+    /**
+     * Update a source
+     *
+     * @param Source $source
+     *
+     * @return void
+     */
+    public function update(Source $source): void
+    {
+        $this->upsert($source);
+    }
+
+    /**
+     * Delete a source and dereference it from any rules
+     *
+     * @param Source $source
+     *
+     * @return void
+     */
+    public function delete(Source $source): void
+    {
+        $source->delete();
+        $source->listener_username = null;
+
+        foreach ($source->rule as $rule) {
+            //TODO: add repository for rule
+            EventRuleConfigForm::removeRule($this->db, $rule);
+        }
+
+        $this->em->save($source);
+    }
+
+    /**
+     * Hash the given password using the configured algorithm
+     *
+     * @param string $password
+     *
+     * @return string
+     */
+    public static function hashPassword(string $password): string
+    {
+        // Not using PASSWORD_DEFAULT, as the used algorithm should
+        // be kept in sync with what the daemon understands
+        return password_hash($password, self::HASH_ALGORITHM);
+    }
+
+    /**
+     * Create or update the given source
+     *
+     * This method centralizes the shared persistence logic required by both
+     * the {@see self::create()} and {@see self::update()} operations to avoid code duplication.
+     *
+     * @param Source $source The source to create or update.
+     */
+    private function upsert(Source $source): void
+    {
+        if (isset($source->listener_password)) {
+            try {
+                $source->listener_password_hash = self::hashPassword($source->listener_password);
+            } finally {
+                unset($source->listener_password);
+            }
+        }
+
+        $this->em->save($source);
+    }
+}

--- a/test/php/library/Notifications/Integrations/SourceTest.php
+++ b/test/php/library/Notifications/Integrations/SourceTest.php
@@ -1,0 +1,133 @@
+<?php
+
+// SPDX-FileCopyrightText: 2026 Icinga GmbH <https://icinga.com>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+namespace Tests\Icinga\Module\Notifications\Integrations;
+
+use Icinga\Module\Notifications\Integrations\Source;
+use Icinga\Module\Notifications\Model\Source as SourceModel;
+use ipl\Sql\Connection;
+use PDOStatement;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+/**
+ * Tests for {@see Source}.
+ *
+ * These tests cover the save/delete routing of {@see Source}. All low-level database interactions
+ * (insert data, password hashing, update WHERE clause, soft-delete details) are covered in
+ * {@see \Tests\Icinga\Module\Notifications\Repository\SourceRepositoryTest}.
+ */
+class SourceTest extends TestCase
+{
+    public function testGetNameReturnsNullWhenNotSet(): void
+    {
+        $this->assertNull((new Source(new SourceModel(), $this->createStub(Connection::class)))->getName());
+    }
+
+    public function testGetNameReturnsSetName(): void
+    {
+        $source = (new Source(new SourceModel(), $this->createStub(Connection::class)))->setName('My Source');
+
+        $this->assertSame('My Source', $source->getName());
+    }
+
+    public function testSaveCallsInsertForNewSource(): void
+    {
+        $db = $this->getConnectionMock();
+        $db->expects($this->once())
+            ->method('insert')
+            ->willReturnCallback(function ($_, $data) {
+                $this->assertSame('y', $data['locked']);
+
+                return $this->createStub(PDOStatement::class);
+            });
+        $db->expects($this->never())->method('update');
+
+        (new Source((new SourceModel())->setNew(), $db))
+            ->setName('N')
+            ->setType('icingadb')
+            ->save();
+    }
+
+    public function testSaveCallsUpdateForExistingSource(): void
+    {
+        $db = $this->getConnectionMock();
+        $db->expects($this->never())->method('insert');
+        $db->expects($this->once())
+            ->method('update')
+            ->willReturnCallback(function ($_, $data) {
+                $this->assertSame('y', $data['locked']);
+
+                return $this->createStub(PDOStatement::class);
+            });
+
+        $model = new SourceModel(['id' => 5, 'type' => 'icingadb', 'name' => 'N', 'listener_username' => 'u']);
+        $model->setNew(false);
+
+        (new Source($model, $db))->setName('Updated')->save();
+    }
+
+    public function testSaveThrowsForNewSourceWithoutNameAndType(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Source must have a name and type');
+
+        (new Source((new SourceModel())->setNew(), $this->createStub(Connection::class)))->save();
+    }
+
+    public function testSaveThrowsForNewSourceWithoutName(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Source must have a name and type');
+
+        (new Source((new SourceModel())->setNew(), $this->createStub(Connection::class)))->setType('icingadb')->save();
+    }
+
+    public function testSaveThrowsForNewSourceWithoutType(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Source must have a name and type');
+
+        (new Source((new SourceModel())->setNew(), $this->createStub(Connection::class)))->setName('N')->save();
+    }
+
+    public function testDeleteMarksSourceAsDeleted(): void
+    {
+        $model = new SourceModel([
+            'id'                => 5,
+            'listener_username' => 'u',
+            'deleted'           => 'n'
+        ]);
+        $model->setNew(false);
+        $model->rule = new class {
+            public function columns(string $_): array
+            {
+                return [];
+            }
+        };
+
+        $db = $this->getConnectionMock();
+        $db->expects($this->once())
+            ->method('update')
+            ->willReturnCallback(function ($_, $data) {
+                $this->assertSame('y', $data['deleted']);
+                $this->assertNull($data['listener_username']);
+
+                return $this->createStub(PDOStatement::class);
+            });
+
+        (new Source($model, $db))->delete();
+    }
+
+    private function getConnectionMock(): Connection&MockObject
+    {
+        $db = $this->createMock(Connection::class);
+        $db->method('transaction')->willReturnCallback(fn(callable $cb) => $cb());
+        $db->method('quoteIdentifier')->willReturnCallback(fn($s) => $s);
+
+        return $db;
+    }
+}

--- a/test/php/library/Notifications/Repository/SourceRepositoryTest.php
+++ b/test/php/library/Notifications/Repository/SourceRepositoryTest.php
@@ -1,20 +1,18 @@
 <?php
 
-// SPDX-FileCopyrightText: 2024 Icinga GmbH <https://icinga.com>
+// SPDX-FileCopyrightText: 2026 Icinga GmbH <https://icinga.com>
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-namespace Tests\Icinga\Module\Notifications\Forms;
-
-use Icinga\Module\Notifications\Forms\SourceForm;
+use Icinga\Module\Notifications\Repository\SourceRepository;
 use PHPUnit\Framework\TestCase;
 
-class SourceFormTest extends TestCase
+class SourceRepositoryTest extends TestCase
 {
     public function testWhetherTheUsedHashAlgorithmIsStillTheDefault()
     {
         $this->assertSame(
             PASSWORD_DEFAULT,
-            SourceForm::HASH_ALGORITHM,
+            SourceRepository::HASH_ALGORITHM,
             'PHP\'s default password hash algorithm changed. Consider adding support for it'
         );
     }

--- a/test/php/library/Notifications/Repository/SourceRepositoryTest.php
+++ b/test/php/library/Notifications/Repository/SourceRepositoryTest.php
@@ -3,17 +3,395 @@
 // SPDX-FileCopyrightText: 2026 Icinga GmbH <https://icinga.com>
 // SPDX-License-Identifier: GPL-3.0-or-later
 
+namespace Tests\Icinga\Module\Notifications\Repository;
+
+use DateTime;
+use Icinga\Module\Notifications\Model\Source;
 use Icinga\Module\Notifications\Repository\SourceRepository;
+use ipl\Sql\Connection;
+use PDO;
+use PDOStatement;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * Tests for {@see SourceRepository}.
+ *
+ * No real database is used. A {@see Connection} mock is used and the statements the repository is expected to issue
+ * are anticipated and verified. ORM-driven SELECT queries are served by returning real {@see PDOStatement}s (backed
+ * by an in-memory SQLite database) whose rows the ORM hydrates into models.
+ *
+ * {@see SourceRepository} delegates writes to {@see \Icinga\Module\Notifications\Common\EntityManager}, which wraps
+ * every save in a transaction. The mock's `transaction()` is wired to invoke the callback so that the EntityManager's
+ * insert/update calls reach the mock's expectations.
+ *
+ * What these tests do not cover:
+ * - The actual interaction with a production database.
+ * - The rendered SQL of the issued statements (the connection is mocked before rendering happens).
+ */
 class SourceRepositoryTest extends TestCase
 {
-    public function testWhetherTheUsedHashAlgorithmIsStillTheDefault()
+    /**
+     * Build a real PDOStatement yielding the given rows.
+     *
+     * The ORM's Hydrator consumes the PDOStatement returned by the mocked `select()`. Feeding it a
+     * real statement (even one backed by an in-memory SQLite) gives the Hydrator a genuine cursor to
+     * iterate and lets it map column values to model properties normally.
+     *
+     * @param list<array<string, mixed>> $rows
+     *
+     * @return PDOStatement
+     */
+    private function selectResult(array $rows): PDOStatement
+    {
+        $columns = empty($rows) ? ['id'] : array_keys($rows[0]);
+
+        $pdo = new PDO('sqlite::memory:');
+        $pdo->setAttribute(PDO::ATTR_DEFAULT_FETCH_MODE, PDO::FETCH_OBJ);
+        $pdo->exec('CREATE TABLE result (' . implode(', ', array_map(fn($c) => '"' . $c . '"', $columns)) . ')');
+
+        if (! empty($rows)) {
+            $insert = $pdo->prepare(
+                'INSERT INTO result VALUES (' . implode(', ', array_fill(0, count($columns), '?')) . ')'
+            );
+            foreach ($rows as $row) {
+                $insert->execute(array_values($row));
+            }
+        }
+
+        return $pdo->query('SELECT * FROM result');
+    }
+
+    public function testWhetherTheUsedHashAlgorithmIsStillTheDefault(): void
     {
         $this->assertSame(
             PASSWORD_DEFAULT,
             SourceRepository::HASH_ALGORITHM,
             'PHP\'s default password hash algorithm changed. Consider adding support for it'
         );
+    }
+
+    public function testFindHydratesTheSource(): void
+    {
+        $db = $this->getConnectionMock();
+        $db->expects($this->once())
+            ->method('select')
+            ->willReturn($this->selectResult([
+                [
+                    'id'               => 5,
+                    'type'             => 'icingadb',
+                    'name'             => 'Icinga 2',
+                    'listener_username' => 'listener',
+                    'deleted'          => 'n',
+                    'locked'           => 'n'
+                ]
+            ]));
+
+        $source = (new SourceRepository($db))->find(5);
+
+        $this->assertNotNull($source, 'find() did not return the source');
+        $this->assertEquals(5, $source->id);
+        $this->assertSame('icingadb', $source->type);
+        $this->assertSame('Icinga 2', $source->name);
+        $this->assertSame('listener', $source->listener_username);
+        $this->assertFalse($source->deleted, 'The deleted flag should be cast to a bool');
+        $this->assertFalse($source->locked, 'The locked flag should be cast to a bool');
+    }
+
+    public function testFindReturnsNullIfSourceDoesNotExist(): void
+    {
+        $db = $this->getConnectionMock();
+        $db->expects($this->once())
+            ->method('select')
+            ->willReturn($this->selectResult([]));
+
+        $this->assertNull((new SourceRepository($db))->find(404));
+    }
+
+    public function testFindByUsernameHydratesTheSource(): void
+    {
+        $db = $this->getConnectionMock();
+        $db->expects($this->once())
+            ->method('select')
+            ->willReturn($this->selectResult([
+                [
+                    'id'               => 5,
+                    'type'             => 'icingadb',
+                    'name'             => 'Icinga 2',
+                    'listener_username' => 'alice',
+                    'deleted'          => 'n',
+                    'locked'           => 'n'
+                ]
+            ]));
+
+        $source = (new SourceRepository($db))->findByUsername('alice');
+
+        $this->assertNotNull($source, 'findByUsername() did not return the source');
+        $this->assertEquals(5, $source->id);
+        $this->assertSame('alice', $source->listener_username);
+    }
+
+    public function testFindByUsernameReturnsNullIfNotFound(): void
+    {
+        $db = $this->getConnectionMock();
+        $db->expects($this->once())
+            ->method('select')
+            ->willReturn($this->selectResult([]));
+
+        $this->assertNull((new SourceRepository($db))->findByUsername('nobody'));
+    }
+
+    public function testCreateInsertsSourceAndAssignsId(): void
+    {
+        $start = (int) (new DateTime())->format('Uv');
+
+        $source = new Source([
+            'type'              => 'icingadb',
+            'name'              => 'Icinga 2',
+            'listener_username' => 'listener'
+        ]);
+        $source->setNew();
+
+        $db = $this->getConnectionMock();
+        $db->expects($this->never())->method('update');
+        $db->expects($this->once())
+            ->method('insert')
+            ->willReturnCallback(function ($table, $data) use ($start) {
+                $this->assertSame('source', $table);
+                $this->assertArrayHasKey('changed_at', $data);
+                $this->assertGreaterThanOrEqual($start, $data['changed_at']);
+                unset($data['changed_at']);
+                $this->assertSame(
+                    ['type' => 'icingadb', 'name' => 'Icinga 2', 'listener_username' => 'listener'],
+                    $data
+                );
+
+                return $this->createStub(PDOStatement::class);
+            });
+        $db->expects($this->once())->method('lastInsertId')->willReturn('42');
+
+        (new SourceRepository($db))->create($source);
+
+        $this->assertEquals(42, $source->id, 'The generated id was not assigned to the source');
+    }
+
+    public function testCreateHashesPasswordBeforeInserting(): void
+    {
+        $source = new Source(['type' => 'icingadb', 'name' => 'Src']);
+        $source->listener_password = 'mysecret';
+        $source->setNew();
+
+        $db = $this->getConnectionMock();
+        $db->expects($this->once())
+            ->method('insert')
+            ->willReturnCallback(function ($_, $data) {
+                $this->assertArrayHasKey('listener_password_hash', $data);
+                $this->assertNotSame('mysecret', $data['listener_password_hash']);
+                $this->assertTrue(
+                    password_verify('mysecret', $data['listener_password_hash']),
+                    'The insert data must carry a valid bcrypt hash of the password'
+                );
+
+                return $this->createStub(PDOStatement::class);
+            });
+        $db->method('lastInsertId')->willReturn('1');
+
+        (new SourceRepository($db))->create($source);
+    }
+
+    public function testUpdateUpdatesTheSource(): void
+    {
+        $start = (int) (new DateTime())->format('Uv');
+
+        $source = new Source([
+            'id'   => 5,
+            'type' => 'icingadb',
+            'name' => 'Old Name'
+        ]);
+        $source->setNew(false);
+        $source->name = 'Renamed';
+
+        $db = $this->getConnectionMock();
+        $db->expects($this->never())->method('insert');
+        $db->expects($this->once())
+            ->method('update')
+            ->willReturnCallback(function ($table, $data, $where) use ($start) {
+                $this->assertSame('source', $table);
+                $this->assertSame(['id = ?' => 5], $where);
+                $this->assertArrayHasKey('changed_at', $data);
+                $this->assertGreaterThanOrEqual($start, $data['changed_at']);
+                unset($data['changed_at']);
+                $this->assertSame(['name' => 'Renamed'], $data);
+
+                return $this->createStub(PDOStatement::class);
+            });
+
+        (new SourceRepository($db))->update($source);
+    }
+
+    public function testUpdateHashesPasswordBeforeUpdating(): void
+    {
+        $source = new Source(['id' => 5, 'type' => 'icingadb', 'name' => 'Src']);
+        $source->setNew(false);
+        $source->listener_password = 'newsecret';
+
+        $db = $this->getConnectionMock();
+        $db->expects($this->never())->method('insert');
+        $db->expects($this->once())
+            ->method('update')
+            ->willReturnCallback(function ($_, $data) {
+                $this->assertArrayHasKey('listener_password_hash', $data);
+                $this->assertTrue(
+                    password_verify('newsecret', $data['listener_password_hash']),
+                    'The update data must carry a valid bcrypt hash of the new password'
+                );
+
+                return $this->createStub(PDOStatement::class);
+            });
+
+        (new SourceRepository($db))->update($source);
+    }
+
+    /**
+     * Covers deleting a source that has no rules, so only the source row itself is soft-deleted.
+     *
+     * Three selects are expected: one for {@see SourceRepository::find()}, one for the lazy-loaded
+     * `rule` relation that {@see SourceRepository::delete()} iterates (returns no rows, so
+     * {@see \Icinga\Module\Notifications\Forms\EventRuleConfigForm::removeRule()} is never called), and
+     * one for {@see EntityManager::stampChangedAt()}'s `MAX(changed_at)` read, which fires when the
+     * source itself is persisted via {@see EntityManager::save()}. The latter is unrelated to the rule
+     * cascade this test covers, but is triggered as a side effect of every `EntityManager::save()` call
+     * on a model with a `changed_at` column.
+     *
+     * @return void
+     */
+    public function testDeleteMarksSourceDeleted(): void
+    {
+        $start = (int) (new DateTime())->format('Uv');
+
+        $db = $this->getConnectionMock();
+        $db->expects($this->exactly(3))
+            ->method('select')
+            ->willReturnOnConsecutiveCalls(
+                $this->selectResult([
+                    [
+                        'id'               => 5,
+                        'type'             => 'icingadb',
+                        'name'             => 'Icinga 2',
+                        'listener_username' => 'u',
+                        'deleted'          => 'n',
+                        'locked'           => 'n'
+                    ]
+                ]),
+                $this->selectResult([]), // no rules — EventRuleConfigForm::removeRule is never called
+                $this->selectResult([['changed_at' => 0]]) // EntityManager::stampChangedAt()'s MAX(changed_at)
+            );
+        $db->expects($this->once())
+            ->method('update')
+            ->willReturnCallback(function ($table, $data, $where) use ($start) {
+                $this->assertSame('source', $table);
+                $this->assertSame(['id = ?' => '5'], $where);
+                $this->assertSame('y', $data['deleted']);
+                $this->assertNull($data['listener_username']);
+                $this->assertArrayHasKey('changed_at', $data);
+                $this->assertGreaterThanOrEqual($start, $data['changed_at']);
+
+                return $this->createStub(PDOStatement::class);
+            });
+
+        $repo = new SourceRepository($db);
+        $repo->delete($repo->find(5));
+    }
+
+    /**
+     * Covers deleting a source that has a linked rule: {@see EventRuleConfigForm::removeRule()} must be
+     * called for each rule, soft-deleting the rule and its escalations before the source itself is deleted.
+     *
+     * Four selects are expected: one for {@see SourceRepository::find()}, one for the lazy-loaded `rule`
+     * relation (returns one rule), one for the lazy-loaded `rule_escalation` relation inside
+     * {@see EventRuleConfigForm::removeRule()} (returns no escalations to keep the test focused), and one
+     * for {@see EntityManager::stampChangedAt()}'s `MAX(changed_at)` read, which fires when the source
+     * itself is persisted via {@see EntityManager::save()}. The latter is unrelated to the rule/escalation
+     * cascade this test actually covers, but is triggered as a side effect of every `EntityManager::save()`
+     * call on a model with a `changed_at` column.
+     *
+     * @return void
+     */
+    public function testDeleteRemovesLinkedRules(): void
+    {
+        $db = $this->getConnectionMock();
+        $db->expects($this->exactly(4))
+            ->method('select')
+            ->willReturnOnConsecutiveCalls(
+                $this->selectResult([
+                    [
+                        'id'               => 5,
+                        'type'             => 'icingadb',
+                        'name'             => 'Icinga 2',
+                        'listener_username' => 'u',
+                        'deleted'          => 'n',
+                        'locked'           => 'n'
+                    ]
+                ]),
+                $this->selectResult([
+                    ['id' => 7]
+                ]),
+                $this->selectResult([]), // no escalations
+                $this->selectResult([['changed_at' => 0]]) // EntityManager::stampChangedAt()'s MAX(changed_at)
+            );
+
+        $updatedTables = [];
+        $db->expects($this->exactly(3))
+            ->method('update')
+            ->willReturnCallback(function ($table) use (&$updatedTables) {
+                $updatedTables[] = $table;
+
+                return $this->createStub(PDOStatement::class);
+            });
+
+        $repo = new SourceRepository($db);
+        $repo->delete($repo->find(5));
+
+        $this->assertContains('rule', $updatedTables, 'The linked rule must be soft-deleted');
+        $this->assertContains('source', $updatedTables, 'The source itself must be soft-deleted');
+    }
+
+
+    public function testCreateClearsPlaintextPasswordAfterHashing(): void
+    {
+        $source = new Source(['type' => 'icingadb', 'name' => 'Src']);
+        $source->listener_password = 'mysecret';
+        $source->setNew();
+
+        $db = $this->getConnectionMock();
+        $db->method('insert')->willReturn($this->createStub(PDOStatement::class));
+        $db->method('lastInsertId')->willReturn('1');
+
+        (new SourceRepository($db))->create($source);
+
+        $this->assertFalse(isset($source->listener_password), 'listener_password must be unset after hashing');
+    }
+
+    public function testUpdateClearsPlaintextPasswordAfterHashing(): void
+    {
+        $source = new Source(['id' => 5, 'type' => 'icingadb', 'name' => 'Src']);
+        $source->setNew(false);
+        $source->listener_password = 'newsecret';
+
+        $db = $this->getConnectionMock();
+        $db->method('update')->willReturn($this->createStub(PDOStatement::class));
+
+        (new SourceRepository($db))->update($source);
+
+        $this->assertFalse(isset($source->listener_password), 'listener_password must be unset after hashing');
+    }
+
+    private function getConnectionMock(): Connection&MockObject
+    {
+        $db = $this->createMock(Connection::class);
+        $db->method('transaction')->willReturnCallback(fn(callable $cb) => $cb());
+        $db->method('quoteIdentifier')->willReturnCallback(fn($s) => $s);
+
+        return $db;
     }
 }


### PR DESCRIPTION
Add `Sources` class so integrations can use it to configure and manage their notification source.

Test classes are generated using claude code.

resolves https://github.com/Icinga/icinga-notifications-web/issues/463
require https://github.com/Icinga/icinga-notifications/pull/432

Blocked by: https://github.com/Icinga/icinga-notifications-web/pull/482