### PR TITLE
`RotationConfigForm`: Fix handoff interval 0

### DIFF
--- a/application/forms/RotationConfigForm.php
+++ b/application/forms/RotationConfigForm.php
@@ -955,7 +955,8 @@ class RotationConfigForm extends CompatForm
             'min' => 1,
             'value' => 1,
             'label' => $this->translate('Handoff every'),
-            'description' => $this->translate('Have multiple rotation members take turns after this interval.')
+            'description' => $this->translate('Have multiple rotation members take turns after this interval.'),
+            'validators' => [new GreaterThanValidator()]
         ]);
         $interval = $options->getElement('interval');
         $interval->getDecorators()
@@ -1240,6 +1241,10 @@ class RotationConfigForm extends CompatForm
                 'p',
                 Attributes::create(['id' => 'first-handoff-description']),
                 DeferredText::create(function () {
+                    if (! $this->isValid()) {
+                        return '';
+                    }
+
                     $ruleGenerator = $this->yieldRecurrenceRules(1);
                     if (! $ruleGenerator->valid()) {
                         return $this->translate('This rotation can no longer happen');
@@ -1262,6 +1267,10 @@ class RotationConfigForm extends CompatForm
                 }),
                 new HtmlElement('br'),
                 $this->displayTimezone !== $this->scheduleTimezone ? DeferredText::create(function () {
+                    if (! $this->isValid()) {
+                        return '';
+                    }
+
                     $ruleGenerator = $this->yieldRecurrenceRules(1);
                     if (! $ruleGenerator->valid()) {
                         return '';


### PR DESCRIPTION
resolve #438 

The stacktrace was caused by the `Rotation Start` autosubmitting in order to calculate the first handoff, which happens before the handoff interval is validated.

To prevent this, the first handoff is only calculated for valid `$options` and a missing `GreaterThanValidator` for the interval of the multi day mode is added, the other 2 modes already use one.