### PR TITLE
Enhance severity icons

### DIFF
--- a/application/forms/EventRuleConfigElements/EscalationCondition.php
+++ b/application/forms/EventRuleConfigElements/EscalationCondition.php
@@ -5,6 +5,7 @@
 
 namespace Icinga\Module\Notifications\Forms\EventRuleConfigElements;
 
+use Icinga\Module\Notifications\Common\Severity;
 use ipl\Html\Attributes;
 use ipl\Html\FormElement\FieldsetElement;
 use ipl\Html\FormElement\SubmitButtonElement;
@@ -140,19 +141,14 @@ class EscalationCondition extends FieldsetElement
         ]);
 
         if ($selectedColumn === 'incident_severity') {
+            $severityOptions = [];
+            foreach (Severity::cases() as $severity) {
+                $severityOptions[$severity->getValue()] = $severity->getLabel();
+            }
+
             $this->addElement('select', 'severity', [
                 'required' => true,
-                'options' => [
-                    'ok' => $this->translate('Ok', 'notification.severity'),
-                    'debug' => $this->translate('Debug', 'notification.severity'),
-                    'info' => $this->translate('Information', 'notification.severity'),
-                    'notice' => $this->translate('Notice', 'notification.severity'),
-                    'warning' => $this->translate('Warning', 'notification.severity'),
-                    'err' => $this->translate('Error', 'notification.severity'),
-                    'crit' => $this->translate('Critical', 'notification.severity'),
-                    'alert' => $this->translate('Alert', 'notification.severity'),
-                    'emerg' => $this->translate('Emergency', 'notification.severity')
-                ]
+                'options'  => $severityOptions
             ]);
         } elseif ($selectedColumn === 'incident_age') {
             $noOf = $this->createElement('number', 'no_of', [

--- a/library/Notifications/Common/Icons.php
+++ b/library/Notifications/Common/Icons.php
@@ -59,7 +59,7 @@ final class Icons
 
     public const UNMUTE = 'volume-high';
 
-    public const SEVERITY_OK = 'heart';
+    public const SEVERITY_OK = 'circle-check';
 
     public const SEVERITY_CRIT = 'circle-exclamation';
 

--- a/library/Notifications/Common/Icons.php
+++ b/library/Notifications/Common/Icons.php
@@ -58,22 +58,4 @@ final class Icons
     public const MUTE = 'volume-xmark';
 
     public const UNMUTE = 'volume-high';
-
-    public const SEVERITY_OK = 'circle-check';
-
-    public const SEVERITY_CRIT = 'circle-exclamation';
-
-    public const SEVERITY_WARN = 'triangle-exclamation';
-
-    public const SEVERITY_ERR = 'circle-xmark';
-
-    public const SEVERITY_DEBUG = 'bug-slash';
-
-    public const SEVERITY_INFO = 'circle-info';
-
-    public const SEVERITY_ALERT = 'bell';
-
-    public const SEVERITY_EMERG = 'bullhorn';
-
-    public const SEVERITY_NOTICE = 'envelope';
 }

--- a/library/Notifications/Common/Severity.php
+++ b/library/Notifications/Common/Severity.php
@@ -1,0 +1,83 @@
+<?php
+
+// SPDX-FileCopyrightText: 2026 Icinga GmbH <https://icinga.com>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+namespace Icinga\Module\Notifications\Common;
+
+use ipl\Web\Widget\Icon;
+
+/**
+ * Incident severity levels
+ *
+ * Each case maps to the backing string stored in the `severity` type column of the `incident` and `incident_history`
+ * tables. Register {@see \ipl\Orm\Behavior\EnumCast} on a model to have those columns hydrated automatically as enum
+ * instances.
+ */
+enum Severity: string
+{
+    case OK        = 'ok';
+    case CRITICAL  = 'crit';
+    case WARNING   = 'warning';
+    case ERROR     = 'err';
+    case DEBUG     = 'debug';
+    case INFO      = 'info';
+    case ALERT     = 'alert';
+    case EMERGENCY = 'emerg';
+    case NOTICE    = 'notice';
+
+    /**
+     * Get the backing string value
+     *
+     * @return string
+     */
+    public function getValue(): string
+    {
+        return $this->value;
+    }
+
+    /**
+     * Get the label
+     *
+     * @return string
+     */
+    public function getLabel(): string
+    {
+        return match ($this) {
+            self::OK        => t('Ok', 'notifications.severity'),
+            self::CRITICAL  => t('Critical', 'notifications.severity'),
+            self::WARNING   => t('Warning', 'notifications.severity'),
+            self::ERROR     => t('Error', 'notifications.severity'),
+            self::DEBUG     => t('Debug', 'notifications.severity'),
+            self::INFO      => t('Information', 'notifications.severity'),
+            self::ALERT     => t('Alert', 'notifications.severity'),
+            self::EMERGENCY => t('Emergency', 'notifications.severity'),
+            self::NOTICE    => t('Notice', 'notifications.severity'),
+        };
+    }
+
+    /**
+     * Get the icon
+     *
+     * @return Icon
+     */
+    public function getIcon(): Icon
+    {
+        $icon = match ($this) {
+            self::OK        => 'circle-check',
+            self::CRITICAL  => 'circle-exclamation',
+            self::WARNING   => 'triangle-exclamation',
+            self::ERROR     => 'circle-xmark',
+            self::DEBUG     => 'bug-slash',
+            self::INFO      => 'circle-info',
+            self::ALERT     => 'bell',
+            self::EMERGENCY => 'bullhorn',
+            self::NOTICE    => 'envelope'
+        };
+
+        return new Icon($icon, [
+            'class' => ['severity-' . $this->getValue()],
+            'title' => sprintf(t('Severity set to %s'), $this->getLabel())
+        ]);
+    }
+}

--- a/library/Notifications/Daemon/Daemon.php
+++ b/library/Notifications/Daemon/Daemon.php
@@ -285,7 +285,7 @@ class Daemon extends EventEmitter
                         $notification->contact_id,
                         (object) [
                             'incident_id' => $notification->incident_id,
-                            'severity'    => $incident->severity,
+                            'severity'    => $incident->severity->getValue(),
                             'title'       => ObjectsRendererHook::getObjectNameAsString($incident->object),
                             'message'     => $notification->message
                         ]

--- a/library/Notifications/Model/Incident.php
+++ b/library/Notifications/Model/Incident.php
@@ -7,7 +7,9 @@ namespace Icinga\Module\Notifications\Model;
 
 use DateTime;
 use Icinga\Module\Notifications\Common\Database;
+use Icinga\Module\Notifications\Common\Severity;
 use ipl\Orm\Behavior\Binary;
+use ipl\Orm\Behavior\EnumCast;
 use ipl\Orm\Behavior\MillisecondTimestamp;
 use ipl\Orm\Behaviors;
 use ipl\Orm\Model;
@@ -23,7 +25,7 @@ use ipl\Sql\Select;
  * @property string $object_id
  * @property DateTime $started_at
  * @property ?DateTime $recovered_at
- * @property string $severity
+ * @property Severity $severity
  * @property ?string $mute_reason
  *
  * @property Query|Objects $object
@@ -97,6 +99,7 @@ class Incident extends Model
             'started_at',
             'recovered_at'
         ]));
+        $behaviors->add(new EnumCast(Severity::class, ['severity']));
     }
 
     public function createRelations(Relations $relations): void

--- a/library/Notifications/Model/IncidentHistory.php
+++ b/library/Notifications/Model/IncidentHistory.php
@@ -7,6 +7,8 @@ namespace Icinga\Module\Notifications\Model;
 
 use DateTime;
 use Icinga\Module\Notifications\Common\Database;
+use Icinga\Module\Notifications\Common\Severity;
+use ipl\Orm\Behavior\EnumCast;
 use ipl\Orm\Behavior\MillisecondTimestamp;
 use ipl\Orm\Behaviors;
 use ipl\Orm\Model;
@@ -28,8 +30,8 @@ use ipl\Sql\Select;
  * @property ?int $schedule_id
  * @property ?int $contactgroup_id
  * @property ?int $channel_id
- * @property ?string $new_severity
- * @property ?string $old_severity
+ * @property ?Severity $new_severity
+ * @property ?Severity $old_severity
  * @property ?string $new_recipient_role
  * @property ?string $old_recipient_role
  * @property ?string $message
@@ -100,6 +102,7 @@ class IncidentHistory extends Model
     public function createBehaviors(Behaviors $behaviors): void
     {
         $behaviors->add(new MillisecondTimestamp(['time', 'sent_at']));
+        $behaviors->add(new EnumCast(Severity::class, ['new_severity', 'old_severity']));
     }
 
     public function getDefaultSort(): array

--- a/library/Notifications/View/IncidentHistoryRenderer.php
+++ b/library/Notifications/View/IncidentHistoryRenderer.php
@@ -41,11 +41,36 @@ class IncidentHistoryRenderer implements ItemRenderer
 
     public function assembleVisual($item, HtmlDocument $visual, string $layout): void
     {
-        $incidentIcon = $this->getIncidentEventIcon($item);
         if ($item->type === 'incident_severity_changed') {
-            $content = new Icon($incidentIcon, ['class' => 'severity-' . $item->new_severity]);
+            [$icon, $title] = match ($item->new_severity) {
+                'ok'      => [Icons::SEVERITY_OK, $this->translate('Ok')],
+                'warning' => [Icons::SEVERITY_WARN, $this->translate('Warning')],
+                'err'     => [Icons::SEVERITY_ERR, $this->translate('Error')],
+                'crit'    => [Icons::SEVERITY_CRIT, $this->translate('Critical')],
+                'debug'   => [Icons::SEVERITY_DEBUG, $this->translate('Debug')],
+                'info'    => [Icons::SEVERITY_INFO, $this->translate('Info')],
+                'alert'   => [Icons::SEVERITY_ALERT, $this->translate('Alert')],
+                'emerg'   => [Icons::SEVERITY_EMERG, $this->translate('Emergency')],
+                'notice'  => [Icons::SEVERITY_NOTICE, $this->translate('Notice')],
+                default   => [Icons::UNDEFINED, $this->translate('Undefined')]
+            };
+
+            $content = new Icon($icon, [
+                'class' => ['severity-' . $item->new_severity],
+                'title' => sprintf('%s: %s', $this->translate('Severity'), $title)
+            ]);
         } else {
-            $content = new IconBall($incidentIcon);
+            $content = new IconBall(match ($item->type) {
+                'opened'                    => Icons::OPENED,
+                'muted'                     => Icons::MUTE,
+                'unmuted'                   => Icons::UNMUTE,
+                'recipient_role_changed'    => $this->getRoleIcon($item),
+                'closed'                    => Icons::CLOSED,
+                'rule_matched'              => Icons::RULE_MATCHED,
+                'escalation_triggered'      => Icons::TRIGGERED,
+                'notified'                  => Icons::NOTIFIED,
+                default                     => Icons::UNDEFINED
+            });
         }
 
         $visual->addHtml($content);
@@ -72,47 +97,6 @@ class IncidentHistoryRenderer implements ItemRenderer
     public function assemble($item, string $name, HtmlDocument $element, string $layout): bool
     {
         return false; // no custom sections
-    }
-
-    /**
-     * Get the icon for the incident event
-     *
-     * @param IncidentHistory $item
-     *
-     * @return string
-     */
-    protected function getIncidentEventIcon(IncidentHistory $item): string
-    {
-        return match ($item->type) {
-            'opened'                    => Icons::OPENED,
-            'muted'                     => Icons::MUTE,
-            'unmuted'                   => Icons::UNMUTE,
-            'incident_severity_changed' => $this->getSeverityIcon($item),
-            'recipient_role_changed'    => $this->getRoleIcon($item),
-            'closed'                    => Icons::CLOSED,
-            'rule_matched'              => Icons::RULE_MATCHED,
-            'escalation_triggered'      => Icons::TRIGGERED,
-            'notified'                  => Icons::NOTIFIED,
-            default                     => Icons::UNDEFINED
-        };
-    }
-
-    /**
-     * Get the icon for the new incident severity
-     *
-     * @param IncidentHistory $item
-     *
-     * @return string
-     */
-    protected function getSeverityIcon(IncidentHistory $item): string
-    {
-        return match ($item->new_severity) {
-            'ok'      => Icons::OK,
-            'warning' => Icons::WARNING,
-            'err'     => Icons::ERROR,
-            'crit'    => Icons::CRITICAL,
-            default   => Icons::UNDEFINED
-        };
     }
 
     /**

--- a/library/Notifications/View/IncidentHistoryRenderer.php
+++ b/library/Notifications/View/IncidentHistoryRenderer.php
@@ -16,7 +16,6 @@ use ipl\Html\Text;
 use ipl\Html\ValidHtml;
 use ipl\I18n\Translation;
 use ipl\Web\Common\ItemRenderer;
-use ipl\Web\Widget\Icon;
 use ipl\Web\Widget\TimeAgo;
 
 /** @implements ItemRenderer<IncidentHistory> */
@@ -42,23 +41,7 @@ class IncidentHistoryRenderer implements ItemRenderer
     public function assembleVisual($item, HtmlDocument $visual, string $layout): void
     {
         if ($item->type === 'incident_severity_changed') {
-            [$icon, $title] = match ($item->new_severity) {
-                'ok'      => [Icons::SEVERITY_OK, $this->translate('Ok')],
-                'warning' => [Icons::SEVERITY_WARN, $this->translate('Warning')],
-                'err'     => [Icons::SEVERITY_ERR, $this->translate('Error')],
-                'crit'    => [Icons::SEVERITY_CRIT, $this->translate('Critical')],
-                'debug'   => [Icons::SEVERITY_DEBUG, $this->translate('Debug')],
-                'info'    => [Icons::SEVERITY_INFO, $this->translate('Info')],
-                'alert'   => [Icons::SEVERITY_ALERT, $this->translate('Alert')],
-                'emerg'   => [Icons::SEVERITY_EMERG, $this->translate('Emergency')],
-                'notice'  => [Icons::SEVERITY_NOTICE, $this->translate('Notice')],
-                default   => [Icons::UNDEFINED, $this->translate('Undefined')]
-            };
-
-            $content = new Icon($icon, [
-                'class' => ['severity-' . $item->new_severity],
-                'title' => sprintf('%s: %s', $this->translate('Severity'), $title)
-            ]);
+            $content = $item->new_severity->getIcon();
         } else {
             $content = new IconBall(match ($item->type) {
                 'opened'                    => Icons::OPENED,
@@ -139,7 +122,7 @@ class IncidentHistoryRenderer implements ItemRenderer
             case 'opened':
                 $message = sprintf(
                     $this->translate('Incident opened at severity %s'),
-                    $this->mapSeverity($item->new_severity)
+                    $item->new_severity->getLabel()
                 );
 
                 break;
@@ -207,8 +190,8 @@ class IncidentHistoryRenderer implements ItemRenderer
             case 'incident_severity_changed':
                 $message = sprintf(
                     $this->translate('Incident severity changed from %s to %s'),
-                    $this->mapSeverity($item->old_severity),
-                    $this->mapSeverity($item->new_severity)
+                    $item->old_severity->getLabel(),
+                    $item->new_severity->getLabel()
                 );
 
                 break;
@@ -296,21 +279,5 @@ class IncidentHistoryRenderer implements ItemRenderer
         }
 
         return $message;
-    }
-
-    private function mapSeverity(?string $severity): ?string
-    {
-        return match ($severity) {
-            'ok'        => $this->translate('Ok', 'notifications.severity'),
-            'crit'      => $this->translate('Critical', 'notifications.severity'),
-            'warning'   => $this->translate('Warning', 'notifications.severity'),
-            'err'       => $this->translate('Error', 'notifications.severity'),
-            'debug'     => $this->translate('Debug', 'notifications.severity'),
-            'info'      => $this->translate('Information', 'notifications.severity'),
-            'alert'     => $this->translate('Alert', 'notifications.severity'),
-            'emerg'     => $this->translate('Emergency', 'notifications.severity'),
-            'notice'    => $this->translate('Notice', 'notifications.severity'),
-            default     => null,
-        };
     }
 }

--- a/library/Notifications/View/IncidentRenderer.php
+++ b/library/Notifications/View/IncidentRenderer.php
@@ -35,14 +35,23 @@ class IncidentRenderer implements ItemRenderer
 
     public function assembleVisual($item, HtmlDocument $visual, string $layout): void
     {
-        $icon = match ($item->severity) {
-            'ok'    => Icons::OK,
-            'err'   => Icons::ERROR,
-            'crit'  => Icons::CRITICAL,
-            default => Icons::WARNING
+        [$icon, $title] = match ($item->severity) {
+            'ok'      => [Icons::SEVERITY_OK, $this->translate('Ok')],
+            'warning' => [Icons::SEVERITY_WARN, $this->translate('Warning')],
+            'err'     => [Icons::SEVERITY_ERR, $this->translate('Error')],
+            'crit'    => [Icons::SEVERITY_CRIT, $this->translate('Critical')],
+            'debug'   => [Icons::SEVERITY_DEBUG, $this->translate('Debug')],
+            'info'    => [Icons::SEVERITY_INFO, $this->translate('Info')],
+            'alert'   => [Icons::SEVERITY_ALERT, $this->translate('Alert')],
+            'emerg'   => [Icons::SEVERITY_EMERG, $this->translate('Emergency')],
+            'notice'  => [Icons::SEVERITY_NOTICE, $this->translate('Notice')],
+            default   => [Icons::UNDEFINED, $this->translate('Undefined')]
         };
 
-        $content = new Icon($icon, ['class' => ['severity-' . $item->severity]]);
+        $content = new Icon($icon, [
+            'class' => ['severity-' . $item->severity],
+            'title' => sprintf('%s: %s', $this->translate('Severity'), $title)
+        ]);
 
         if ($item->severity === 'ok' || $item->severity === 'err') {
             $content->setStyle('fa-regular');

--- a/library/Notifications/View/IncidentRenderer.php
+++ b/library/Notifications/View/IncidentRenderer.php
@@ -7,6 +7,7 @@ namespace Icinga\Module\Notifications\View;
 
 use Icinga\Module\Notifications\Common\Icons;
 use Icinga\Module\Notifications\Common\Links;
+use Icinga\Module\Notifications\Common\Severity;
 use Icinga\Module\Notifications\Model\Incident;
 use Icinga\Module\Notifications\Model\Objects;
 use Icinga\Module\Notifications\Model\Source;
@@ -35,25 +36,8 @@ class IncidentRenderer implements ItemRenderer
 
     public function assembleVisual($item, HtmlDocument $visual, string $layout): void
     {
-        [$icon, $title] = match ($item->severity) {
-            'ok'      => [Icons::SEVERITY_OK, $this->translate('Ok')],
-            'warning' => [Icons::SEVERITY_WARN, $this->translate('Warning')],
-            'err'     => [Icons::SEVERITY_ERR, $this->translate('Error')],
-            'crit'    => [Icons::SEVERITY_CRIT, $this->translate('Critical')],
-            'debug'   => [Icons::SEVERITY_DEBUG, $this->translate('Debug')],
-            'info'    => [Icons::SEVERITY_INFO, $this->translate('Info')],
-            'alert'   => [Icons::SEVERITY_ALERT, $this->translate('Alert')],
-            'emerg'   => [Icons::SEVERITY_EMERG, $this->translate('Emergency')],
-            'notice'  => [Icons::SEVERITY_NOTICE, $this->translate('Notice')],
-            default   => [Icons::UNDEFINED, $this->translate('Undefined')]
-        };
-
-        $content = new Icon($icon, [
-            'class' => ['severity-' . $item->severity],
-            'title' => sprintf('%s: %s', $this->translate('Severity'), $title)
-        ]);
-
-        if ($item->severity === 'ok' || $item->severity === 'err') {
+        $content = $item->severity->getIcon();
+        if ($item->severity === Severity::OK || $item->severity === Severity::ERROR) {
             $content->setStyle('fa-regular');
         }
 
@@ -86,7 +70,7 @@ class IncidentRenderer implements ItemRenderer
 
     public function assembleExtendedInfo($item, HtmlDocument $info, string $layout): void
     {
-        if ($item->severity !== 'ok' && $item->mute_reason !== null) {
+        if ($item->severity !== Severity::OK && $item->mute_reason !== null) {
             $info->addHtml(new Icon(Icons::MUTE, ['title' => $item->mute_reason]));
         }
 

--- a/test/php/library/Notifications/Common/SeverityTest.php
+++ b/test/php/library/Notifications/Common/SeverityTest.php
@@ -1,0 +1,119 @@
+<?php
+
+// SPDX-FileCopyrightText: 2026 Icinga GmbH <https://icinga.com>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+namespace Tests\Icinga\Module\Notifications\Common;
+
+use Icinga\Module\Notifications\Common\Severity;
+use ipl\I18n\NoopTranslator;
+use ipl\I18n\StaticTranslator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+class SeverityTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        StaticTranslator::$instance = new NoopTranslator();
+    }
+
+    /**
+     * @return array<string, array{Severity, string}>
+     */
+    public static function backingValueProvider(): array
+    {
+        return [
+            'ok' => [Severity::OK, 'ok'],
+            'critical' => [Severity::CRITICAL, 'crit'],
+            'warning' => [Severity::WARNING, 'warning'],
+            'error' => [Severity::ERROR, 'err'],
+            'debug' => [Severity::DEBUG, 'debug'],
+            'info' => [Severity::INFO, 'info'],
+            'alert' => [Severity::ALERT, 'alert'],
+            'emergency' => [Severity::EMERGENCY, 'emerg'],
+            'notice' => [Severity::NOTICE, 'notice']
+        ];
+    }
+
+    /**
+     * @return array<string, array{Severity, string, string}>
+     */
+    public static function iconProvider(): array
+    {
+        return [
+            'ok' => [Severity::OK, 'fa-circle-check', 'severity-ok'],
+            'critical' => [Severity::CRITICAL, 'fa-circle-exclamation', 'severity-crit'],
+            'warning' => [Severity::WARNING, 'fa-triangle-exclamation', 'severity-warning'],
+            'error' => [Severity::ERROR, 'fa-circle-xmark', 'severity-err'],
+            'debug' => [Severity::DEBUG, 'fa-bug-slash', 'severity-debug'],
+            'info' => [Severity::INFO, 'fa-circle-info', 'severity-info'],
+            'alert' => [Severity::ALERT, 'fa-bell', 'severity-alert'],
+            'emergency' => [Severity::EMERGENCY, 'fa-bullhorn', 'severity-emerg'],
+            'notice' => [Severity::NOTICE, 'fa-envelope', 'severity-notice']
+        ];
+    }
+
+    #[DataProvider('backingValueProvider')]
+    public function testBackingValueIsTheDbString(Severity $severity, string $expected): void
+    {
+        $this->assertSame($expected, $severity->value);
+    }
+
+    #[DataProvider('backingValueProvider')]
+    public function testFromParsesDbString(Severity $expected, string $dbValue): void
+    {
+        $this->assertSame($expected, Severity::from($dbValue));
+    }
+
+    public function testGetLabelCoversAllCases(): void
+    {
+        $this->assertSame('Ok', Severity::OK->getLabel());
+        $this->assertSame('Critical', Severity::CRITICAL->getLabel());
+        $this->assertSame('Warning', Severity::WARNING->getLabel());
+        $this->assertSame('Error', Severity::ERROR->getLabel());
+        $this->assertSame('Debug', Severity::DEBUG->getLabel());
+        $this->assertSame('Information', Severity::INFO->getLabel());
+        $this->assertSame('Alert', Severity::ALERT->getLabel());
+        $this->assertSame('Emergency', Severity::EMERGENCY->getLabel());
+        $this->assertSame('Notice', Severity::NOTICE->getLabel());
+    }
+
+    #[DataProvider('iconProvider')]
+    public function testGetIconRendersCorrectIconClass(Severity $severity, string $iconClass, string $_): void
+    {
+        $this->assertStringContainsString($iconClass, $severity->getIcon()->render());
+    }
+
+    #[DataProvider('iconProvider')]
+    public function testGetIconRendersCorrectSeverityClass(Severity $severity, string $_, string $severityClass): void
+    {
+        $this->assertStringContainsString($severityClass, $severity->getIcon()->render());
+    }
+
+    #[DataProvider('backingValueProvider')]
+    public function testGetIconTitleContainsSeverityLabel(Severity $severity, string $_): void
+    {
+        $expected = sprintf('Severity set to %s', $severity->getLabel());
+        $this->assertStringContainsString($expected, $severity->getIcon()->render());
+    }
+
+    public function testAllCasesAreCovered(): void
+    {
+        $this->assertSame(
+            [
+                Severity::OK,
+                Severity::CRITICAL,
+                Severity::WARNING,
+                Severity::ERROR,
+                Severity::DEBUG,
+                Severity::INFO,
+                Severity::ALERT,
+                Severity::EMERGENCY,
+                Severity::NOTICE
+            ],
+            Severity::cases(),
+            'A Severity case was added or removed — update the test providers and this assertion'
+        );
+    }
+}


### PR DESCRIPTION
Introduces a Severity backed enum that centralises all severity logic — backing values, translated labels, and icons — in one place, replacing scattered string constants in Icons and inline match expressions in the renderers. Wires up EnumCast on Incident and IncidentHistory so the severity column is hydrated directly as a Severity instance, turning raw string comparisons like `$item->severity ===   'ok'` into type-safe `$item->severity === Severity::OK`. Also updates the `SEVERITY_OK` icon from `heart` to `circle-check` for visual consistency with the other severity levels. 

resolves #479
require https://github.com/Icinga/ipl-orm/pull/162