### PR TITLE
Fix invalid csrf token in `RotationConfigForm`

### DIFF
--- a/application/forms/RotationConfigForm.php
+++ b/application/forms/RotationConfigForm.php
@@ -1240,8 +1240,8 @@ class RotationConfigForm extends CompatForm
             $this->addHtml(new HtmlElement(
                 'p',
                 Attributes::create(['id' => 'first-handoff-description']),
-                DeferredText::create(function () {
-                    if (! $this->isValid()) {
+                DeferredText::create(function () use ($options) {
+                    if (! $options->isValid()) {
                         return '';
                     }
 
@@ -1266,8 +1266,8 @@ class RotationConfigForm extends CompatForm
                     }
                 }),
                 new HtmlElement('br'),
-                $this->displayTimezone !== $this->scheduleTimezone ? DeferredText::create(function () {
-                    if (! $this->isValid()) {
+                $this->displayTimezone !== $this->scheduleTimezone ? DeferredText::create(function () use ($options) {
+                    if (! $options->isValid()) {
                         return '';
                     }
 


### PR DESCRIPTION
https://github.com/Icinga/icinga-notifications-web/pull/496 introduced validation of the entire form when calculating the first handoff, but the validation of the CSRF element fails when it is run there.

To fix this only the `$options` element is validated, since it should cover everything the first handoff needs.