### PR TITLE
`Severity`: Sort cases by acuity level

### DIFF
--- a/library/Notifications/Common/Severity.php
+++ b/library/Notifications/Common/Severity.php
@@ -11,20 +11,21 @@ use ipl\Web\Widget\Icon;
  * Incident severity levels
  *
  * Each case maps to the backing string stored in the `severity` type column of the `incident` and `incident_history`
- * tables. Register {@see \ipl\Orm\Behavior\EnumCast} on a model to have those columns hydrated automatically as enum
- * instances.
+ * tables. Declaration order reflects increasing acuity. Register {@see \ipl\Orm\Behavior\EnumCast} on a model to have
+ * those columns hydrated automatically as enum instances.
  */
 enum Severity: string
 {
     case OK        = 'ok';
-    case CRITICAL  = 'crit';
-    case WARNING   = 'warning';
-    case ERROR     = 'err';
     case DEBUG     = 'debug';
     case INFO      = 'info';
+    case NOTICE    = 'notice';
+    case WARNING   = 'warning';
+    case ERROR     = 'err';
+    case CRITICAL  = 'crit';
     case ALERT     = 'alert';
     case EMERGENCY = 'emerg';
-    case NOTICE    = 'notice';
+
 
     /**
      * Get the backing string value

--- a/test/php/library/Notifications/Common/SeverityTest.php
+++ b/test/php/library/Notifications/Common/SeverityTest.php
@@ -103,17 +103,17 @@ class SeverityTest extends TestCase
         $this->assertSame(
             [
                 Severity::OK,
-                Severity::CRITICAL,
-                Severity::WARNING,
-                Severity::ERROR,
                 Severity::DEBUG,
                 Severity::INFO,
+                Severity::NOTICE,
+                Severity::WARNING,
+                Severity::ERROR,
+                Severity::CRITICAL,
                 Severity::ALERT,
-                Severity::EMERGENCY,
-                Severity::NOTICE
+                Severity::EMERGENCY
             ],
             Severity::cases(),
-            'A Severity case was added or removed — update the test providers and this assertion'
+            'A Severity case was added, removed, or reordered — update the test providers and this assertion'
         );
     }
 }


### PR DESCRIPTION
This PR sorts the cases by severity level, so that `Severity::cases()` returns the correct order.