### PR TITLE
Fix missing `changed_at` in `IncidentQuickActions`

### DIFF
--- a/library/Notifications/Widget/Detail/IncidentQuickActions.php
+++ b/library/Notifications/Widget/Detail/IncidentQuickActions.php
@@ -153,7 +153,10 @@ class IncidentQuickActions extends Form
             if ($incidentContact->contact_id !== null) {
                 Database::get()->update(
                     'incident_contact',
-                    ['role' => $roleName],
+                    [
+                        'role' => $roleName,
+                        'changed_at' => (int) (new DateTime())->format("Uv")
+                    ],
                     [
                         'contact_id = ?'    => $incidentContact->contact_id,
                         'incident_id = ?'   => $this->incident->id
@@ -163,7 +166,8 @@ class IncidentQuickActions extends Form
                 Database::get()->insert('incident_contact', [
                     'incident_id'   => $this->incident->id,
                     'contact_id'    => $this->currentUserId,
-                    'role'          => $roleName
+                    'role'          => $roleName,
+                    'changed_at'    => (int) (new DateTime())->format("Uv")
                 ]);
             }
 


### PR DESCRIPTION
`IncidentQuickActions` currently does not write to the `changed_at` column of `incident_contact`.
This causes an error `Failed to change role to ...` in the insert case, because the `NOT NULL` constraint of the `changed_at` column is violated, and leads to outdated `changed_at` timestamps in the update case.

To fix this the current timestamp is written to `changed_at` in both cases.