### PR TITLE
`EscalationCondition`: Remove not required incident age operators

### DIFF
--- a/application/forms/EventRuleConfigElements/EscalationCondition.php
+++ b/application/forms/EventRuleConfigElements/EscalationCondition.php
@@ -118,19 +118,27 @@ class EscalationCondition extends FieldsetElement
             )
         ]));
 
-        $this->addElement('select', 'operator', [
-            'required' => true,
-            'options' => [
+        $selectedColumn = $this->getPopulatedValue('column');
+        if ($selectedColumn === 'incident_age') {
+            $operators = ['>' => '>'];
+        } else {
+            $operators = [
                 '='  => '=',
                 '>'  => '>',
                 '>=' => '>=',
                 '<'  => '<',
                 '<=' => '<=',
                 '!=' => '!='
-            ]
+            ];
+        }
+
+        $this->addElement('select', 'operator', [
+            'required' => true,
+            'options' => $operators,
+            'disabled' => $selectedColumn === 'incident_age'
         ]);
 
-        if ($this->getPopulatedValue('column') === 'incident_severity') {
+        if ($selectedColumn === 'incident_severity') {
             $this->addElement('select', 'severity', [
                 'required' => true,
                 'options' => [
@@ -145,7 +153,7 @@ class EscalationCondition extends FieldsetElement
                     'emerg' => $this->translate('Emergency', 'notification.severity')
                 ]
             ]);
-        } elseif ($this->getPopulatedValue('column') === 'incident_age') {
+        } elseif ($selectedColumn === 'incident_age') {
             $noOf = $this->createElement('number', 'no_of', [
                 'required' => true,
                 'min' => 1,

--- a/test/php/application/forms/EventRuleConfigFormTest.php
+++ b/test/php/application/forms/EventRuleConfigFormTest.php
@@ -132,7 +132,7 @@ class EventRuleConfigFormTest extends TestCase
                 (new RuleEscalation())->setProperties([
                     'id' => 1,
                     'position' => 0,
-                    'condition' => 'incident_age>=5m',
+                    'condition' => 'incident_age>5m',
                     'rule_escalation_recipient' => [
                         (new RuleEscalationRecipient())->setProperties([
                             'id' => 1,


### PR DESCRIPTION
This PR removes unnecessary operators for incident age, keeping only the `>` operator.

resolves #476 