### PR TITLE
`SourceForm`: Show sources maintained by integration as read-only

### DIFF
--- a/application/forms/DeleteSourceForm.php
+++ b/application/forms/DeleteSourceForm.php
@@ -16,6 +16,7 @@ use ipl\Sql\Connection;
 use ipl\Stdlib\Filter;
 use ipl\Web\Common\CsrfCounterMeasure;
 use ipl\Web\Compat\CompatForm;
+use RuntimeException;
 
 class DeleteSourceForm extends CompatForm
 {
@@ -36,7 +37,7 @@ class DeleteSourceForm extends CompatForm
     public function loadSource(int $id): static
     {
         $source = Source::on(Database::get())
-            ->columns(['id', 'name'])
+            ->columns(['id', 'name', 'locked'])
             ->filter(Filter::equal('id', $id))
             ->first();
         /** @var ?Source $source */
@@ -104,6 +105,10 @@ class DeleteSourceForm extends CompatForm
      */
     public function removeSource(Connection $db): void
     {
+        if ($this->source->locked) {
+            throw new RuntimeException('Source is locked');
+        }
+
         $rules = Rule::on($db)
             ->columns('id')
             ->filter(Filter::equal('source_id', $this->source->id));

--- a/application/forms/SourceForm.php
+++ b/application/forms/SourceForm.php
@@ -15,10 +15,13 @@ use ipl\Html\Text;
 use ipl\Sql\Connection;
 use ipl\Stdlib\Filter;
 use ipl\Validator\CallbackValidator;
+use ipl\Web\Common\CalloutType;
 use ipl\Web\Common\CsrfCounterMeasure;
 use ipl\Web\Compat\CompatForm;
 use ipl\Web\Url;
 use ipl\Web\Widget\ButtonLink;
+use ipl\Web\Widget\Callout;
+use RuntimeException;
 
 class SourceForm extends CompatForm
 {
@@ -39,6 +42,9 @@ class SourceForm extends CompatForm
     /** @var ?int */
     private ?int $sourceId = null;
 
+    /** @var bool Whether the source is locked for editing */
+    private bool $isLocked = false;
+
     public function __construct(Connection $db)
     {
         $this->db = $db;
@@ -46,6 +52,7 @@ class SourceForm extends CompatForm
 
     protected function assemble(): void
     {
+        $this->addAttributes(Attributes::create(['class' => 'source-form']));
         $this->applyDefaultElementDecorators();
         $this->addCsrfCounterMeasure();
         $this->addHtml(new HtmlElement(
@@ -64,7 +71,8 @@ class SourceForm extends CompatForm
             'name',
             [
                 'label'     => $this->translate('Source Name'),
-                'required'  => true
+                'required'  => true,
+                'disabled'  => $this->isLocked
             ]
         );
         $this->addElement(
@@ -75,6 +83,7 @@ class SourceForm extends CompatForm
                 'required'  => true,
                 'label'     => $this->translate('Source Type'),
                 'value'     => self::TYPE_GENERIC,
+                'disabled'  => $this->isLocked,
                 'class'     => 'autosubmit',
                 'options'   => [
                     self::TYPE_GENERIC    => $this->translate('Generic', 'notifications.source.type'),
@@ -103,6 +112,7 @@ class SourceForm extends CompatForm
                 [
                     'required'      => true,
                     'label'         => $this->translate('Source Identifier'),
+                    'disabled'  => $this->isLocked
                 ]
             );
         }
@@ -128,6 +138,7 @@ class SourceForm extends CompatForm
             [
                 'required' => true,
                 'label' => $this->translate('Username'),
+                'disabled'  => $this->isLocked,
                 'validators' => [new CallbackValidator(
                     function ($value, CallbackValidator $validator) {
                         // Username must be unique
@@ -147,6 +158,15 @@ class SourceForm extends CompatForm
                 )]
             ]
         );
+
+        if ($this->isLocked) {
+            $this->prependHtml(new Callout(
+                CalloutType::Info,
+                $this->translate('This source is managed by an integration, so changes can only be applied through it.')
+            ));
+
+            return;
+        }
 
         $credentials->addElement(
             'password',
@@ -260,6 +280,10 @@ class SourceForm extends CompatForm
      */
     public function editSource(): void
     {
+        if ($this->isLocked) {
+            throw new RuntimeException('Source is locked');
+        }
+
         $data = $this->getValues();
 
         $source = [
@@ -310,6 +334,8 @@ class SourceForm extends CompatForm
         if ($source === null) {
             throw new HttpNotFoundException($this->translate('Source not found'));
         }
+
+        $this->isLocked = $source->locked;
 
         return [
             'name' => $source->name,

--- a/library/Notifications/Model/Source.php
+++ b/library/Notifications/Model/Source.php
@@ -26,6 +26,7 @@ use Throwable;
  * @property ?string $listener_password_hash
  * @property DateTime $changed_at
  * @property bool $deleted
+ * @property bool $locked
  *
  * @property Query|Objects $object
  * @property Query|Rule $rule
@@ -53,7 +54,8 @@ class Source extends Model
             'listener_username',
             'listener_password_hash',
             'changed_at',
-            'deleted'
+            'deleted',
+            'locked'
         ];
     }
 
@@ -80,7 +82,7 @@ class Source extends Model
     public function createBehaviors(Behaviors $behaviors): void
     {
         $behaviors->add(new MillisecondTimestamp(['changed_at']));
-        $behaviors->add(new BoolCast(['deleted']));
+        $behaviors->add(new BoolCast(['deleted', 'locked']));
     }
 
     public function createRelations(Relations $relations): void

--- a/public/css/form.less
+++ b/public/css/form.less
@@ -174,3 +174,7 @@
     border-top: 1px solid var(--gray-light, @gray-light);
   }
 }
+
+.source-form .callout {
+  margin-bottom: 1em;
+}


### PR DESCRIPTION
This pull request introduces a `locked/read-only` mode for the Source configuration form, intended for sources whose configuration is maintained by an integration and should not be editable in Notification Web.

#### Changes:

- Add a locked boolean column to the `Source` model (including boolean casting).
- Update SourceForm to detect `source.locked` to render the form as read-only with an informational callout.

resolves #462
