### PR TITLE
Add `filter_name` text field to the event rule `SearchEditor`

### DIFF
--- a/application/controllers/EventRuleController.php
+++ b/application/controllers/EventRuleController.php
@@ -230,7 +230,6 @@ class EventRuleController extends CompatController
         $filterNameElement = $editor->createElement('text', 'filter_name', [
             'label' => $this->translate('Filter Name'),
             'value' => $parsedFilter['filter_name'] ?? null,
-            'placeholder' => $this->translate('Optional filter name'),
             'decorators' => [
                 'Label',
                 'LabelGroup' => [

--- a/application/controllers/EventRuleController.php
+++ b/application/controllers/EventRuleController.php
@@ -26,7 +26,6 @@ use Icinga\Web\Session;
 use ipl\Html\Attributes;
 use ipl\Html\Contract\Form;
 use ipl\Html\Html;
-use ipl\Html\HtmlElement;
 use ipl\Html\Text;
 use ipl\Stdlib\Filter;
 use ipl\Stdlib\Filter\Condition;
@@ -224,8 +223,37 @@ class EventRuleController extends CompatController
         }
 
         $editor = (new SearchEditor())
+            ->addAttributes(Attributes::create(['class' => 'event-rule-filter']))
             ->setQueryString($parsedFilter['qs'] ?? '')
             ->setAction(Url::fromRequest()->with('object_filter', $filter)->getAbsoluteUrl());
+
+        $filterNameElement = $editor->createElement('text', 'filter_name', [
+            'label' => $this->translate('Filter Name'),
+            'value' => $parsedFilter['filter_name'] ?? null,
+            'placeholder' => $this->translate('Optional filter name'),
+            'decorators' => [
+                'Label',
+                'LabelGroup' => [
+                    'name' => 'HtmlTag',
+                    'options' => [
+                        'tag' => 'div',
+                        'class' => 'control-label-group'
+                    ]
+                ],
+                'RenderElement',
+                'ControlGroup' => [
+                    'name' => 'HtmlTag',
+                    'options' => [
+                        'tag' => 'div',
+                        'class' => 'control-group filter-name'
+                    ]
+                ],
+            ]
+        ]);
+
+        $filterNameElement->applyDecoration();
+        $editor->registerElement($filterNameElement);
+        $editor->prependHtml($filterNameElement);
 
         if ($hook !== null) {
             $editor->setSuggestionUrl(
@@ -283,7 +311,10 @@ class EventRuleController extends CompatController
 
         $editor->on(Form::ON_SUBMIT, function (SearchEditor $form) use ($ruleId, $getJsonPaths) {
             $filter = $form->getFilter();
-            $this->session->set('object_filter', (new RuleSerializer($filter, $getJsonPaths($filter)))->getJson());
+            $this->session->set(
+                'object_filter',
+                (new RuleSerializer($filter, $getJsonPaths($filter), $form->getValue('filter_name')))->getJson()
+            );
             $this->redirectNow(Links::eventRule($ruleId)->setParam('_filterOnly'));
         })->handleRequest($this->getServerRequest());
 

--- a/application/forms/EventRuleConfigElements/EscalationConditions.php
+++ b/application/forms/EventRuleConfigElements/EscalationConditions.php
@@ -11,6 +11,7 @@ use ipl\Html\Contract\FormElement;
 use ipl\Html\FormElement\FieldsetElement;
 use ipl\Html\FormElement\SubmitButtonElement;
 use ipl\Html\HtmlElement;
+use ipl\Html\Text;
 use ipl\Stdlib\Filter;
 use ipl\Stdlib\Filter\Condition;
 use ipl\Web\Filter\QueryString;
@@ -30,7 +31,10 @@ class EscalationConditions extends FieldsetElement
         /** @var SubmitButtonElement $button */
         $button = $this->createElement('submitButton', 'add-button', [
             'title' => $this->translate('Add Condition'),
-            'label' => new Icon('plus'),
+            'label' => [
+                new Icon('plus'),
+                new HtmlElement('span', content: Text::create($this->translate('Add Condition')))
+            ],
             'class' => ['add-button', 'animated']
         ]);
 

--- a/application/forms/EventRuleConfigForm.php
+++ b/application/forms/EventRuleConfigForm.php
@@ -13,7 +13,9 @@ use Icinga\Module\Notifications\Model\Rule;
 use Icinga\Module\Notifications\Model\RuleEscalation;
 use ipl\Html\Attributes;
 use ipl\Html\FormElement\SubmitButtonElement;
+use ipl\Html\HtmlDocument;
 use ipl\Html\HtmlElement;
+use ipl\Html\Text;
 use ipl\Html\ValidHtml;
 use ipl\I18n\Translation;
 use ipl\Sql\Connection;
@@ -131,11 +133,33 @@ class EventRuleConfigForm extends CompatForm
         $this->registerElement($hiddenInput);
 
         if ($hiddenInput->hasValue()) {
-            $label = new Icon('filter');
-            $title = $this->translate('Adjust Filter');
+            $parsedFilter = json_decode($hiddenInput->getValue(), true, flags: JSON_THROW_ON_ERROR);
+
+            if (! empty($parsedFilter['filter_name'])) {
+                $label = new HtmlElement(
+                    'span',
+                    Attributes::create(['class' => 'name']),
+                    Text::create($parsedFilter['filter_name'])
+                );
+                $title = sprintf(
+                    '%s (%s: %s)',
+                    $this->translate('Adjust Filter'),
+                    $this->translate('Name'),
+                    $parsedFilter['filter_name']
+                );
+            } else {
+                $label = new HtmlDocument();
+                $label
+                    ->addHtml(new Icon('filter'))
+                    ->addHtml(new HtmlElement('span', content: Text::create($this->translate('Adjust Filter'))));
+                $title = $this->translate('Adjust Filter');
+            }
         } else {
-            $label = new Icon('plus');
-            $title = $this->translate('Add filter');
+            $label = new HtmlDocument();
+            $label
+                ->addHtml(new Icon('plus'))
+                ->addHtml(new HtmlElement('span', content: Text::create($this->translate('Add Filter'))));
+            $title = $this->translate('Add Filter');
         }
 
         return new HtmlElement(

--- a/application/forms/EventRuleConfigForm.php
+++ b/application/forms/EventRuleConfigForm.php
@@ -13,7 +13,6 @@ use Icinga\Module\Notifications\Model\Rule;
 use Icinga\Module\Notifications\Model\RuleEscalation;
 use ipl\Html\Attributes;
 use ipl\Html\FormElement\SubmitButtonElement;
-use ipl\Html\HtmlDocument;
 use ipl\Html\HtmlElement;
 use ipl\Html\Text;
 use ipl\Html\ValidHtml;
@@ -135,12 +134,9 @@ class EventRuleConfigForm extends CompatForm
         if ($hiddenInput->hasValue()) {
             $parsedFilter = json_decode($hiddenInput->getValue(), true, flags: JSON_THROW_ON_ERROR);
 
+            $icon = 'filter';
             if (! empty($parsedFilter['filter_name'])) {
-                $label = new HtmlElement(
-                    'span',
-                    Attributes::create(['class' => 'name']),
-                    Text::create($parsedFilter['filter_name'])
-                );
+                $text = $parsedFilter['filter_name'];
                 $title = sprintf(
                     '%s (%s: %s)',
                     $this->translate('Adjust Filter'),
@@ -148,25 +144,23 @@ class EventRuleConfigForm extends CompatForm
                     $parsedFilter['filter_name']
                 );
             } else {
-                $label = new HtmlDocument();
-                $label
-                    ->addHtml(new Icon('filter'))
-                    ->addHtml(new HtmlElement('span', content: Text::create($this->translate('Adjust Filter'))));
-                $title = $this->translate('Adjust Filter');
+                $text = $this->translate('Adjust Filter');
+                $title = $text;
             }
         } else {
-            $label = new HtmlDocument();
-            $label
-                ->addHtml(new Icon('plus'))
-                ->addHtml(new HtmlElement('span', content: Text::create($this->translate('Add Filter'))));
-            $title = $this->translate('Add Filter');
+            $icon = 'plus';
+            $text = $this->translate('Add Filter');
+            $title = $text;
         }
 
         return new HtmlElement(
             'div',
             Attributes::create(['class' => 'button-wrapper']),
             new Link(
-                $label,
+                [
+                    new Icon($icon),
+                    new HtmlElement('span', content: Text::create($text))
+                ],
                 $this->searchEditorUrl,
                 Attributes::create([
                     'class'               => ['search-editor-opener', 'filter-button'],

--- a/library/Notifications/Util/RuleSerializer.php
+++ b/library/Notifications/Util/RuleSerializer.php
@@ -17,6 +17,9 @@ class RuleSerializer
     /** @var int The filter version */
     public const VERSION = 2;
 
+    /** @var ?string The name of the filter */
+    protected ?string $filterName;
+
     /** @var Filter\Condition|Filter\Chain */
     protected Filter\Rule $filter;
 
@@ -28,11 +31,13 @@ class RuleSerializer
      *
      * @param Filter\Rule $filter
      * @param array<string, string[]> $jsonPaths JSON paths keyed by column name
+     * @param ?string $filterName The name of the filter
      */
-    public function __construct(Filter\Rule $filter, array $jsonPaths)
+    public function __construct(Filter\Rule $filter, array $jsonPaths, ?string $filterName = null)
     {
         $this->filter = $filter;
         $this->jsonPaths = $jsonPaths;
+        $this->filterName = $filterName;
     }
 
     /**
@@ -48,6 +53,11 @@ class RuleSerializer
             'version' => self::VERSION,
             'qs'      => QueryString::render($this->filter),
         ];
+
+        if ($this->filterName) {
+            $result['filter_name'] = $this->filterName;
+        }
+
         if ($this->filter instanceof Filter\Chain) {
             if ($this->filter->isEmpty()) {
                 return null;

--- a/public/css/detail/event-rule-detail.less
+++ b/public/css/detail/event-rule-detail.less
@@ -76,7 +76,7 @@
   }
 
   #object-filter-controls {
-    width: 20em;
+    width: 16em;
     height: fit-content;
   }
 
@@ -88,7 +88,7 @@
   .dynamic-list.empty .add-button,
   > #object-filter-controls > .button-wrapper .filter-button {
     align-self: flex-start;
-    padding: 1.25em 2em;
+    padding: 1em;
   }
 
   .dynamic-list.empty > .add-button-wrapper,
@@ -116,12 +116,9 @@
         overflow: hidden;
         word-break: break-word;
         .line-clamp(2);
+        min-width: 4em;
       }
     }
-  }
-
-  > #object-filter-controls > .button-wrapper {
-    min-width: 12em;
   }
 
   > .escalations {

--- a/public/css/detail/event-rule-detail.less
+++ b/public/css/detail/event-rule-detail.less
@@ -105,9 +105,18 @@
       background-color: @connectorColor;
     }
 
-    .add-button,
-    .filter-button {
+    .add-button {
       flex: 0;
+    }
+
+    .filter-button {
+      flex-direction: column;
+
+      .name {
+        overflow: hidden;
+        word-break: break-word;
+        .line-clamp(2);
+      }
     }
   }
 
@@ -259,5 +268,19 @@
     .btn-remove {
       .button(@body-bg-color, @color-critical, @color-critical-accentuated);
     }
+  }
+}
+
+.event-rule-filter > .filter-name {
+  display: flex;
+  align-items: baseline;
+  justify-content: center;
+  gap: .5625em;
+  margin-bottom: .5em;
+
+  input {
+    flex-grow: 1;
+    max-width: 35em;
+    .rounded-corners();
   }
 }

--- a/public/css/detail/event-rule-detail.less
+++ b/public/css/detail/event-rule-detail.less
@@ -76,19 +76,26 @@
   }
 
   #object-filter-controls {
-    width: 16em;
+    width: 20em;
     height: fit-content;
   }
 
   .set-wrapper:has(.dynamic-list.empty .add-button),
   > #object-filter-controls {
-    padding: 1.25em 0;
+    padding: .75em 0;
   }
 
   .dynamic-list.empty .add-button,
   > #object-filter-controls > .button-wrapper .filter-button {
     align-self: flex-start;
-    padding: 1em;
+    flex-direction: column;
+    padding: 1.25em 0.5em;
+
+    > span {
+      overflow: hidden;
+      word-break: break-word;
+      .line-clamp(2);
+    }
   }
 
   .dynamic-list.empty > .add-button-wrapper,
@@ -101,24 +108,19 @@
       flex: 1 1 auto;
       min-width: 1.25em;
       height: @connectorHeight;
-      margin-top: 1.5em;
+      margin-top: 2em;
       background-color: @connectorColor;
     }
 
-    .add-button {
-      flex: 0;
-    }
-
+    .add-button,
     .filter-button {
-      flex-direction: column;
-
-      .name {
-        overflow: hidden;
-        word-break: break-word;
-        .line-clamp(2);
-        min-width: 4em;
-      }
+      flex: 0;
+      min-width: 8em;
     }
+  }
+
+  > #object-filter-controls > .button-wrapper {
+    min-width: 12em;
   }
 
   > .escalations {

--- a/test/php/application/forms/EventRuleConfigFormTest.php
+++ b/test/php/application/forms/EventRuleConfigFormTest.php
@@ -220,7 +220,7 @@ class EventRuleConfigFormTest extends TestCase
             'id' => 1337,
             'source_id' => 1338,
             'name' => 'Test',
-            'object_filter' => 'hostgroup.name=Test%20Group',
+            'object_filter' => '{"filter_name":null,"qs":"hostgroup.name=Test%20Group"}',
             'timeperiod_id' => null,
             'rule_escalation' => $ruleEscalationMock
         ]);
@@ -301,7 +301,7 @@ class EventRuleConfigFormTest extends TestCase
                         [
                             'name' => 'Test',
                             'source_id' => 1338,
-                            'object_filter' => 'hostgroup.name=Test%20Group'
+                            'object_filter' => '{"filter_name":null,"qs":"hostgroup.name=Test%20Group"}'
                         ],
                         $data
                     );
@@ -590,7 +590,7 @@ class EventRuleConfigFormTest extends TestCase
             'id' => 1337,
             'source_id' => 1338,
             'name' => 'Test',
-            'object_filter' => 'servicegroup.name=Test%20Group',
+            'object_filter' => '{"filter_name":null,"qs":"servicegroup.name=Test%20Group"}',
             'timeperiod_id' => null,
             'rule_escalation' => $ruleEscalationMock
         ]);
@@ -609,7 +609,7 @@ class EventRuleConfigFormTest extends TestCase
                     [
                         'name' => 'Test',
                         'source_id' => 1338,
-                        'object_filter' => 'servicegroup.name=Test%20Group'
+                        'object_filter' => '{"filter_name":null,"qs":"servicegroup.name=Test%20Group"}'
                     ],
                     $data
                 );

--- a/test/php/library/Notifications/Util/RuleSerializerTest.php
+++ b/test/php/library/Notifications/Util/RuleSerializerTest.php
@@ -99,4 +99,22 @@ class RuleSerializerTest extends TestCase
 
         $this->assertNull($result);
     }
+
+    public function testGetJsonIncludesFilterNameWhenProvided()
+    {
+        $filter = Filter::equal('a', 'x');
+
+        $result = json_decode((new RuleSerializer($filter, ['a' => ['$.a']], 'my filter'))->getJson(), true);
+
+        $this->assertSame('my filter', $result['filter_name']);
+    }
+
+    public function testGetJsonDoesNotHaveFilterNameWhenNotProvided()
+    {
+        $filter = Filter::equal('a', 'x');
+
+        $result = json_decode((new RuleSerializer($filter, ['a' => ['$.a']]))->getJson(), true);
+
+        $this->assertNotContains('filter_name', $result);
+    }
 }


### PR DESCRIPTION
This PR adds `filter_name` an optional text field to the event rule `SearchEditor`, when set, displayed as the button label — making filters self-describing without opening the editor.

**Without custom name**
<img width="2317" height="570" alt="image" src="https://github.com/user-attachments/assets/d49efb0b-d384-4785-8612-6fe566d030f9" />

**With custom name**
<img width="1832" height="535" alt="image" src="https://github.com/user-attachments/assets/cf21c728-6b38-420e-a33f-836cda2651d2" />
<img width="2317" height="357" alt="image" src="https://github.com/user-attachments/assets/2bac37a2-d1bc-49bc-ab31-8ebf37740800" />


resolves #459