### PR TITLE
`EscalationRecipient`: Improve default label of channel selection element

### DIFF
--- a/application/forms/EventRuleConfigElements/EscalationRecipient.php
+++ b/application/forms/EventRuleConfigElements/EscalationRecipient.php
@@ -118,7 +118,7 @@ class EscalationRecipient extends FieldsetElement
     protected function assemble(): void
     {
         $pleaseChoose = ['' => sprintf(' - %s - ', $this->translate('Please choose'))];
-        $defaultChannel = ['' => $this->translate('Default Channel')];
+        $defaultChannel = ['' => $this->translate('Contact Default Channel')];
 
         $this->addElement('hidden', 'id');
 


### PR DESCRIPTION
This PR improves the default label of the channel selection element.

resolves: #477