### PR TITLE
`EscalationCondition.php`: Set default `operator` value

### DIFF
--- a/application/forms/EventRuleConfigElements/EscalationCondition.php
+++ b/application/forms/EventRuleConfigElements/EscalationCondition.php
@@ -135,6 +135,7 @@ class EscalationCondition extends FieldsetElement
         $this->addElement('select', 'operator', [
             'required' => true,
             'options' => $operators,
+            'value' => array_key_first($operators),
             'disabled' => $selectedColumn === 'incident_age'
         ]);
 


### PR DESCRIPTION
For the `incident_age` column, the `operator` select is disabled and only offers a single option (`>`). Disabled HTML selects don't submit a value, so the operator was previously missing from the submitted data and form could not be submitted. Defaulting the element's value to the first available option ensures it's always set, even while disabled.