### PR TITLE
Allow to configure `client_certificate_subject`

### DIFF
--- a/application/forms/SourceForm.php
+++ b/application/forms/SourceForm.php
@@ -108,81 +108,147 @@ class SourceForm extends CompatForm
             );
         }
 
-        $this->addElement('fieldset', 'credentials', [
-            'label' => $this->translate('Source Credentials')
-        ]);
-        $credentials = $this->getElement('credentials');
-        $credentials->addHtml(new HtmlElement(
-            'p',
-            Attributes::create(['class' => 'description']),
-            Text::create($this->translate(
-                'These credentials will be used by the source to authenticate'
-                . ' against Icinga Notifications when submitting events. You will need to add this to the'
-                . ' source\'s configuration as well.'
-                . ' Consult the documentation of your source for configuration details.'
-            ))
-        ));
-
-        $credentials->addElement(
-            'text',
-            'listener_username',
+        $this->addElement(
+            'select',
+            'auth_type',
             [
-                'required' => true,
-                'label' => $this->translate('Username'),
-                'disabled'  => $this->source?->locked,
-                'validators' => [new CallbackValidator(
-                    function ($value, CallbackValidator $validator) {
-                        // Username must be unique
-                        $source = Source::on(Database::get())
-                            ->filter(Filter::equal('listener_username', $value));
-                        if ($this->source !== null) {
-                            $source->filter(Filter::unequal('id', $this->source->id));
-                        }
-
-                        if ($source->first() !== null) {
-                            $validator->addMessage($this->translate('This username is already in use.'));
-                            return false;
-                        }
-
-                        return true;
-                    }
-                )]
+                'class' => 'autosubmit',
+                'disabled' => $this->source?->locked,
+                'label' => $this->translate('Authentication Type'),
+                'value' => 'password',
+                'options' =>
+                    [
+                        'password' => $this->translate('Username and password'),
+                        'certificate' => $this->translate('Client certificate')
+                    ]
             ]
         );
 
-        if (! $this->source?->locked) {
-            $credentials->addElement(
-                'password',
-                'listener_password',
-                [
-                    'required'      => $this->source === null,
-                    'label'         => $this->source !== null
-                        ? $this->translate('New Password')
-                        : $this->translate('Password'),
-                    'autocomplete'  => 'new-password',
-                    'validators'    => [['name' => 'StringLength', 'options' => ['min' => 16]]]
-                ]
-            );
-            $credentials->addElement(
-                'password',
-                'listener_password_dupe',
-                [
-                    'ignore'        => true,
-                    'required'      => $this->source === null,
-                    'label'         => $this->translate('Repeat Password'),
-                    'autocomplete'  => 'new-password',
-                    'validators'    => [new CallbackValidator(function (string $value, CallbackValidator $validator) {
-                        if ($value !== $this->getElement('credentials')->getValue('listener_password')) {
-                            $validator->addMessage($this->translate('Passwords do not match'));
+        if ($this->getPopulatedValue('auth_type', 'password') === 'password') {
+            $this->addElement('fieldset', 'credentials', [
+                'label' => $this->translate('Source Credentials')
+            ]);
+            $credentials = $this->getElement('credentials');
+            $credentials->addHtml(new HtmlElement(
+                'p',
+                Attributes::create(['class' => 'description']),
+                Text::create($this->translate(
+                    'These credentials will be used by the source to authenticate'
+                    . ' against Icinga Notifications when submitting events. You will need to add this to the'
+                    . ' source\'s configuration as well.'
+                    . ' Consult the documentation of your source for configuration details.'
+                ))
+            ));
 
-                            return false;
+            $credentials->addElement(
+                'text',
+                'listener_username',
+                [
+                    'required' => true,
+                    'label' => $this->translate('Username'),
+                    'disabled'  => $this->source?->locked,
+                    'validators' => [new CallbackValidator(
+                        function ($value, CallbackValidator $validator) {
+                            // Username must be unique
+                            $source = Source::on(Database::get())
+                                ->filter(Filter::equal('listener_username', $value));
+                            if ($this->source !== null) {
+                                $source->filter(Filter::unequal('id', $this->source->id));
+                            }
+
+                            if ($source->first() !== null) {
+                                $validator->addMessage($this->translate('This username is already in use.'));
+                                return false;
+                            }
+
+                            return true;
                         }
-
-                        return true;
-                    })]
+                    )]
                 ]
             );
 
+            if (! $this->source?->locked) {
+                $credentials->addElement(
+                    'password',
+                    'listener_password',
+                    [
+                        'required'      => $this->source?->listener_password_hash === null,
+                        'label'         => $this->source?->listener_password_hash !== null
+                            ? $this->translate('New Password')
+                            : $this->translate('Password'),
+                        'autocomplete'  => 'new-password',
+                        'validators'    => [['name' => 'StringLength', 'options' => ['min' => 16]]]
+                    ]
+                );
+                $credentials->addElement(
+                    'password',
+                    'listener_password_dupe',
+                    [
+                        'ignore'        => true,
+                        'required'      => $this->source?->listener_password_hash === null,
+                        'label'         => $this->translate('Repeat Password'),
+                        'autocomplete'  => 'new-password',
+                        'validators' => [
+                            new CallbackValidator(function (string $value, CallbackValidator $validator) {
+                                if ($value !== $this->getElement('credentials')->getValue('listener_password')) {
+                                    $validator->addMessage($this->translate('Passwords do not match'));
+
+                                    return false;
+                                }
+
+                                return true;
+                            })
+                        ]
+                    ]
+                );
+            }
+        } else {
+            $this->addElement('fieldset', 'certificate', [
+                'label' => $this->translate('Client Certificate')
+            ]);
+            $certificate = $this->getElement('certificate');
+            $certificate->addHtml(new HtmlElement(
+                'p',
+                Attributes::create(['class' => 'description']),
+                Text::create($this->translate(
+                    'The source will authenticate using a TLS client certificate when submitting events'
+                    . ' over HTTPS. Enter the subject of the certificate the source will present.'
+                    . ' Icinga Notifications uses it to identify the source.'
+                ))
+            ));
+
+            $certificate->addElement(
+                'text',
+                'client_certificate_subject',
+                [
+                    'required' => true,
+                    'label' => $this->translate('Certificate Subject'),
+                    'disabled' => $this->source?->locked,
+                    'placeholder' => 'CN=source.example.com,OU=Monitoring,O=Icinga,C=DE',
+                    'validators' => [
+                        ['name' => 'StringLength', 'options' => ['max' => 768]],
+                        new CallbackValidator(function ($value, CallbackValidator $validator) {
+                            $source = Source::on(Database::get())
+                                ->filter(Filter::equal('client_certificate_subject', $value));
+                            if ($this->source !== null) {
+                                $source->filter(Filter::unequal('id', $this->source->id));
+                            }
+
+                            if ($source->first() !== null) {
+                                $validator->addMessage(
+                                    $this->translate('This certificate subject is already in use.')
+                                );
+                                return false;
+                            }
+
+                            return true;
+                        })
+                    ]
+                ]
+            );
+        }
+
+        if ($this->source === null || ! $this->source->locked) {
             $this->addElement(
                 'submit',
                 'save',
@@ -229,8 +295,12 @@ class SourceForm extends CompatForm
             'name' => $source->name,
             'type' => $source->type,
             'source_type' => $source->type === self::TYPE_GENERIC ? self::TYPE_GENERIC : self::TYPE_INTEGRATED,
+            'auth_type' => $source->listener_username === null ? 'certificate' : 'password',
             'credentials' => [
                 'listener_username' => $source->listener_username
+            ],
+            'certificate' => [
+                'client_certificate_subject' => $source->client_certificate_subject
             ]
         ]);
 
@@ -250,10 +320,20 @@ class SourceForm extends CompatForm
 
         $this->source->name = $this->getValue('name');
         $this->source->type = $this->getValue('type', self::TYPE_GENERIC);
-        $this->source->listener_username = $this->getElement('credentials')->getValue('listener_username');
-        $pwd = $this->getElement('credentials')->getValue('listener_password');
-        if ($pwd) {
-            $this->source->listener_password = $pwd;
+
+        if ($this->getValue('auth_type') === 'certificate') {
+            $this->source->client_certificate_subject = $this->getElement('certificate')
+                ->getValue('client_certificate_subject');
+            $this->source->listener_username = null;
+            $this->source->listener_password_hash = null;
+        } else {
+            $this->source->listener_username = $this->getElement('credentials')->getValue('listener_username');
+            $this->source->client_certificate_subject = null;
+
+            $pwd = $this->getElement('credentials')->getValue('listener_password');
+            if ($pwd) {
+                $this->source->listener_password = $pwd;
+            }
         }
 
         return $this->source;

--- a/library/Notifications/Model/Source.php
+++ b/library/Notifications/Model/Source.php
@@ -29,6 +29,7 @@ use Throwable;
  *                                      database). The repository hashes it and assigns the result to
  *                                      {@see self::$listener_password_hash} before saving the source to the database.
  *                                      See the usage in {@see SourceRepository::upsert()}.
+ * @property ?string $client_certificate_subject The subject of the TLS client certificate
  * @property DateTime $changed_at
  * @property bool $deleted
  * @property bool $locked
@@ -58,6 +59,7 @@ class Source extends Model
             'name',
             'listener_username',
             'listener_password_hash',
+            'client_certificate_subject',
             'changed_at',
             'deleted',
             'locked'

--- a/library/Notifications/Repository/SourceRepository.php
+++ b/library/Notifications/Repository/SourceRepository.php
@@ -101,6 +101,7 @@ final class SourceRepository
     {
         $source->delete();
         $source->listener_username = null;
+        $source->client_certificate_subject = null;
 
         foreach ($source->rule as $rule) {
             //TODO: add repository for rule

--- a/test/php/library/Notifications/Repository/SourceRepositoryTest.php
+++ b/test/php/library/Notifications/Repository/SourceRepositoryTest.php
@@ -175,6 +175,31 @@ class SourceRepositoryTest extends TestCase
         $this->assertEquals(42, $source->id, 'The generated id was not assigned to the source');
     }
 
+    public function testCreatePersistsClientCertificateSubject(): void
+    {
+        $source = new Source([
+            'type'                       => 'icingadb',
+            'name'                       => 'Icinga 2',
+            'client_certificate_subject' => 'CN=source.example.com'
+        ]);
+        $source->setNew();
+
+        $db = $this->getConnectionMock();
+        $db->expects($this->never())->method('update');
+        $db->expects($this->once())
+            ->method('insert')
+            ->willReturnCallback(function ($_, $data) {
+                $this->assertSame('CN=source.example.com', $data['client_certificate_subject']);
+                $this->assertArrayNotHasKey('listener_username', $data);
+                $this->assertArrayNotHasKey('listener_password_hash', $data);
+
+                return $this->createStub(PDOStatement::class);
+            });
+        $db->method('lastInsertId')->willReturn('1');
+
+        (new SourceRepository($db))->create($source);
+    }
+
     public function testCreateHashesPasswordBeforeInserting(): void
     {
         $source = new Source(['type' => 'icingadb', 'name' => 'Src']);
@@ -356,6 +381,50 @@ class SourceRepositoryTest extends TestCase
         $this->assertContains('source', $updatedTables, 'The source itself must be soft-deleted');
     }
 
+    /**
+     * Covers deleting a certificate-based source: {@see SourceRepository::delete()} must null the
+     * `client_certificate_subject` alongside the `listener_username`, so the soft-deleted row keeps no
+     * identity and frees the unique certificate subject for reuse.
+     *
+     * The fixture carries a non-null subject on purpose: the {@see EntityManager} only emits columns that
+     * actually change, so a source loaded without a subject would never surface it in the UPDATE.
+     *
+     * Three selects are expected: {@see SourceRepository::find()}, the lazy-loaded `rule` relation (no rows),
+     * and {@see EntityManager::stampChangedAt()}'s `MAX(changed_at)` read triggered by the save.
+     *
+     * @return void
+     */
+    public function testDeleteNullsClientCertificateSubject(): void
+    {
+        $db = $this->getConnectionMock();
+        $db->expects($this->exactly(3))
+            ->method('select')
+            ->willReturnOnConsecutiveCalls(
+                $this->selectResult([
+                    [
+                        'id'                         => 5,
+                        'type'                       => 'icingadb',
+                        'name'                       => 'Icinga 2',
+                        'client_certificate_subject' => 'CN=source.example.com',
+                        'deleted'                    => 'n',
+                        'locked'                     => 'n'
+                    ]
+                ]),
+                $this->selectResult([]), // no rules
+                $this->selectResult([['changed_at' => 0]]) // EntityManager::stampChangedAt()'s MAX(changed_at)
+            );
+        $db->expects($this->once())
+            ->method('update')
+            ->willReturnCallback(function ($_, $data) {
+                $this->assertSame('y', $data['deleted']);
+                $this->assertNull($data['client_certificate_subject']);
+
+                return $this->createStub(PDOStatement::class);
+            });
+
+        $repo = new SourceRepository($db);
+        $repo->delete($repo->find(5));
+    }
 
     public function testCreateClearsPlaintextPasswordAfterHashing(): void
     {


### PR DESCRIPTION
resolve #507 
requires https://github.com/Icinga/icinga-notifications/pull/454

To support authentication with client certificates, the `SourceForm` must support the configuration of the `client_certificate_subject` column of the `source` table.

Since a source can only have one authentication type configured, an `Authentication Type` select element is added to decide whether the username + password, or the certificate field is displayed.