### PR TITLE
`SourceForm`: Allow to delete a locked source

### DIFF
--- a/application/controllers/SourceController.php
+++ b/application/controllers/SourceController.php
@@ -64,11 +64,8 @@ class SourceController extends CompatController
 
     public function deleteAction(): void
     {
-        if ($this->source->locked) {
-            throw new RuntimeException('Source is locked');
-        }
-
         $form = (new DeleteSourceForm())
+            ->setLocked($this->source->locked)
             ->setCsrfCounterMeasureId(Session::getSession()->getId())
             ->setAction(Url::fromRequest()->getAbsoluteUrl())
             ->on(Form::ON_SUBMIT, function (): never {

--- a/application/forms/DeleteSourceForm.php
+++ b/application/forms/DeleteSourceForm.php
@@ -7,12 +7,31 @@ namespace Icinga\Module\Notifications\Forms;
 
 use ipl\Html\HtmlElement;
 use ipl\Html\Text;
+use ipl\Web\Common\CalloutType;
 use ipl\Web\Common\CsrfCounterMeasure;
 use ipl\Web\Compat\CompatForm;
+use ipl\Web\Widget\Callout;
 
 class DeleteSourceForm extends CompatForm
 {
     use CsrfCounterMeasure;
+
+    /** @var bool Whether the source is locked */
+    protected bool $locked = false;
+
+    /**
+     * Set whether the source is locked
+     *
+     * @param bool $locked
+     *
+     * @return $this
+     */
+    public function setLocked(bool $locked = true): static
+    {
+        $this->locked = $locked;
+
+        return $this;
+    }
 
     protected function assemble(): void
     {
@@ -43,6 +62,16 @@ class DeleteSourceForm extends CompatForm
                 ))
             )
         ));
+
+        if ($this->locked) {
+            $this->addHtml(new Callout(
+                CalloutType::Warning,
+                $this->translate(
+                    'This source is managed by an integration and may cause malfunction if deleted without'
+                    . ' disabling the integration first.'
+                )
+            ));
+        }
 
         $this->addElement('submit', 'delete', [
             'label' => $this->translate('Understood. Delete this source.'),

--- a/application/forms/SourceForm.php
+++ b/application/forms/SourceForm.php
@@ -38,6 +38,14 @@ class SourceForm extends CompatForm
         $this->addAttributes(Attributes::create(['class' => 'source-form']));
         $this->applyDefaultElementDecorators();
         $this->addCsrfCounterMeasure();
+
+        if ($this->source?->locked) {
+            $this->addHtml(new Callout(
+                CalloutType::Info,
+                $this->translate('This source is managed by an integration, so changes can only be applied through it.')
+            ));
+        }
+
         $this->addHtml(new HtmlElement(
             'p',
             Attributes::create(['class' => 'description']),
@@ -142,67 +150,67 @@ class SourceForm extends CompatForm
             ]
         );
 
-        if ($this->source?->locked) {
-            $this->prependHtml(new Callout(
-                CalloutType::Info,
-                $this->translate('This source is managed by an integration, so changes can only be applied through it.')
-            ));
+        if (! $this->source?->locked) {
+            $credentials->addElement(
+                'password',
+                'listener_password',
+                [
+                    'required'      => $this->source === null,
+                    'label'         => $this->source !== null
+                        ? $this->translate('New Password')
+                        : $this->translate('Password'),
+                    'autocomplete'  => 'new-password',
+                    'validators'    => [['name' => 'StringLength', 'options' => ['min' => 16]]]
+                ]
+            );
+            $credentials->addElement(
+                'password',
+                'listener_password_dupe',
+                [
+                    'ignore'        => true,
+                    'required'      => $this->source === null,
+                    'label'         => $this->translate('Repeat Password'),
+                    'autocomplete'  => 'new-password',
+                    'validators'    => [new CallbackValidator(function (string $value, CallbackValidator $validator) {
+                        if ($value !== $this->getElement('credentials')->getValue('listener_password')) {
+                            $validator->addMessage($this->translate('Passwords do not match'));
 
-            return;
+                            return false;
+                        }
+
+                        return true;
+                    })]
+                ]
+            );
+
+            $this->addElement(
+                'submit',
+                'save',
+                [
+                    'label' => $this->source === null
+                        ? $this->translate('Add Source')
+                        : $this->translate('Save Changes')
+                ]
+            );
         }
 
-        $credentials->addElement(
-            'password',
-            'listener_password',
-            [
-                'required'      => $this->source === null,
-                'label'         => $this->source !== null
-                    ? $this->translate('New Password')
-                    : $this->translate('Password'),
-                'autocomplete'  => 'new-password',
-                'validators'    => [['name' => 'StringLength', 'options' => ['min' => 16]]]
-            ]
-        );
-        $credentials->addElement(
-            'password',
-            'listener_password_dupe',
-            [
-                'ignore'        => true,
-                'required'      => $this->source === null,
-                'label'         => $this->translate('Repeat Password'),
-                'autocomplete'  => 'new-password',
-                'validators'    => [new CallbackValidator(function (string $value, CallbackValidator $validator) {
-                    if ($value !== $this->getElement('credentials')->getValue('listener_password')) {
-                        $validator->addMessage($this->translate('Passwords do not match'));
-
-                        return false;
-                    }
-
-                    return true;
-                })]
-            ]
-        );
-
-        $this->addElement(
-            'submit',
-            'save',
-            [
-                'label' => $this->source === null ?
-                    $this->translate('Add Source') :
-                    $this->translate('Save Changes')
-            ]
-        );
-
         if ($this->source !== null) {
-            $this->getElement('save')->prependWrapper(
-                (new HtmlDocument())
-                    ->addHtml(
-                        (new ButtonLink(
-                            $this->translate('Delete'),
-                            Url::fromPath('notifications/source/delete/', ['id' => $this->source->id])
-                        ))->openInModal()
-                    )
-            );
+            $deleteButton = (new ButtonLink(
+                $this->translate('Delete'),
+                Url::fromPath('notifications/source/delete/', ['id' => $this->source->id])
+            ))->openInModal();
+
+            if ($this->hasElement('save')) {
+                $this->getElement('save')->prependWrapper(
+                    (new HtmlDocument())->addHtml($deleteButton)
+                );
+            } else {
+                $this->addHtml(new HtmlElement(
+                    'div',
+                    new Attributes(['class' => ['control-group', 'form-controls']]),
+                    $deleteButton
+                ));
+            }
         }
     }
 


### PR DESCRIPTION
This PR allow to delete locked source, while keeping normal edits blocked.

### Changes:

- Show an informational callout on locked sources in `SourceForm`, while still rendering a delete action.
- Allow deletion of locked sources and adding an explicit warning in the delete confirmation form.
- Adjust the SourceForm button rendering so the delete button still appears even when the save button is omitted for locked sources.

resolves #517 