### PR TITLE
Properly handle soft-deleted rows

### DIFF
--- a/application/controllers/ContactGroupController.php
+++ b/application/controllers/ContactGroupController.php
@@ -42,13 +42,7 @@ class ContactGroupController extends CompatController
         $this->controls->addAttributes(Attributes::create(['class' => 'contactgroup-detail']));
 
         $this->addControl(new ObjectHeader($group));
-
-        $contacts = Contact::on(Database::get())
-            ->filter(Filter::all(
-                Filter::equal('contactgroup_member.contactgroup_id', $group->id),
-            ));
-
-        $this->addControl($this->createPaginationControl($contacts));
+        $this->addControl($this->createPaginationControl($group->contact));
         $this->addControl($this->createLimitControl());
 
         $this->addContent(
@@ -61,7 +55,7 @@ class ContactGroupController extends CompatController
         );
 
         $this->addContent(
-            (new ObjectList($contacts, new ContactRenderer()))
+            (new ObjectList($group->contact, new ContactRenderer()))
                 ->setItemLayoutClass(MinimalItemLayout::class)
         );
 

--- a/application/controllers/ContactGroupController.php
+++ b/application/controllers/ContactGroupController.php
@@ -46,7 +46,6 @@ class ContactGroupController extends CompatController
         $contacts = Contact::on(Database::get())
             ->filter(Filter::all(
                 Filter::equal('contactgroup_member.contactgroup_id', $group->id),
-                Filter::equal('contactgroup_member.deleted', 'n')
             ));
 
         $this->addControl($this->createPaginationControl($contacts));

--- a/application/controllers/EventRuleController.php
+++ b/application/controllers/EventRuleController.php
@@ -388,10 +388,7 @@ class EventRuleController extends CompatController
         if ($ruleId !== -1) {
             $source = Rule::on(Database::get())
                 ->columns(['id' => 'source.id', 'type' => 'source.type'])
-                ->filter(Filter::all(
-                    Filter::equal('id', $ruleId),
-                    Filter::equal('deleted', 'n')
-                ))
+                ->filter(Filter::equal('id', $ruleId))
                 ->first();
         } elseif (isset($this->session->source)) {
             /** @var ?Source $source */

--- a/library/Notifications/Api/V1/Channels.php
+++ b/library/Notifications/Api/V1/Channels.php
@@ -108,7 +108,8 @@ class Channels extends ApiV1 implements RequestHandlerInterface, EndpointInterfa
                 'name',
                 'type',
                 'config'
-            ]);
+            ])
+            ->where(['ch.deleted = ?' => 'n']);
 
         if ($identifier === null) {
             return $this->getPlural($queryFilter, $stmt);
@@ -192,7 +193,10 @@ class Channels extends ApiV1 implements RequestHandlerInterface, EndpointInterfa
             (new Select())
                 ->from('channel')
                 ->columns('id')
-                ->where(['external_uuid = ?' => $channelIdentifier])
+                ->where([
+                    'external_uuid = ?' => $channelIdentifier,
+                    'deleted = ?' => 'n'
+                ])
         );
 
         return $channel->id ?? false;
@@ -212,7 +216,10 @@ class Channels extends ApiV1 implements RequestHandlerInterface, EndpointInterfa
             (new Select())
                 ->from('channel')
                 ->columns('type')
-                ->where(['id = ?' => $channelId])
+                ->where([
+                    'id = ?' => $channelId,
+                    'deleted = ?' => 'n'
+                ])
         );
 
         return $channel->type;

--- a/library/Notifications/Api/V1/ContactGroups.php
+++ b/library/Notifications/Api/V1/ContactGroups.php
@@ -448,7 +448,10 @@ class ContactGroups extends ApiV1 implements RequestHandlerInterface, EndpointIn
             (new Select())
                 ->from('contactgroup')
                 ->columns('id')
-                ->where(['external_uuid = ?' => $identifier])
+                ->where([
+                    'external_uuid = ?' => $identifier,
+                    'deleted = ?' => 'n'
+                ])
         );
 //
 //        if ($group === false) {
@@ -771,7 +774,10 @@ class ContactGroups extends ApiV1 implements RequestHandlerInterface, EndpointIn
         $stmt = (new Select())
             ->from('contactgroup')
             ->columns('1')
-            ->where(['name = ?' => $name]);
+            ->where([
+                'name = ?' => $name,
+                'deleted = ?' => 'n'
+            ]);
 
         if ($contactgroupId) {
             $stmt->where(['id != ?' => $contactgroupId]);

--- a/library/Notifications/Api/V1/Contacts.php
+++ b/library/Notifications/Api/V1/Contacts.php
@@ -203,7 +203,6 @@ class Contacts extends ApiV1 implements RequestHandlerInterface, EndpointInterfa
     public function get(?string $identifier, string $queryFilter): ResponseInterface
     {
         $stmt = (new Select())
-            ->distinct()
             ->from('contact co')
             ->columns([
                 'contact_id'      => 'co.id',
@@ -212,7 +211,6 @@ class Contacts extends ApiV1 implements RequestHandlerInterface, EndpointInterfa
                 'username',
                 'default_channel' => 'ch.external_uuid',
             ])
-            ->joinLeft('contact_address ca', 'ca.contact_id = co.id')
             ->joinLeft('channel ch', 'ch.id = co.default_channel_id')
             ->where(['co.deleted = ?' => 'n']);
 
@@ -531,7 +529,10 @@ class Contacts extends ApiV1 implements RequestHandlerInterface, EndpointInterfa
             (new Select())
                 ->from('contact_address')
                 ->columns(['type', 'address'])
-                ->where(['contact_id = ?' => $contactId])
+                ->where([
+                    'contact_id = ?' => $contactId,
+                    'deleted = ?' => 'n'
+                ])
         );
 
         return $addresses;
@@ -551,7 +552,10 @@ class Contacts extends ApiV1 implements RequestHandlerInterface, EndpointInterfa
             (new Select())
                 ->from('contact')
                 ->columns('id')
-                ->where(['external_uuid = ?' => $identifier])
+                ->where([
+                    'external_uuid = ?' => $identifier,
+                    'deleted = ?' => 'n'
+                ])
         );
 
 //        if ($contact === false) {

--- a/library/Notifications/Common/Database.php
+++ b/library/Notifications/Common/Database.php
@@ -22,28 +22,6 @@ use PDO;
 
 final class Database
 {
-    /**
-     * @var string[] Tables with a deleted flag
-     *
-     * The filter `deleted=n` is automatically added to these tables.
-     */
-    private const TABLES_WITH_DELETED_FLAG = [
-        'channel',
-        'contact',
-        'contact_address',
-        'contactgroup',
-        'contactgroup_member',
-        'rotation',
-        'rotation_member',
-        'rule',
-        'rule_escalation',
-        'rule_escalation_recipient',
-        'schedule',
-        'source',
-        'timeperiod',
-        'timeperiod_entry',
-    ];
-
     /** @var ?Connection Database connection */
     private static ?Connection $instance = null;
 
@@ -145,35 +123,6 @@ final class Database
         }
 
         $db->getQueryBuilder()
-            ->on(QueryBuilder::ON_ASSEMBLE_SELECT, function (Select $select) {
-                $from = $select->getFrom();
-                $baseTableName = reset($from);
-
-                if (! in_array($baseTableName, self::TABLES_WITH_DELETED_FLAG, true)) {
-                    return;
-                }
-
-                $baseTableAlias = key($from);
-                if (! is_string($baseTableAlias)) {
-                    $baseTableAlias = $baseTableName;
-                }
-
-                $condition = 'deleted = ?';
-                $where = $select->getWhere();
-
-                if ($where && self::hasCondition($baseTableAlias, $condition, $where)) {
-                    return;
-                }
-
-                // getNextChangedAt() wants MAX(changed_at) of all rows, deleted or not
-                foreach ($select->getColumns() as $column) {
-                    if ($column instanceof Expression && str_contains($column->getStatement(), 'MAX(changed_at)')) {
-                        return;
-                    }
-                }
-
-                $select->where([$baseTableAlias . '.' . $condition => 'n']);
-            })
             ->on(QueryBuilder::ON_ASSEMBLE_INSERT, function (Insert $insert) use ($db): void {
                 $columns = $insert->getColumns();
                 $pos = array_search('changed_at', $columns);
@@ -260,32 +209,5 @@ final class Database
         }
 
         $select->groupBy($groupBy);
-    }
-
-    /**
-     * Check if the given condition is part of the where clause with value 'y'
-     *
-     * @param string $baseTable
-     * @param string $conditionToFind
-     * @param array<int|string, int|string> $where
-     *
-     * @return bool
-     */
-    private static function hasCondition(string $baseTable, string $conditionToFind, array $where): bool
-    {
-        foreach ($where as $condition => $value) {
-            if (is_array($value)) {
-                $found = self::hasCondition($baseTable, $conditionToFind, $value);
-            } else {
-                $found = ($condition === $conditionToFind || $condition === $baseTable . '.' . $conditionToFind)
-                    && $value === 'y';
-            }
-
-            if ($found) {
-                return true;
-            }
-        }
-
-        return false;
     }
 }

--- a/library/Notifications/Common/EntityManager.php
+++ b/library/Notifications/Common/EntityManager.php
@@ -367,10 +367,6 @@ class EntityManager
         $isSoftDeletable = $childModel->isSoftDeletable();
         $changedAtColumn = $childModel->getChangedAtColumn();
         $columns = $keyColumns;
-        if ($isSoftDeletable) {
-            $columns[] = $childModel::DELETED;
-        }
-
         if ($changedAtColumn !== null) {
             $columns[] = $changedAtColumn;
         }
@@ -379,12 +375,11 @@ class EntityManager
             ->from($this->db->quoteIdentifier($childModel->getTableName()))
             ->columns(array_map($this->db->quoteIdentifier(...), $columns))
             ->where($this->createCondition($condition));
+        if ($isSoftDeletable) {
+            $select->where([sprintf('%s = ?', $this->db->quoteIdentifier($childModel::DELETED)) => 'n']);
+        }
 
         foreach ($this->db->select($select)->fetchAll(PDO::FETCH_ASSOC) as $row) {
-            if ($isSoftDeletable && $row[$childModel::DELETED] === 'y') {
-                continue;
-            }
-
             // Rebuild the stored child in its in-memory form, so its identity is comparable to the desired
             // set and delete() re-persists it identically; then let delete() pick hard vs soft
             $orphan = new $targetClass();

--- a/library/Notifications/Integrations/Incident.php
+++ b/library/Notifications/Integrations/Incident.php
@@ -232,16 +232,13 @@ class Incident
             ->filter(
                 Filter::all(
                     Filter::equal('incident_id', $this->incident->id),
-                    Filter::equal('role', $roles),
-                    Filter::unequal('contact.deleted', true),
-                    Filter::unequal('contactgroup.deleted', true),
-                    Filter::unequal('schedule.deleted', true),
+                    Filter::equal('role', $roles)
                 )
             );
 
         $recipients = [];
         foreach ($entries as $entry) {
-            if ($entry->contact_id !== null) {
+            if (isset($entry->contact->id)) {
                 $recipients[] = [
                     'type'      => 'contact',
                     'id'        => $entry->contact_id,
@@ -250,7 +247,7 @@ class Incident
                     'role'      => $entry->role,
                     'roleChangedAt' => $entry->changed_at
                 ];
-            } elseif ($entry->contactgroup_id !== null) {
+            } elseif (isset($entry->contactgroup->id)) {
                 $recipients[] = [
                     'type'      => 'contactgroup',
                     'id'        => $entry->contactgroup_id,
@@ -259,7 +256,7 @@ class Incident
                     'role'      => $entry->role,
                     'roleChangedAt' => $entry->changed_at
                 ];
-            } elseif ($entry->schedule_id !== null) {
+            } elseif (isset($entry->schedule->id)) {
                 $recipients[] = [
                     'type'      => 'schedule',
                     'id'        => $entry->schedule_id,

--- a/library/Notifications/Model/AvailableChannelType.php
+++ b/library/Notifications/Model/AvailableChannelType.php
@@ -44,6 +44,7 @@ class AvailableChannelType extends Model
     public function createRelations(Relations $relations): void
     {
         $relations->hasMany('channel', Channel::class)
-            ->setForeignKey('type');
+            ->setForeignKey('type')
+            ->setJoinType('LEFT');
     }
 }

--- a/library/Notifications/Model/Channel.php
+++ b/library/Notifications/Model/Channel.php
@@ -89,7 +89,8 @@ class Channel extends Model
             ->setJoinType('LEFT')
             ->setForeignKey('default_channel_id');
         $relations->belongsTo('available_channel_type', AvailableChannelType::class)
-            ->setCandidateKey('type');
+            ->setCandidateKey('type')
+            ->setJoinType('LEFT');
     }
 
     /**

--- a/library/Notifications/Model/Channel.php
+++ b/library/Notifications/Model/Channel.php
@@ -13,6 +13,7 @@ use ipl\Orm\Behavior\MillisecondTimestamp;
 use ipl\Orm\Behaviors;
 use ipl\Orm\Query;
 use ipl\Orm\Relations;
+use ipl\Stdlib\Filter;
 use ipl\Web\Widget\Icon;
 
 /**
@@ -103,5 +104,10 @@ class Channel extends Model
             'email'      => new Icon('at'),
             default      => new Icon('envelope')
         };
+    }
+
+    public function createVisibilityFilter(Filter\Chain $filter): void
+    {
+        $filter->add(Filter::equal('deleted', 'n'));
     }
 }

--- a/library/Notifications/Model/Contact.php
+++ b/library/Notifications/Model/Contact.php
@@ -13,6 +13,7 @@ use ipl\Orm\Behavior\MillisecondTimestamp;
 use ipl\Orm\Behaviors;
 use ipl\Orm\Query;
 use ipl\Orm\Relations;
+use ipl\Stdlib\Filter;
 
 /**
  * @property int $id
@@ -113,5 +114,10 @@ class Contact extends Model
         $relations->belongsToMany('contactgroup', Contactgroup::class)
             ->through(ContactgroupMember::class)
             ->setJoinType('LEFT');
+    }
+
+    public function createVisibilityFilter(Filter\Chain $filter): void
+    {
+        $filter->add(Filter::equal('deleted', 'n'));
     }
 }

--- a/library/Notifications/Model/Contact.php
+++ b/library/Notifications/Model/Contact.php
@@ -101,15 +101,18 @@ class Contact extends Model
             ->through(RuleEscalationRecipient::class)
             ->setJoinType('LEFT');
 
-        $relations->hasMany('incident_contact', IncidentContact::class);
-        $relations->hasMany('incident_history', IncidentHistory::class);
+        $relations->hasMany('incident_contact', IncidentContact::class)
+            ->setJoinType('LEFT');
+        $relations->hasMany('incident_history', IncidentHistory::class)
+            ->setJoinType('LEFT');
         $relations->hasMany('rotation_member', RotationMember::class)
             ->setJoinType('LEFT');
         $relations->hasMany('contact_address', ContactAddress::class);
         $relations->hasMany('rule_escalation_recipient', RuleEscalationRecipient::class)
             ->setJoinType('LEFT');
 
-        $relations->hasMany('contactgroup_member', ContactgroupMember::class);
+        $relations->hasMany('contactgroup_member', ContactgroupMember::class)
+            ->setJoinType('LEFT');
 
         $relations->belongsToMany('contactgroup', Contactgroup::class)
             ->through(ContactgroupMember::class)

--- a/library/Notifications/Model/ContactAddress.php
+++ b/library/Notifications/Model/ContactAddress.php
@@ -12,6 +12,7 @@ use ipl\Orm\Behavior\MillisecondTimestamp;
 use ipl\Orm\Behaviors;
 use ipl\Orm\Query;
 use ipl\Orm\Relations;
+use ipl\Stdlib\Filter;
 
 /**
  * @property int $id
@@ -55,5 +56,10 @@ class ContactAddress extends Model
     public function createRelations(Relations $relations): void
     {
         $relations->belongsTo('contact', Contact::class);
+    }
+
+    public function createVisibilityFilter(Filter\Chain $filter): void
+    {
+        $filter->add(Filter::equal('deleted', 'n'));
     }
 }

--- a/library/Notifications/Model/Contactgroup.php
+++ b/library/Notifications/Model/Contactgroup.php
@@ -77,8 +77,10 @@ class Contactgroup extends Model
     {
         $relations->hasMany('rule_escalation_recipient', RuleEscalationRecipient::class)
             ->setJoinType('LEFT');
-        $relations->hasMany('incident_history', IncidentHistory::class);
-        $relations->hasMany('contactgroup_member', ContactgroupMember::class);
+        $relations->hasMany('incident_history', IncidentHistory::class)
+            ->setJoinType('LEFT');
+        $relations->hasMany('contactgroup_member', ContactgroupMember::class)
+            ->setJoinType('LEFT');
         $relations
             ->belongsToMany('contact', Contact::class)
             ->through(ContactgroupMember::class)

--- a/library/Notifications/Model/Contactgroup.php
+++ b/library/Notifications/Model/Contactgroup.php
@@ -13,6 +13,7 @@ use ipl\Orm\Behavior\MillisecondTimestamp;
 use ipl\Orm\Behaviors;
 use ipl\Orm\Query;
 use ipl\Orm\Relations;
+use ipl\Stdlib\Filter;
 
 /**
  * Contact group
@@ -88,5 +89,10 @@ class Contactgroup extends Model
         $relations->belongsToMany('rule_escalation', RuleEscalation::class)
             ->through(RuleEscalationRecipient::class)
             ->setJoinType('LEFT');
+    }
+
+    public function createVisibilityFilter(Filter\Chain $filter): void
+    {
+        $filter->add(Filter::equal('deleted', 'n'));
     }
 }

--- a/library/Notifications/Model/ContactgroupMember.php
+++ b/library/Notifications/Model/ContactgroupMember.php
@@ -12,6 +12,7 @@ use ipl\Orm\Behavior\MillisecondTimestamp;
 use ipl\Orm\Behaviors;
 use ipl\Orm\Query;
 use ipl\Orm\Relations;
+use ipl\Stdlib\Filter;
 
 /**
  * Contactgroup Member
@@ -56,5 +57,10 @@ class ContactgroupMember extends Model
     {
         $relations->belongsTo('contactgroup', Contactgroup::class);
         $relations->belongsTo('contact', Contact::class);
+    }
+
+    public function createVisibilityFilter(Filter\Chain $filter): void
+    {
+        $filter->add(Filter::equal('deleted', 'n'));
     }
 }

--- a/library/Notifications/Model/Incident.php
+++ b/library/Notifications/Model/Incident.php
@@ -111,14 +111,17 @@ class Incident extends Model
         $relations->belongsTo('object', Objects::class);
 
         $relations->belongsToMany('contact', Contact::class)
-            ->through(IncidentContact::class);
+            ->through(IncidentContact::class)
+            ->setJoinType('LEFT');
 
-        $relations->hasMany('incident_contact', IncidentContact::class);
+        $relations->hasMany('incident_contact', IncidentContact::class)
+            ->setJoinType('LEFT');
         $relations->hasMany('incident_history', IncidentHistory::class);
 
         $relations
             ->belongsToMany('rule', Rule::class)
-            ->through('incident_rule');
+            ->through('incident_rule')
+            ->setJoinType('LEFT');
 
         $relations
             ->belongsToMany('rule_escalation', RuleEscalation::class)

--- a/library/Notifications/Model/Objects.php
+++ b/library/Notifications/Model/Objects.php
@@ -72,7 +72,8 @@ class Objects extends Model
 
     public function createRelations(Relations $relations): void
     {
-        $relations->hasMany('incident', Incident::class);
+        $relations->hasMany('incident', Incident::class)
+            ->setJoinType('LEFT');
 
         $relations->hasMany('object_id_tag', ObjectIdTag::class);
         $relations->hasMany('tag', Tag::class);

--- a/library/Notifications/Model/Rotation.php
+++ b/library/Notifications/Model/Rotation.php
@@ -15,6 +15,7 @@ use ipl\Orm\Behaviors;
 use ipl\Orm\Contract\RetrieveBehavior;
 use ipl\Orm\Query;
 use ipl\Orm\Relations;
+use ipl\Stdlib\Filter;
 
 /**
  * Rotation
@@ -111,5 +112,10 @@ class Rotation extends Model
                 }
             }
         });
+    }
+
+    public function createVisibilityFilter(Filter\Chain $filter): void
+    {
+        $filter->add(Filter::equal('deleted', 'n'));
     }
 }

--- a/library/Notifications/Model/RotationMember.php
+++ b/library/Notifications/Model/RotationMember.php
@@ -12,6 +12,7 @@ use ipl\Orm\Behavior\MillisecondTimestamp;
 use ipl\Orm\Behaviors;
 use ipl\Orm\Query;
 use ipl\Orm\Relations;
+use ipl\Stdlib\Filter;
 
 /**
  * RotationMember
@@ -65,5 +66,10 @@ class RotationMember extends Model
             ->setJoinType('LEFT');
         $relations->belongsTo('contactgroup', Contactgroup::class)
             ->setJoinType('LEFT');
+    }
+
+    public function createVisibilityFilter(Filter\Chain $filter): void
+    {
+        $filter->add(Filter::equal('deleted', 'n'));
     }
 }

--- a/library/Notifications/Model/Rule.php
+++ b/library/Notifications/Model/Rule.php
@@ -13,6 +13,7 @@ use ipl\Orm\Behavior\MillisecondTimestamp;
 use ipl\Orm\Behaviors;
 use ipl\Orm\Query;
 use ipl\Orm\Relations;
+use ipl\Stdlib\Filter;
 
 /**
  * @property int $id
@@ -90,5 +91,10 @@ class Rule extends Model
             ->setJoinType('LEFT');
 
         $relations->hasMany('incident_history', IncidentHistory::class)->setJoinType('LEFT');
+    }
+
+    public function createVisibilityFilter(Filter\Chain $filter): void
+    {
+        $filter->add(Filter::equal('deleted', 'n'));
     }
 }

--- a/library/Notifications/Model/Rule.php
+++ b/library/Notifications/Model/Rule.php
@@ -83,7 +83,8 @@ class Rule extends Model
     public function createRelations(Relations $relations): void
     {
         $relations->belongsTo('source', Source::class);
-        $relations->hasMany('rule_escalation', RuleEscalation::class);
+        $relations->hasMany('rule_escalation', RuleEscalation::class)
+            ->setJoinType('LEFT');
 
         $relations
             ->belongsToMany('incident', Incident::class)

--- a/library/Notifications/Model/RuleEscalation.php
+++ b/library/Notifications/Model/RuleEscalation.php
@@ -13,6 +13,7 @@ use ipl\Orm\Behavior\MillisecondTimestamp;
 use ipl\Orm\Behaviors;
 use ipl\Orm\Query;
 use ipl\Orm\Relations;
+use ipl\Stdlib\Filter;
 
 /**
  * @property int $id
@@ -111,5 +112,10 @@ class RuleEscalation extends Model
             ->setJoinType('LEFT');
         $relations->hasMany('incident_history', IncidentHistory::class)
             ->setJoinType('LEFT');
+    }
+
+    public function createVisibilityFilter(Filter\Chain $filter): void
+    {
+        $filter->add(Filter::equal('deleted', 'n'));
     }
 }

--- a/library/Notifications/Model/RuleEscalationRecipient.php
+++ b/library/Notifications/Model/RuleEscalationRecipient.php
@@ -81,10 +81,10 @@ class RuleEscalationRecipient extends Model
     public function createRelations(Relations $relations): void
     {
         $relations->belongsTo('rule_escalation', RuleEscalation::class);
-        $relations->belongsTo('contact', Contact::class);
-        $relations->belongsTo('schedule', Schedule::class);
-        $relations->belongsTo('contactgroup', Contactgroup::class);
-        $relations->belongsTo('channel', Channel::class);
+        $relations->belongsTo('contact', Contact::class)->setJoinType('LEFT');
+        $relations->belongsTo('schedule', Schedule::class)->setJoinType('LEFT');
+        $relations->belongsTo('contactgroup', Contactgroup::class)->setJoinType('LEFT');
+        $relations->belongsTo('channel', Channel::class)->setJoinType('LEFT');
     }
 
     /**

--- a/library/Notifications/Model/RuleEscalationRecipient.php
+++ b/library/Notifications/Model/RuleEscalationRecipient.php
@@ -12,6 +12,7 @@ use ipl\Orm\Behavior\MillisecondTimestamp;
 use ipl\Orm\Behaviors;
 use ipl\Orm\Query;
 use ipl\Orm\Relations;
+use ipl\Stdlib\Filter;
 
 /**
  * @property int $id
@@ -99,5 +100,10 @@ class RuleEscalationRecipient extends Model
             (bool) $this->schedule_id     => $this->schedule->first(),
             default                       => null
         };
+    }
+
+    public function createVisibilityFilter(Filter\Chain $filter): void
+    {
+        $filter->add(Filter::equal('deleted', 'n'));
     }
 }

--- a/library/Notifications/Model/Schedule.php
+++ b/library/Notifications/Model/Schedule.php
@@ -76,10 +76,12 @@ class Schedule extends Model
 
     public function createRelations(Relations $relations): void
     {
-        $relations->hasMany('rotation', Rotation::class);
+        $relations->hasMany('rotation', Rotation::class)
+            ->setJoinType('LEFT');
         $relations->hasMany('rule_escalation_recipient', RuleEscalationRecipient::class)
             ->setJoinType('LEFT');
-        $relations->hasMany('incident_history', IncidentHistory::class);
+        $relations->hasMany('incident_history', IncidentHistory::class)
+            ->setJoinType('LEFT');
 
         $relations->belongsToMany('rule_escalation', RuleEscalation::class)
             ->through(RuleEscalationRecipient::class)

--- a/library/Notifications/Model/Schedule.php
+++ b/library/Notifications/Model/Schedule.php
@@ -13,6 +13,7 @@ use ipl\Orm\Behavior\MillisecondTimestamp;
 use ipl\Orm\Behaviors;
 use ipl\Orm\Query;
 use ipl\Orm\Relations;
+use ipl\Stdlib\Filter;
 
 /**
  * @property int $id
@@ -83,5 +84,10 @@ class Schedule extends Model
         $relations->belongsToMany('rule_escalation', RuleEscalation::class)
             ->through(RuleEscalationRecipient::class)
             ->setJoinType('LEFT');
+    }
+
+    public function createVisibilityFilter(Filter\Chain $filter): void
+    {
+        $filter->add(Filter::equal('deleted', 'n'));
     }
 }

--- a/library/Notifications/Model/Source.php
+++ b/library/Notifications/Model/Source.php
@@ -96,8 +96,10 @@ class Source extends Model
 
     public function createRelations(Relations $relations): void
     {
-        $relations->hasMany('object', Objects::class);
-        $relations->hasMany('rule', Rule::class);
+        $relations->hasMany('object', Objects::class)
+            ->setJoinType('LEFT');
+        $relations->hasMany('rule', Rule::class)
+            ->setJoinType('LEFT');
     }
 
     /**

--- a/library/Notifications/Model/Source.php
+++ b/library/Notifications/Model/Source.php
@@ -17,6 +17,7 @@ use ipl\Orm\Behavior\MillisecondTimestamp;
 use ipl\Orm\Behaviors;
 use ipl\Orm\Query;
 use ipl\Orm\Relations;
+use ipl\Stdlib\Filter;
 use ipl\Web\Widget\Icon;
 use Throwable;
 
@@ -131,5 +132,10 @@ class Source extends Model
         self::$icons[$this->type] = $icon;
 
         return $icon;
+    }
+
+    public function createVisibilityFilter(Filter\Chain $filter): void
+    {
+        $filter->add(Filter::equal('deleted', 'n'));
     }
 }

--- a/library/Notifications/Model/Timeperiod.php
+++ b/library/Notifications/Model/Timeperiod.php
@@ -13,6 +13,7 @@ use ipl\Orm\Behavior\MillisecondTimestamp;
 use ipl\Orm\Behaviors;
 use ipl\Orm\Query;
 use ipl\Orm\Relations;
+use ipl\Stdlib\Filter;
 
 /**
  * Timeperiod
@@ -59,5 +60,10 @@ class Timeperiod extends Model
             ->setJoinType('LEFT');
         $relations->hasMany('timeperiod_entry', TimeperiodEntry::class)
             ->setJoinType('LEFT');
+    }
+
+    public function createVisibilityFilter(Filter\Chain $filter): void
+    {
+        $filter->add(Filter::equal('deleted', 'n'));
     }
 }

--- a/library/Notifications/Model/TimeperiodEntry.php
+++ b/library/Notifications/Model/TimeperiodEntry.php
@@ -12,6 +12,7 @@ use ipl\Orm\Behavior\MillisecondTimestamp;
 use ipl\Orm\Behaviors;
 use ipl\Orm\Query;
 use ipl\Orm\Relations;
+use ipl\Stdlib\Filter;
 use Recurr\Frequency;
 use Recurr\Rule;
 
@@ -77,6 +78,11 @@ class TimeperiodEntry extends Model
     {
         $relations->belongsTo('timeperiod', Timeperiod::class);
         $relations->belongsTo('member', RotationMember::class);
+    }
+
+    public function createVisibilityFilter(Filter\Chain $filter): void
+    {
+        $filter->add(Filter::equal('deleted', 'n'));
     }
 
     /**

--- a/library/Notifications/Repository/ChannelRepository.php
+++ b/library/Notifications/Repository/ChannelRepository.php
@@ -37,7 +37,6 @@ final class ChannelRepository
     {
         return Channel::on($this->db)
             ->filter(Filter::equal('id', $id))
-            ->filter(Filter::equal('deleted', false))
             ->first();
     }
 

--- a/library/Notifications/Repository/ContactGroupRepository.php
+++ b/library/Notifications/Repository/ContactGroupRepository.php
@@ -43,7 +43,6 @@ final class ContactGroupRepository
     {
         return Contactgroup::on($this->db)
             ->filter(Filter::equal('id', $id))
-            ->filter(Filter::equal('deleted', false))
             ->first();
     }
 
@@ -115,14 +114,12 @@ final class ContactGroupRepository
         $model->rotation
             ->query()
             ->withColumns(['schedule.timezone'])
-            ->filter(Filter::equal('deleted', false))
             ->orderBy('priority', SORT_DESC); // Important, MUST BE DESC to not open gaps when deleting one below
-        $model->rule_escalation->query()->columns('id')->filter(Filter::equal('deleted', false));
+        $model->rule_escalation->query()->columns('id');
 
         foreach ($model->rotation as $rotation) {
             $rotation->member
                 ->query()
-                ->filter(Filter::equal('deleted', false))
                 ->columns(['id', 'contact_id', 'contactgroup_id', 'position']);
 
             $otherMembers = [];
@@ -167,10 +164,7 @@ final class ContactGroupRepository
             $otherRecipient = $escalation->rule_escalation_recipient
                 ->query()
                 ->columns([new Expression('1')])
-                ->filter(Filter::all(
-                    Filter::unequal('contactgroup_id', $id),
-                    Filter::equal('deleted', false)
-                ))
+                ->filter(Filter::unequal('contactgroup_id', $id))
                 ->first();
             if ($otherRecipient === null) {
                 (new EscalationRepository($this->db))->delete($escalation->id);

--- a/library/Notifications/Repository/ContactRepository.php
+++ b/library/Notifications/Repository/ContactRepository.php
@@ -43,7 +43,6 @@ final class ContactRepository
     {
         return Contact::on($this->db)
             ->filter(Filter::equal('id', $id))
-            ->filter(Filter::equal('deleted', false))
             ->first();
     }
 
@@ -58,7 +57,6 @@ final class ContactRepository
     {
         return Contact::on($this->db)
             ->filter(Filter::equal('username', $username))
-            ->filter(Filter::equal('deleted', false))
             ->first();
     }
 
@@ -121,10 +119,6 @@ final class ContactRepository
         $model->username = $contact->username;
         $model->default_channel_id = $contact->channelId;
 
-        $model->contact_address
-            ->query()
-            ->filter(Filter::equal('deleted', false));
-
         $requiredAddresses = $contact->addresses;
         foreach ($model->contact_address as $contactAddress) {
             if (isset($requiredAddresses[$contactAddress->type])) {
@@ -168,14 +162,12 @@ final class ContactRepository
         $model->rotation
             ->query()
             ->withColumns(['schedule.timezone'])
-            ->filter(Filter::equal('deleted', false))
             ->orderBy('priority', SORT_DESC); // Important, MUST BE DESC to not open gaps when deleting one below
-        $model->rule_escalation->query()->columns('id')->filter(Filter::equal('deleted', false));
+        $model->rule_escalation->query()->columns('id');
 
         foreach ($model->rotation as $rotation) {
             $rotation->member
                 ->query()
-                ->filter(Filter::equal('deleted', 'n'))
                 ->columns(['id', 'contact_id', 'contactgroup_id', 'position']);
 
             $otherMembers = [];
@@ -220,10 +212,7 @@ final class ContactRepository
             $otherRecipient = $escalation->rule_escalation_recipient
                 ->query()
                 ->columns([new Expression('1')])
-                ->filter(Filter::all(
-                    Filter::unequal('contact_id', $id),
-                    Filter::equal('deleted', 'n')
-                ))
+                ->filter(Filter::unequal('contact_id', $id))
                 ->first();
             if ($otherRecipient === null) {
                 (new EscalationRepository($this->db))->delete($escalation->id);

--- a/library/Notifications/Repository/EscalationRepository.php
+++ b/library/Notifications/Repository/EscalationRepository.php
@@ -38,7 +38,6 @@ final class EscalationRepository
     {
         return RuleEscalation::on($this->db)
             ->filter(Filter::equal('id', $id))
-            ->filter(Filter::equal('deleted', false))
             ->first();
     }
 
@@ -104,7 +103,6 @@ final class EscalationRepository
             }
         }
 
-        $model->rule_escalation_recipient->query()->filter(Filter::equal('deleted', false));
         foreach ($model->rule_escalation_recipient as $recipientModel) {
             if (isset($recipientsToKeep[$recipientModel->id])) {
                 $recipient = $recipientsToKeep[$recipientModel->id];

--- a/library/Notifications/Repository/EscalationRuleRepository.php
+++ b/library/Notifications/Repository/EscalationRuleRepository.php
@@ -35,7 +35,6 @@ final class EscalationRuleRepository
     {
         return Rule::on($this->db)
             ->filter(Filter::equal('id', $id))
-            ->filter(Filter::equal('deleted', false))
             ->first();
     }
 
@@ -98,10 +97,7 @@ final class EscalationRuleRepository
             }
         }
 
-        $model->rule_escalation
-            ->query()
-            ->columns('id')
-            ->filter(Filter::equal('deleted', false));
+        $model->rule_escalation->query()->columns('id');
         foreach ($model->rule_escalation as $escalationModel) {
             if (! in_array($escalationModel->id, $escalationsToKeep, true)) {
                 $escalationRepository->delete($escalationModel->id);
@@ -136,10 +132,7 @@ final class EscalationRuleRepository
 
         $escalationRepository = new EscalationRepository($this->db);
 
-        $escalations = $rule->rule_escalation
-            ->query()
-            ->columns('id')
-            ->filter(Filter::equal('deleted', false));
+        $escalations = $rule->rule_escalation->query()->columns('id');
         foreach ($escalations as $escalation) {
             $escalationRepository->delete($escalation->id);
         }

--- a/library/Notifications/Repository/RotationRepository.php
+++ b/library/Notifications/Repository/RotationRepository.php
@@ -51,7 +51,6 @@ final class RotationRepository
         $rotation  = Rotation::on($this->db)
             ->withColumns('schedule.timezone')
             ->filter(Filter::equal('rotation.id', $id))
-            ->filter(Filter::equal('rotation.deleted', false))
             ->first();
 
         if ($rotation === null) {
@@ -84,7 +83,6 @@ final class RotationRepository
             $previousShift = TimeperiodEntry::on($this->db)
                 ->columns('until_time')
                 ->filter(Filter::all(
-                    Filter::equal('deleted', false),
                     Filter::equal('timeperiod.rotation.schedule_id', $rotation->schedule_id),
                     Filter::equal('timeperiod.rotation.priority', $rotation->priority),
                     Filter::unequal('timeperiod.owned_by_rotation_id', $rotation->id),
@@ -103,7 +101,6 @@ final class RotationRepository
             $newerRotation = Rotation::on($this->db)
                 ->columns(['first_handoff', 'options', 'mode', 'schedule.timezone'])
                 ->filter(Filter::all(
-                    Filter::equal('deleted', false),
                     Filter::equal('schedule_id', $rotation->schedule_id),
                     Filter::equal('priority', $rotation->priority),
                     Filter::greaterThan('first_handoff', $rotation->first_handoff)
@@ -204,7 +201,6 @@ final class RotationRepository
             $rotationsToMove = Rotation::on($this->db)
                 ->columns(['id', 'priority'])
                 ->filter(Filter::equal('schedule_id', $rotation->scheduleId))
-                ->filter(Filter::equal('deleted', false))
                 ->orderBy('priority', SORT_DESC);
 
             $entityManager = new EntityManager($this->db);
@@ -244,8 +240,7 @@ final class RotationRepository
             $versions = Rotation::on($this->db)
                 ->columns(['id', 'name'])
                 ->filter(Filter::equal('schedule_id', $rotation->scheduleId))
-                ->filter(Filter::equal('priority', $rotation->priority))
-                ->filter(Filter::equal('deleted', false));
+                ->filter(Filter::equal('priority', $rotation->priority));
             foreach ($versions as $version) {
                 $version->setNew(false);
                 $version->name = $rotation->name;
@@ -254,7 +249,6 @@ final class RotationRepository
 
             $firstHandoff = $createStmt->current();
             $timeperiodEntries = TimeperiodEntry::on($this->db)
-                ->filter(Filter::equal('deleted', false))
                 ->filter(Filter::equal('timeperiod.owned_by_rotation_id', $rotation->id));
 
             foreach ($timeperiodEntries as $timeperiodEntry) {
@@ -303,7 +297,6 @@ final class RotationRepository
         } else {
             $entries = TimeperiodEntry::on($this->db)
                 ->columns('id')
-                ->filter(Filter::equal('deleted', false))
                 ->filter(Filter::equal('timeperiod.owned_by_rotation_id', $rotation->id));
             foreach ($entries as $entry) {
                 $entityManager->save($entry->setNew(false)->delete());
@@ -345,7 +338,6 @@ final class RotationRepository
         $model = Rotation::on($this->db)
             ->withColumns(['timeperiod.id'])
             ->filter(Filter::equal('id', $id))
-            ->filter(Filter::equal('deleted', false))
             ->first()?->setNew(false);
         if ($model === null) {
             throw new RuntimeException('Cannot delete a rotation that does not exist in the database');
@@ -358,7 +350,7 @@ final class RotationRepository
         $model->timeperiod->timeperiod_entry = [];
         $model->timeperiod->delete();
 
-        $model->member->query()->columns(['id', 'position'])->filter(Filter::equal('deleted', false));
+        $model->member->query()->columns(['id', 'position']);
         foreach ($model->member as $member) {
             $member->position = null;
             $member->delete();
@@ -379,7 +371,6 @@ final class RotationRepository
                 ->columns([new Expression('1')])
                 ->filter(Filter::equal('schedule_id', $model->schedule_id))
                 ->filter(Filter::equal('priority', $freedPriority))
-                ->filter(Filter::equal('deleted', false))
                 ->first();
 
             $requirePriorityUpdate = $versions === null;
@@ -390,7 +381,6 @@ final class RotationRepository
                 ->columns(['id', 'priority'])
                 ->filter(Filter::equal('schedule_id', $model->schedule_id))
                 ->filter(Filter::greaterThan('priority', $freedPriority))
-                ->filter(Filter::equal('deleted', false))
                 ->orderBy('priority', SORT_ASC);
 
             foreach ($siblings as $sibling) {
@@ -413,8 +403,7 @@ final class RotationRepository
         $siblings = Rotation::on($this->db)
             ->columns('id')
             ->filter(Filter::equal('schedule_id', $rotation->scheduleId))
-            ->filter(Filter::equal('priority', $rotation->priority))
-            ->filter(Filter::equal('deleted', false));
+            ->filter(Filter::equal('priority', $rotation->priority));
         foreach ($siblings as $sibling) {
             $this->delete($sibling->id);
         }
@@ -432,7 +421,6 @@ final class RotationRepository
     {
         $model = Rotation::on($this->db)
             ->filter(Filter::equal('id', $id))
-            ->filter(Filter::equal('deleted', false))
             ->first()?->setNew(false);
         if ($model === null) {
             throw new RuntimeException('Cannot move a rotation that does not exist in the database');
@@ -452,7 +440,6 @@ final class RotationRepository
                 ->filter(Filter::equal('schedule_id', $model->schedule_id))
                 ->filter(Filter::greaterThanOrEqual('priority', $newPriority))
                 ->filter(Filter::lessThan('priority', $freedPriority))
-                ->filter(Filter::equal('deleted', false))
                 ->orderBy('priority', SORT_DESC);
             foreach ($siblings as $sibling) {
                 $sibling->setNew(false);
@@ -465,7 +452,6 @@ final class RotationRepository
                 ->filter(Filter::equal('schedule_id', $model->schedule_id))
                 ->filter(Filter::lessThanOrEqual('priority', $newPriority))
                 ->filter(Filter::greaterThan('priority', $freedPriority))
-                ->filter(Filter::equal('deleted', false))
                 ->orderBy('priority', SORT_ASC);
             foreach ($siblings as $sibling) {
                 $sibling->setNew(false);

--- a/library/Notifications/Repository/ScheduleRepository.php
+++ b/library/Notifications/Repository/ScheduleRepository.php
@@ -39,7 +39,6 @@ final class ScheduleRepository
     {
         return Schedule::on($this->db)
             ->filter(Filter::equal('schedule.id', $id))
-            ->filter(Filter::equal('schedule.deleted', false))
             ->first();
     }
 
@@ -87,15 +86,10 @@ final class ScheduleRepository
 
             $rotations = $model->rotation
                 ->query()
-                ->filter(Filter::equal('deleted', false))
                 ->orderBy('priority', SORT_ASC);
             foreach ($rotations as $rotation) {
-                $currentMembers = $rotation->member
-                    ->filter(Filter::equal('deleted', false))
-                    ->orderBy('position', SORT_ASC);
-
                 $members = [];
-                foreach ($currentMembers as $member) {
+                foreach ($rotation->member->orderBy('position', SORT_ASC) as $member) {
                     if ($member->contact_id !== null) {
                         $members[] = ['contact', $member->contact_id];
                     } else {
@@ -139,26 +133,19 @@ final class ScheduleRepository
 
         $rotations = $schedule->rotation->query()
             ->columns('id')
-            ->filter(Filter::equal('deleted', false))
             ->orderBy('priority', SORT_DESC);
         foreach ($rotations as $rotation) {
             (new RotationRepository($this->db))->delete($rotation->id);
         }
 
-        $schedule->rule_escalation
-            ->query()
-            ->columns('id')
-            ->filter(Filter::equal('deleted', false));
+        $schedule->rule_escalation->query()->columns('id');
         foreach ($schedule->rule_escalation as $escalation) {
             $schedule->rule_escalation->detach($escalation);
 
             $otherRecipients = $escalation->rule_escalation_recipient
                 ->query()
                 ->columns([new Expression('1')])
-                ->filter(Filter::all(
-                    Filter::unequal('schedule_id', $schedule->id),
-                    Filter::equal('deleted', 'n')
-                ))
+                ->filter(Filter::unequal('schedule_id', $schedule->id))
                 ->first();
             if ($otherRecipients === null) {
                 (new EscalationRepository($this->db))->delete($escalation->id);
@@ -188,16 +175,9 @@ final class ScheduleRepository
 
         $rotationRepository = new RotationRepository($this->db);
 
-        $rotations = $original->rotation
-            ->filter(Filter::equal('deleted', false))
-            ->orderBy('priority', SORT_ASC);
-        foreach ($rotations as $rotation) {
-            $currentMembers = $rotation->member
-                ->filter(Filter::equal('deleted', false))
-                ->orderBy('position', SORT_ASC);
-
+        foreach ($original->rotation->orderBy('priority', SORT_ASC) as $rotation) {
             $members = [];
-            foreach ($currentMembers as $member) {
+            foreach ($rotation->member->orderBy('position', SORT_ASC) as $member) {
                 if ($member->contact_id !== null) {
                     $members[] = ['contact', $member->contact_id];
                 } else {

--- a/library/Notifications/Repository/SourceRepository.php
+++ b/library/Notifications/Repository/SourceRepository.php
@@ -106,7 +106,7 @@ class SourceRepository
         $source->listener_username = null;
         $source->delete();
 
-        $source->rule->query()->columns('id')->filter(Filter::equal('deleted', false));
+        $source->rule->query()->columns('id');
         foreach ($source->rule as $rule) {
             (new EscalationRuleRepository($this->db))->delete($rule->id);
         }

--- a/library/Notifications/View/IncidentHistoryRenderer.php
+++ b/library/Notifications/View/IncidentHistoryRenderer.php
@@ -131,8 +131,8 @@ class IncidentHistoryRenderer implements ItemRenderer
 
                 break;
             case "notified":
-                if ($item->contactgroup_id) {
-                    if ($item->notification_state === 'sent') {
+                if (isset($item->contactgroup->name) && isset($item->contact->full_name)) {
+                    if (isset($item->channel->type)) {
                         $message = sprintf(
                             $this->translate('Contact %s notified via %s as member of contact group %s'),
                             $item->contact->full_name,
@@ -141,15 +141,13 @@ class IncidentHistoryRenderer implements ItemRenderer
                         );
                     } else {
                         $message = sprintf(
-                            $this->translate('Contact %s notified via %s as member of contact group %s (%s)'),
+                            $this->translate('Contact %s notified as member of contact group %s'),
                             $item->contact->full_name,
-                            $item->channel->type,
-                            $item->contactgroup->name,
-                            IncidentHistory::translateNotificationState($item->notification_state)
+                            $item->contactgroup->name
                         );
                     }
-                } elseif ($item->schedule_id) {
-                    if ($item->notfication_state === 'sent') {
+                } elseif (isset($item->schedule->name) && isset($item->contact->full_name)) {
+                    if (isset($item->channel->type)) {
                         $message = sprintf(
                             $this->translate('Contact %s notified via %s as member of schedule %s'),
                             $item->contact->full_name,
@@ -158,29 +156,44 @@ class IncidentHistoryRenderer implements ItemRenderer
                         );
                     } else {
                         $message = sprintf(
-                            $this->translate('Contact %s notified via %s as member of schedule %s (%s)'),
+                            $this->translate('Contact %s notified as member of schedule %s'),
                             $item->contact->full_name,
-                            $item->schedule->name,
-                            $item->channel->type,
-                            IncidentHistory::translateNotificationState($item->notification_state)
+                            $item->schedule->name
                         );
                     }
-                } elseif ($item->notification_state === 'sent') {
-                    $message = sprintf(
-                        $this->translate('Contact %s notified via %s'),
-                        $item->contact->full_name,
-                        $item->channel->type
-                    );
-                } else {
-                    $message = new FormattedString(
-                        $this->translate('Contact %s notified via %s %s'),
-                        [
+                } elseif (isset($item->contact->full_name)) {
+                    if (isset($item->channel->type)) {
+                        $message = sprintf(
+                            $this->translate('Contact %s notified via %s'),
                             $item->contact->full_name,
-                            $item->channel->type,
+                            $item->channel->type
+                        );
+                    } else {
+                        $message = sprintf(
+                            $this->translate('Contact %s notified'),
+                            $item->contact->full_name
+                        );
+                    }
+                } else {
+                    if (isset($item->channel->type)) {
+                        $message = sprintf(
+                            $this->translate('Unknown recipient notified via %s'),
+                            $item->channel->type
+                        );
+                    } else {
+                        $message = $this->translate('Unknown recipient notified');
+                    }
+                }
+
+                if ($item->notification_state !== 'sent') {
+                    $message = new FormattedString(
+                        '%s (%s)',
+                        [
+                            $message,
                             Html::tag(
                                 'span',
                                 ['class' => 'state-text'],
-                                sprintf('(%s)', IncidentHistory::translateNotificationState($item->notification_state))
+                                IncidentHistory::translateNotificationState($item->notification_state)
                             )
                         ]
                     );
@@ -199,24 +212,20 @@ class IncidentHistoryRenderer implements ItemRenderer
                 $newRole = $item->new_recipient_role;
                 $message = '';
                 if ($newRole === 'manager' || (! $newRole && $item->old_recipient_role === 'manager')) {
-                    if ($item->contact_id) {
-                        $message = sprintf(
-                            $this->translate('Contact %s %s managing this incident'),
-                            $item->contact->full_name,
-                            ! $item->new_recipient_role ? 'stopped' : 'started'
-                        );
-                    } elseif ($item->contactgroup_id) {
-                        $message = sprintf(
-                            $this->translate('Contact group %s %s managing this incident'),
-                            $item->contactgroup->name,
-                            ! $item->new_recipient_role ? 'stopped' : 'started'
-                        );
+                    if (isset($item->contact->full_name)) {
+                        $message = ! $newRole
+                            ? sprintf(
+                                $this->translate('Contact %s stopped managing this incident'),
+                                $item->contact->full_name
+                            )
+                            : sprintf(
+                                $this->translate('Contact %s started managing this incident'),
+                                $item->contact->full_name
+                            );
                     } else {
-                        $message = sprintf(
-                            $this->translate('Schedule %s %s managing this incident'),
-                            $item->schedule->name,
-                            ! $item->new_recipient_role ? 'stopped' : 'started'
-                        );
+                        $message = ! $newRole
+                            ? $this->translate('Unknown recipient stopped managing this incident')
+                            : $this->translate('Unknown recipient started managing this incident');
                     }
                 } elseif (
                     $newRole === 'subscriber'
@@ -224,38 +233,49 @@ class IncidentHistoryRenderer implements ItemRenderer
                         ! $newRole && $item->old_recipient_role === 'subscriber'
                     )
                 ) {
-                    if ($item->contact_id) {
-                        $message = sprintf(
-                            $this->translate('Contact %s %s this incident'),
-                            $item->contact->full_name,
-                            ! $item->new_recipient_role ? 'unsubscribed from' : 'subscribed to'
-                        );
-                    } elseif ($item->contactgroup_id) {
-                        $message = sprintf(
-                            $this->translate('Contact group %s %s this incident'),
-                            $item->contactgroup->name,
-                            ! $item->new_recipient_role ? 'unsubscribed from' : 'subscribed to'
-                        );
+                    if (isset($item->contact->full_name)) {
+                        $message = ! $newRole
+                            ? sprintf(
+                                $this->translate('Contact %s unsubscribed from this incident'),
+                                $item->contact->full_name
+                            )
+                            : sprintf(
+                                $this->translate('Contact %s subscribed to this incident'),
+                                $item->contact->full_name
+                            );
                     } else {
-                        $message = sprintf(
-                            $this->translate('Schedule %s %s this incident'),
-                            $item->schedule->name,
-                            ! $item->new_recipient_role ? 'unsubscribed from' : 'subscribed to'
-                        );
+                        $message = ! $newRole
+                            ? $this->translate('Unknown recipient unsubscribed from this incident')
+                            : $this->translate('Unknown recipient subscribed to this incident');
                     }
                 }
 
                 break;
             case 'rule_matched':
-                $message = sprintf($this->translate('Rule %s matched on this incident'), $item->rule->name);
+                if (isset($item->rule->name)) {
+                    $message = sprintf($this->translate('Rule %s matched on this incident'), $item->rule->name);
+                } else {
+                    $message = $this->translate('Unknown rule matched on this incident');
+                }
 
                 break;
             case 'escalation_triggered':
-                $message = sprintf(
-                    $this->translate('Rule %s reached escalation %s'),
-                    $item->rule->name,
-                    $item->rule_escalation->name
-                );
+                if (isset($item->rule->name)) {
+                    if (isset($item->rule_escalation->name)) {
+                        $message = sprintf(
+                            $this->translate('Rule %s reached escalation %s'),
+                            $item->rule->name,
+                            $item->rule_escalation->name
+                        );
+                    } else {
+                        $message = sprintf(
+                            $this->translate('Rule %s reached unknown escalation'),
+                            $item->rule->name
+                        );
+                    }
+                } else {
+                    $message = $this->translate('Unknown rule reached escalation');
+                }
 
                 break;
             case 'muted':

--- a/library/Notifications/View/IncidentRenderer.php
+++ b/library/Notifications/View/IncidentRenderer.php
@@ -68,11 +68,17 @@ class IncidentRenderer implements ItemRenderer
 
         /** @var Source $source */
         $source = $item->object->source;
-        $info->addHtml(
-            (new Ball(Ball::SIZE_BIG))
-                ->addAttributes(Attributes::create(['class' => 'source-icon', 'title' => $source->name]))
-                ->addHtml($source->getIcon())
-        );
+        if (isset($source->name)) {
+            $info->addHtml(
+                (new Ball(Ball::SIZE_BIG))
+                    ->addAttributes(Attributes::create(['class' => 'source-icon', 'title' => $source->name]))
+                    ->addHtml($source->getIcon())
+            );
+        } else {
+            $info->addHtml(new Icon('circle-question', [
+                'title' => $this->translate('No source information available')
+            ]));
+        }
 
         if ($item->recovered_at !== null) {
             $info->addHtml(FormattedString::create(

--- a/library/Notifications/Widget/Detail/IncidentDetail.php
+++ b/library/Notifications/Widget/Detail/IncidentDetail.php
@@ -53,14 +53,15 @@ class IncidentDetail extends BaseHtmlElement
         $contacts = [];
         $query = $this->incident->incident_contact
             ->with('contact')
-            ->filter(Filter::equal('contact.deleted', 'n'))
             ->orderBy('role', SORT_DESC);
 
         foreach ($query as $incident_contact) {
-            $contact = $incident_contact->contact;
-            $contact->role = $incident_contact->role;
+            if (isset($incident_contact->contact->id)) {
+                $contact = $incident_contact->contact;
+                $contact->role = $incident_contact->role;
 
-            $contacts[] = $contact;
+                $contacts[] = $contact;
+            }
         }
 
         $disableContactLink = ! $this->getAuth()->hasPermission('notifications/view/contacts')

--- a/library/Notifications/Widget/Detail/IncidentDetail.php
+++ b/library/Notifications/Widget/Detail/IncidentDetail.php
@@ -21,7 +21,6 @@ use ipl\Html\HtmlElement;
 use ipl\Html\Text;
 use ipl\Html\ValidHtml;
 use ipl\I18n\Translation;
-use ipl\Stdlib\Filter;
 use ipl\Web\Layout\MinimalItemLayout;
 use ipl\Web\Url;
 use ipl\Web\Widget\CopyToClipboard;
@@ -68,7 +67,7 @@ class IncidentDetail extends BaseHtmlElement
             || ! $this->getAuth()->hasPermission('notifications/config/contacts');
 
         return [
-            Html::tag('h2', t('Subscribers')),
+            Html::tag('h2', $this->translate('Subscribers')),
             (new ObjectList($contacts, (new IncidentContactRenderer())->disableContactLink($disableContactLink)))
                 ->setItemLayoutClass(MinimalItemLayout::class)
                 ->setDetailActionsDisabled($disableContactLink)
@@ -79,7 +78,9 @@ class IncidentDetail extends BaseHtmlElement
     protected function createRelatedObject(): array
     {
         $object = $this->incident->object;
-        $hook = SourceHookLocator::forType($object->source->type);
+        $hook = isset($object->source->type)
+            ? SourceHookLocator::forType($object->source->type)
+            : null;
 
         $objectUrl = $hook?->createObjectLink($object->id_tags);
         if ($objectUrl === null) {
@@ -100,7 +101,7 @@ class IncidentDetail extends BaseHtmlElement
         }
 
         return [
-            new HtmlElement('h2', null, Text::create(t('Related Object'))),
+            new HtmlElement('h2', null, Text::create($this->translate('Related Object'))),
             $objectUrl
         ];
     }
@@ -151,7 +152,7 @@ class IncidentDetail extends BaseHtmlElement
             ]);
 
         return [
-            Html::tag('h2', t('Incident History')),
+            Html::tag('h2', $this->translate('Incident History')),
             (new ObjectList($query, new IncidentHistoryRenderer()))
                 ->setItemLayoutClass(MinimalItemLayout::class)
                 ->setDetailActionsDisabled()
@@ -161,11 +162,18 @@ class IncidentDetail extends BaseHtmlElement
     /** @return ValidHtml[] */
     protected function createSource(): array
     {
+        if (! isset($this->incident->object->source->name)) {
+            return [
+                Html::tag('h2', $this->translate('Event Source')),
+                new EmptyState($this->translate('No source information available'))
+            ];
+        }
+
         $list = new HtmlElement('ul', Attributes::create(['class' => 'source-list']));
         $list->addHtml(new HtmlElement('li', null, new EventSourceBadge($this->incident->object->source)));
 
         return [
-            Html::tag('h2', t('Event Source')),
+            Html::tag('h2', $this->translate('Event Source')),
             $list
         ];
     }

--- a/test/php/Lib/DatabaseUtils.php
+++ b/test/php/Lib/DatabaseUtils.php
@@ -1,0 +1,55 @@
+<?php
+
+// SPDX-FileCopyrightText: 2026 Icinga GmbH <https://icinga.com>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+namespace Tests\Icinga\Module\Notifications\Lib;
+
+use ipl\Orm\Model;
+use ipl\Sql\Connection;
+use ipl\Sql\Select;
+
+trait DatabaseUtils
+{
+    /**
+     * Load a database row directly, bypassing the model's `deleted` filter
+     *
+     * @template TModel of Model
+     *
+     * @param Connection $db
+     * @param int|int[] $id
+     * @param class-string<TModel> $class
+     *
+     * @return ?TModel
+     */
+    private function loadRawEntity(Connection $db, int|array $id, string $class): ?Model
+    {
+        $entity = new $class();
+        $where = [];
+        if (is_array($id)) {
+            foreach ($id as $k => $v) {
+                $where["$k = ?"] = $v;
+            }
+        } else {
+            $k = ((array) $entity->getKeyName())[0];
+            $where["$k = ?"] = $id;
+        }
+
+        $result = $db->select(
+            (new Select())
+                ->from($entity->getTableName())
+                ->columns(array_map($db->quoteIdentifier(...), array_merge(
+                    (array) $entity->getKeyName(),
+                    $entity->getColumns()
+                )))
+                ->where($where)
+        )->fetch(\PDO::FETCH_ASSOC);
+        if ($result === false) {
+            return null;
+        }
+
+        $entity->setProperties($result);
+
+        return $entity;
+    }
+}

--- a/test/php/Lib/EntityManager/GadgetBadge.php
+++ b/test/php/Lib/EntityManager/GadgetBadge.php
@@ -9,6 +9,7 @@ use Icinga\Module\Notifications\Common\Model;
 use ipl\Orm\Behavior\BoolCast;
 use ipl\Orm\Behavior\MillisecondTimestamp;
 use ipl\Orm\Behaviors;
+use ipl\Stdlib\Filter;
 
 /**
  * Soft-delete junction model linking {@see Gadget} and {@see Badge} through a surrogate primary key.
@@ -39,6 +40,11 @@ class GadgetBadge extends Model
     {
         $behaviors->add(new MillisecondTimestamp(['changed_at']));
         $behaviors->add(new BoolCast(['deleted']));
+    }
+
+    public function createVisibilityFilter(Filter\Chain $filter): void
+    {
+        $filter->add(Filter::equal('deleted', 'n'));
     }
 
     public function isSoftDeletable(): bool

--- a/test/php/Lib/EntityManager/GadgetTag.php
+++ b/test/php/Lib/EntityManager/GadgetTag.php
@@ -9,6 +9,7 @@ use Icinga\Module\Notifications\Common\Model;
 use ipl\Orm\Behavior\BoolCast;
 use ipl\Orm\Behavior\MillisecondTimestamp;
 use ipl\Orm\Behaviors;
+use ipl\Stdlib\Filter;
 
 /**
  * Soft-delete junction model linking {@see Gadget} and {@see Tag}.
@@ -38,6 +39,11 @@ class GadgetTag extends Model
     {
         $behaviors->add(new MillisecondTimestamp(['changed_at']));
         $behaviors->add(new BoolCast(['deleted']));
+    }
+
+    public function createVisibilityFilter(Filter\Chain $filter): void
+    {
+        $filter->add(Filter::equal('deleted', 'n'));
     }
 
     public function isSoftDeletable(): bool

--- a/test/php/Lib/EntityManager/StampedNote.php
+++ b/test/php/Lib/EntityManager/StampedNote.php
@@ -10,6 +10,7 @@ use ipl\Orm\Behavior\BoolCast;
 use ipl\Orm\Behavior\MillisecondTimestamp;
 use ipl\Orm\Behaviors;
 use ipl\Orm\Relations;
+use ipl\Stdlib\Filter;
 
 /**
  * HasMany child of {@see Stamped} that carries a `deleted` column, so the EntityManager soft-deletes
@@ -42,5 +43,10 @@ class StampedNote extends Model
     public function createRelations(Relations $relations): void
     {
         $relations->belongsTo('stamped', Stamped::class);
+    }
+
+    public function createVisibilityFilter(Filter\Chain $filter): void
+    {
+        $filter->add(Filter::equal('deleted', 'n'));
     }
 }

--- a/test/php/library/Notifications/Repository/ChannelRepositoryTest.php
+++ b/test/php/library/Notifications/Repository/ChannelRepositoryTest.php
@@ -16,6 +16,7 @@ use ipl\Sql\Test\SharedDatabases\TransactionIsolation;
 use ipl\Stdlib\Filter;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use Tests\Icinga\Module\Notifications\Lib\DatabaseUtils;
 
 /**
  * Tests for {@see ChannelRepository}.
@@ -31,6 +32,7 @@ use PHPUnit\Framework\TestCase;
 #[TransactionIsolation]
 class ChannelRepositoryTest extends TestCase
 {
+    use DatabaseUtils;
     use DbTestBackends;
 
     protected static function initializeNotificationsDb(Connection $db): void
@@ -67,7 +69,7 @@ class ChannelRepositoryTest extends TestCase
     }
 
     /**
-     * Load a channel row directly, bypassing the repository's `deleted` filter
+     * Load a channel row directly
      *
      * @param Connection $db
      * @param int $id
@@ -93,7 +95,6 @@ class ChannelRepositoryTest extends TestCase
         $this->assertSame('Support', $channel->name);
         $this->assertSame('email', $channel->type);
         $this->assertSame('{"sender_mail":"noreply@example.com"}', $channel->config);
-        $this->assertFalse($channel->deleted, 'The deleted flag should be cast to a bool');
     }
 
     #[DataProvider('sharedDatabases')]
@@ -125,7 +126,6 @@ class ChannelRepositoryTest extends TestCase
         $this->assertSame('Support', $stored->name);
         $this->assertSame('email', $stored->type);
         $this->assertSame('{"sender_mail":"noreply@example.com"}', $stored->config);
-        $this->assertFalse($stored->deleted);
         $this->assertNotEmpty($stored->external_uuid, 'The channel should have been assigned an external uuid');
     }
 
@@ -198,9 +198,9 @@ class ChannelRepositoryTest extends TestCase
         (new ChannelRepository($db))->delete($id);
 
         // It's only soft-deleted: the row still exists, flagged deleted
-        $stored = $this->loadChannel($db, $id);
+        $stored = $this->loadRawEntity($db, $id, Channel::class);
         $this->assertNotNull($stored, 'The channel row should still exist');
-        $this->assertTrue($stored->deleted, 'The channel should be soft-deleted, not removed');
+        $this->assertSame('y', $stored->deleted, 'The channel should be soft-deleted, not removed');
     }
 
     #[DataProvider('sharedDatabases')]

--- a/test/php/library/Notifications/Repository/ContactGroupRepositoryTest.php
+++ b/test/php/library/Notifications/Repository/ContactGroupRepositoryTest.php
@@ -22,12 +22,12 @@ use Icinga\Module\Notifications\Repository\RotationRepository;
 use Icinga\Module\Notifications\Test\DbTestBackends;
 use InvalidArgumentException;
 use ipl\Sql\Connection;
-use ipl\Sql\Test\SharedDatabases\SchemaGroup;
 use ipl\Sql\Test\SharedDatabases\TransactionIsolation;
 use ipl\Stdlib\Filter;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
+use Tests\Icinga\Module\Notifications\Lib\DatabaseUtils;
 
 /**
  * Tests for {@see ContactGroupRepository}.
@@ -41,6 +41,7 @@ use RuntimeException;
 #[TransactionIsolation]
 class ContactGroupRepositoryTest extends TestCase
 {
+    use DatabaseUtils;
     use DbTestBackends;
 
     /** @var int[] Ids of the three contacts seeded per test, in insertion order */
@@ -71,19 +72,6 @@ class ContactGroupRepositoryTest extends TestCase
     }
 
     /**
-     * Load a group row directly, bypassing the repository's `deleted` filter
-     *
-     * @param Connection $db
-     * @param int $id
-     *
-     * @return ?Contactgroup
-     */
-    private function loadGroup(Connection $db, int $id): ?Contactgroup
-    {
-        return Contactgroup::on($db)->filter(Filter::equal('id', $id))->first();
-    }
-
-    /**
      * Get the group's current (non-deleted) member contact ids, sorted
      *
      * @param Connection $db
@@ -95,8 +83,7 @@ class ContactGroupRepositoryTest extends TestCase
     {
         $members = [];
         $query = ContactgroupMember::on($db)
-            ->filter(Filter::equal('contactgroup_id', $groupId))
-            ->filter(Filter::equal('deleted', false));
+            ->filter(Filter::equal('contactgroup_id', $groupId));
         foreach ($query as $member) {
             $members[] = (int) $member->contact_id;
         }
@@ -172,9 +159,9 @@ class ContactGroupRepositoryTest extends TestCase
         $this->assertNull($repository->find($id), 'A deleted group must not be found anymore');
 
         // But it's only soft-deleted: the row still exists, flagged deleted
-        $group = $this->loadGroup($db, $id);
+        $group = $this->loadRawEntity($db, $id, ContactGroup::class);
         $this->assertNotNull($group, 'The group row should still exist');
-        $this->assertTrue($group->deleted, 'The group should be soft-deleted, not removed');
+        $this->assertSame('y', $group->deleted, 'The group should be soft-deleted, not removed');
 
         $this->assertSame([], $this->membersOf($db, $id), 'The memberships should be soft-deleted too');
     }
@@ -221,7 +208,11 @@ class ContactGroupRepositoryTest extends TestCase
         $repository->delete($groupId);
 
         $this->assertNull($repository->find($groupId), 'The group should have been deleted');
-        $this->assertTrue($this->loadGroup($db, $groupId)->deleted, 'The group should be soft-deleted');
+        $this->assertSame(
+            'y',
+            $this->loadRawEntity($db, $groupId, Contactgroup::class)->deleted,
+            'The group should be soft-deleted'
+        );
     }
 
     #[DataProvider('sharedDatabases')]
@@ -271,7 +262,6 @@ class ContactGroupRepositoryTest extends TestCase
         return iterator_to_array(
             Rotation::on($db)
                 ->filter(Filter::equal('schedule_id', $scheduleId))
-                ->filter(Filter::equal('deleted', false))
                 ->orderBy('priority')
         );
     }
@@ -312,8 +302,7 @@ class ContactGroupRepositoryTest extends TestCase
     {
         $ids = [];
         $query = RotationMember::on($db)
-            ->filter(Filter::equal('rotation_id', $rotationId))
-            ->filter(Filter::equal('deleted', false));
+            ->filter(Filter::equal('rotation_id', $rotationId));
         foreach ($query as $member) {
             $ids[] = (int) $member->contactgroup_id;
         }

--- a/test/php/library/Notifications/Repository/ContactRepositoryTest.php
+++ b/test/php/library/Notifications/Repository/ContactRepositoryTest.php
@@ -22,12 +22,12 @@ use Icinga\Module\Notifications\Repository\RotationRepository;
 use Icinga\Module\Notifications\Test\DbTestBackends;
 use InvalidArgumentException;
 use ipl\Sql\Connection;
-use ipl\Sql\Test\SharedDatabases\SchemaGroup;
 use ipl\Sql\Test\SharedDatabases\TransactionIsolation;
 use ipl\Stdlib\Filter;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
+use Tests\Icinga\Module\Notifications\Lib\DatabaseUtils;
 
 /**
  * Tests for {@see ContactRepository}.
@@ -45,6 +45,7 @@ use RuntimeException;
 #[TransactionIsolation]
 class ContactRepositoryTest extends TestCase
 {
+    use DatabaseUtils;
     use DbTestBackends;
 
     /** @var int Id of the channel seeded per test (auto-increment drifts across rolled-back transactions) */
@@ -65,19 +66,6 @@ class ContactRepositoryTest extends TestCase
     }
 
     /**
-     * Load a contact row directly, bypassing the repository's `deleted` filter
-     *
-     * @param Connection $db
-     * @param int $id
-     *
-     * @return ?Contact
-     */
-    private function loadContact(Connection $db, int $id): ?Contact
-    {
-        return Contact::on($db)->filter(Filter::equal('id', $id))->first();
-    }
-
-    /**
      * Get the contact's non-deleted addresses as a type => address map
      *
      * @param Connection $db
@@ -89,8 +77,7 @@ class ContactRepositoryTest extends TestCase
     {
         $addresses = [];
         $query = ContactAddress::on($db)
-            ->filter(Filter::equal('contact_id', $contactId))
-            ->filter(Filter::equal('deleted', false));
+            ->filter(Filter::equal('contact_id', $contactId));
         foreach ($query as $address) {
             $addresses[$address->type] = $address->address;
         }
@@ -241,9 +228,9 @@ class ContactRepositoryTest extends TestCase
         $this->assertNull($repository->find($id), 'A deleted contact must not be found anymore');
 
         // But it's only soft-deleted: the row still exists, flagged deleted
-        $contact = $this->loadContact($db, $id);
+        $contact = $this->loadRawEntity($db, $id, Contact::class);
         $this->assertNotNull($contact, 'The contact row should still exist');
-        $this->assertTrue($contact->deleted, 'The contact should be soft-deleted, not removed');
+        $this->assertSame('y', $contact->deleted, 'The contact should be soft-deleted, not removed');
 
         // Its addresses are soft-deleted too
         $this->assertSame([], $this->addressesByType($db, $id), 'The contact\'s addresses should be soft-deleted');
@@ -266,8 +253,8 @@ class ContactRepositoryTest extends TestCase
         $repository->delete($id);
 
         // The unique username must be nulled on deletion so the same web user can be re-added later
-        $contact = $this->loadContact($db, $id);
-        $this->assertTrue($contact->deleted);
+        $contact = $this->loadRawEntity($db, $id, Contact::class);
+        $this->assertSame('y', $contact->deleted);
         $this->assertNull($contact->username, 'The unique username must be nulled on deletion so it can be reused');
     }
 
@@ -286,7 +273,6 @@ class ContactRepositoryTest extends TestCase
         $liveMembership = ContactgroupMember::on($db)
             ->filter(Filter::equal('contactgroup_id', $groupId))
             ->filter(Filter::equal('contact_id', $id))
-            ->filter(Filter::equal('deleted', false))
             ->first();
         $this->assertNull($liveMembership, 'The contact\'s group membership must be soft-deleted on deletion');
     }
@@ -308,8 +294,7 @@ class ContactRepositoryTest extends TestCase
         $this->createRotation($db, $scheduleId, 2, [['contact', $c1], ['contact', $c2]]);
 
         $rotations = $this->rotationsOf($db, $scheduleId);
-        $soleId = (int) $rotations[0]->id;
-        $sharedId = (int) $rotations[1]->id;
+        $soleId = $rotations[0]->id;
 
         $repository->delete($c1);
 
@@ -320,24 +305,21 @@ class ContactRepositoryTest extends TestCase
         // The solely-owned rotation is gone; the shared one survives and is renumbered to close the freed slot —
         // it moves up from priority 2 to 1 now that the priority-1 rotation below it was removed
         $this->assertSame(1, $shared->priority, 'The surviving rotation must move up to close the freed priority');
-        $this->assertTrue(
-            Rotation::on($db)->filter(Filter::equal('id', $soleId))->first()->deleted,
+        $this->assertSame(
+            'y',
+            $this->loadRawEntity($db, $soleId, Rotation::class)->deleted,
             'The solely-owned rotation should be soft-deleted'
         );
 
         // C1's membership in the shared rotation must be SOFT-deleted (row kept, flagged), not physically removed
-        $c1Membership = RotationMember::on($db)
-            ->filter(Filter::equal('rotation_id', $sharedId))
-            ->filter(Filter::equal('contact_id', $c1))
-            ->first();
+        $c1Membership = $this->loadRawEntity($db, ['contact_id' => $c1], RotationMember::class);
         $this->assertNotNull($c1Membership, 'The membership row must still exist (soft-deleted, not hard-deleted)');
-        $this->assertTrue($c1Membership->deleted, 'The membership must be soft-deleted');
+        $this->assertSame('y', $c1Membership->deleted, 'The membership must be soft-deleted');
 
         // C2 remains an active member of the shared rotation
         $c2Membership = RotationMember::on($db)
             ->filter(Filter::equal('rotation_id', $shared->id))
             ->filter(Filter::equal('contact_id', $c2))
-            ->filter(Filter::equal('deleted', false))
             ->first();
         $this->assertNotNull($c2Membership, 'C2 should remain an active member of the shared rotation');
     }
@@ -389,8 +371,7 @@ class ContactRepositoryTest extends TestCase
     {
         $ids = [];
         $query = RotationMember::on($db)
-            ->filter(Filter::equal('rotation_id', $rotationId))
-            ->filter(Filter::equal('deleted', false));
+            ->filter(Filter::equal('rotation_id', $rotationId));
         foreach ($query as $member) {
             $ids[] = (int) $member->contact_id;
         }
@@ -413,7 +394,6 @@ class ContactRepositoryTest extends TestCase
         return iterator_to_array(
             Rotation::on($db)
                 ->filter(Filter::equal('schedule_id', $scheduleId))
-                ->filter(Filter::equal('deleted', false))
                 ->orderBy('priority')
         );
     }

--- a/test/php/library/Notifications/Repository/EscalationRepositoryTest.php
+++ b/test/php/library/Notifications/Repository/EscalationRepositoryTest.php
@@ -14,12 +14,12 @@ use Icinga\Module\Notifications\Repository\EscalationRepository;
 use Icinga\Module\Notifications\Test\DbTestBackends;
 use InvalidArgumentException;
 use ipl\Sql\Connection;
-use ipl\Sql\Test\SharedDatabases\SchemaGroup;
 use ipl\Sql\Test\SharedDatabases\TransactionIsolation;
 use ipl\Stdlib\Filter;
 use LogicException;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use Tests\Icinga\Module\Notifications\Lib\DatabaseUtils;
 
 /**
  * Tests for {@see EscalationRepository}.
@@ -37,6 +37,7 @@ use PHPUnit\Framework\TestCase;
 #[TransactionIsolation]
 class EscalationRepositoryTest extends TestCase
 {
+    use DatabaseUtils;
     use DbTestBackends;
 
     /** @var int Id of the contact seeded per test, used as the recipient */
@@ -132,7 +133,6 @@ class EscalationRepositoryTest extends TestCase
         return iterator_to_array(
             RuleEscalationRecipient::on($db)
                 ->filter(Filter::equal('rule_escalation_id', $escalationId))
-                ->filter(Filter::equal('deleted', false))
         );
     }
 
@@ -218,9 +218,9 @@ class EscalationRepositoryTest extends TestCase
         $this->assertNull($repository->find($id), 'A deleted escalation must not be found anymore');
 
         // But it's only soft-deleted: the row still exists, flagged deleted with its position freed
-        $escalation = RuleEscalation::on($db)->filter(Filter::equal('id', $id))->first();
+        $escalation = $this->loadRawEntity($db, $id, RuleEscalation::class);
         $this->assertNotNull($escalation, 'The escalation row should still exist');
-        $this->assertTrue($escalation->deleted, 'The escalation should be soft-deleted, not removed');
+        $this->assertSame('y', $escalation->deleted, 'The escalation should be soft-deleted, not removed');
         $this->assertNull($escalation->position, 'The freed position should be nulled');
 
         $this->assertCount(0, $this->recipientsOf($db, $id), 'The recipients should be soft-deleted too');

--- a/test/php/library/Notifications/Repository/EscalationRuleRepositoryTest.php
+++ b/test/php/library/Notifications/Repository/EscalationRuleRepositoryTest.php
@@ -15,11 +15,11 @@ use Icinga\Module\Notifications\Repository\EscalationRuleRepository;
 use Icinga\Module\Notifications\Test\DbTestBackends;
 use InvalidArgumentException;
 use ipl\Sql\Connection;
-use ipl\Sql\Test\SharedDatabases\SchemaGroup;
 use ipl\Sql\Test\SharedDatabases\TransactionIsolation;
 use ipl\Stdlib\Filter;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use Tests\Icinga\Module\Notifications\Lib\DatabaseUtils;
 
 /**
  * Tests for {@see EscalationRuleRepository}.
@@ -40,6 +40,7 @@ use PHPUnit\Framework\TestCase;
 #[TransactionIsolation]
 class EscalationRuleRepositoryTest extends TestCase
 {
+    use DatabaseUtils;
     use DbTestBackends;
 
     /** @var int Id of the source seeded per test, referenced by the rule */
@@ -106,7 +107,6 @@ class EscalationRuleRepositoryTest extends TestCase
         return iterator_to_array(
             RuleEscalation::on($db)
                 ->filter(Filter::equal('rule_id', $ruleId))
-                ->filter(Filter::equal('deleted', 'n'))
                 ->orderBy('position')
         );
     }
@@ -234,9 +234,9 @@ class EscalationRuleRepositoryTest extends TestCase
         $this->assertNull($repository->find($id), 'A deleted rule must not be found anymore');
 
         // It's only soft-deleted though: the row still exists, flagged deleted
-        $rule = Rule::on($db)->filter(Filter::equal('id', $id))->first();
+        $rule = $this->loadRawEntity($db, $id, Rule::class);
         $this->assertNotNull($rule, 'The rule row should still exist');
-        $this->assertTrue($rule->deleted, 'The rule should be soft-deleted, not removed');
+        $this->assertSame('y', $rule->deleted, 'The rule should be soft-deleted, not removed');
 
         $this->assertCount(0, $this->escalationsOf($db, $id), 'The rule\'s escalations should be soft-deleted too');
     }

--- a/test/php/library/Notifications/Repository/RotationRepositoryTest.php
+++ b/test/php/library/Notifications/Repository/RotationRepositoryTest.php
@@ -16,12 +16,12 @@ use Icinga\Module\Notifications\Model\TimeperiodEntry;
 use Icinga\Module\Notifications\Repository\RotationRepository;
 use Icinga\Module\Notifications\Test\DbTestBackends;
 use ipl\Sql\Connection;
-use ipl\Sql\Test\SharedDatabases\SchemaGroup;
 use ipl\Sql\Test\SharedDatabases\TransactionIsolation;
 use ipl\Stdlib\Filter;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
+use Tests\Icinga\Module\Notifications\Lib\DatabaseUtils;
 
 /**
  * Tests for {@see RotationRepository}.
@@ -38,6 +38,7 @@ use RuntimeException;
 #[TransactionIsolation]
 class RotationRepositoryTest extends TestCase
 {
+    use DatabaseUtils;
     use DbTestBackends;
 
     /** @var int Id of the contact seeded per test, used as a rotation member */
@@ -114,7 +115,6 @@ class RotationRepositoryTest extends TestCase
         return iterator_to_array(
             Rotation::on($db)
                 ->filter(Filter::equal('schedule_id', $scheduleId))
-                ->filter(Filter::equal('deleted', false))
                 ->orderBy('priority')
         );
     }
@@ -145,7 +145,6 @@ class RotationRepositoryTest extends TestCase
         $members = iterator_to_array(
             RotationMember::on($db)
                 ->filter(Filter::equal('rotation_id', $rotation->id))
-                ->filter(Filter::equal('deleted', false))
         );
         $this->assertCount(1, $members);
         $this->assertEquals(self::$contactId, $members[0]->contact_id);
@@ -154,14 +153,12 @@ class RotationRepositoryTest extends TestCase
         // The timeperiod and at least one entry
         $timeperiod = Timeperiod::on($db)
             ->filter(Filter::equal('owned_by_rotation_id', $rotation->id))
-            ->filter(Filter::equal('deleted', false))
             ->first();
         $this->assertNotNull($timeperiod, 'The rotation\'s timeperiod was not created');
 
         $entries = iterator_to_array(
             TimeperiodEntry::on($db)
                 ->filter(Filter::equal('timeperiod_id', $timeperiod->id))
-                ->filter(Filter::equal('deleted', false))
         );
         $this->assertNotEmpty($entries, 'The timeperiod should have at least one entry');
 
@@ -218,7 +215,6 @@ class RotationRepositoryTest extends TestCase
         $members = iterator_to_array(
             RotationMember::on($db)
                 ->filter(Filter::equal('rotation_id', $rotations[0]->id))
-                ->filter(Filter::equal('deleted', false))
         );
         $this->assertCount(1, $members);
         $this->assertEquals(self::$contactId, $members[0]->contact_id);
@@ -227,14 +223,12 @@ class RotationRepositoryTest extends TestCase
         // The timeperiod and at least one entry
         $timeperiod = Timeperiod::on($db)
             ->filter(Filter::equal('owned_by_rotation_id', $rotations[0]->id))
-            ->filter(Filter::equal('deleted', false))
             ->first();
         $this->assertNotNull($timeperiod, 'The rotation\'s timeperiod was not created');
 
         $entries = iterator_to_array(
             TimeperiodEntry::on($db)
                 ->filter(Filter::equal('timeperiod_id', $timeperiod->id))
-                ->filter(Filter::equal('deleted', false))
         );
         $this->assertNotEmpty($entries, 'The timeperiod should have at least one entry');
 
@@ -260,21 +254,17 @@ class RotationRepositoryTest extends TestCase
         $this->assertCount(0, $this->rotationsOf($db, $scheduleId), 'The rotation should no longer be listed');
 
         // The row still exists but is soft-deleted with its priority freed
-        $rotation = Rotation::on($db)->filter(Filter::equal('id', $id))->first();
+        $rotation = $this->loadRawEntity($db, $id, Rotation::class);
         $this->assertNotNull($rotation);
-        $this->assertTrue($rotation->deleted, 'The rotation should be soft-deleted');
+        $this->assertSame('y', $rotation->deleted, 'The rotation should be soft-deleted');
         $this->assertNull($rotation->priority, 'The freed priority should be nulled');
 
         // Its timeperiod is soft-deleted too
-        $timeperiod = Timeperiod::on($db)
-            ->filter(Filter::equal('owned_by_rotation_id', $id))
-            ->first();
-        $this->assertTrue($timeperiod->deleted, 'The rotation\'s timeperiod should be soft-deleted');
+        $timeperiod = $this->loadRawEntity($db, ['owned_by_rotation_id' => $id], Timeperiod::class);
+        $this->assertSame('y', $timeperiod->deleted, 'The rotation\'s timeperiod should be soft-deleted');
 
-        $timeperiodEntries = TimeperiodEntry::on($db)
-            ->filter(Filter::equal('timeperiod_id', $timeperiod->id))
-            ->filter(Filter::equal('deleted', false));
-        $this->assertCount(0, $timeperiodEntries, 'The timeperiod entries should be soft-deleted');
+        $timeperiodEntry = $this->loadRawEntity($db, ['timeperiod_id' => $timeperiod->id], TimeperiodEntry::class);
+        $this->assertSame('y', $timeperiodEntry->deleted, 'The timeperiod entries should be soft-deleted');
     }
 
     #[DataProvider('sharedDatabases')]

--- a/test/php/library/Notifications/Repository/ScheduleRepositoryTest.php
+++ b/test/php/library/Notifications/Repository/ScheduleRepositoryTest.php
@@ -22,11 +22,11 @@ use Icinga\Module\Notifications\Repository\ScheduleRepository;
 use Icinga\Module\Notifications\Test\DbTestBackends;
 use InvalidArgumentException;
 use ipl\Sql\Connection;
-use ipl\Sql\Test\SharedDatabases\SchemaGroup;
 use ipl\Sql\Test\SharedDatabases\TransactionIsolation;
 use ipl\Stdlib\Filter;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use Tests\Icinga\Module\Notifications\Lib\DatabaseUtils;
 
 /**
  * Tests for {@see ScheduleRepository}.
@@ -40,6 +40,7 @@ use PHPUnit\Framework\TestCase;
 #[TransactionIsolation]
 class ScheduleRepositoryTest extends TestCase
 {
+    use DatabaseUtils;
     use DbTestBackends;
 
     /** @var int Id of the contact seeded per test */
@@ -72,19 +73,6 @@ class ScheduleRepositoryTest extends TestCase
     }
 
     /**
-     * Load a schedule row directly, bypassing the repository's `deleted` filter
-     *
-     * @param Connection $db
-     * @param int $id
-     *
-     * @return ?Schedule
-     */
-    private function loadSchedule(Connection $db, int $id): ?Schedule
-    {
-        return Schedule::on($db)->filter(Filter::equal('schedule.id', $id))->first();
-    }
-
-    /**
      * Fetch the non-deleted rotations of the given schedule, ordered by priority
      *
      * @param Connection $db
@@ -97,7 +85,6 @@ class ScheduleRepositoryTest extends TestCase
         return iterator_to_array(
             Rotation::on($db)
                 ->filter(Filter::equal('schedule_id', $scheduleId))
-                ->filter(Filter::equal('deleted', false))
                 ->orderBy('priority')
         );
     }
@@ -115,7 +102,6 @@ class ScheduleRepositoryTest extends TestCase
         $members = [];
         $query = RotationMember::on($db)
             ->filter(Filter::equal('rotation_id', $rotationId))
-            ->filter(Filter::equal('deleted', false))
             ->orderBy('position');
         foreach ($query as $member) {
             $members[] = $member->contact_id !== null
@@ -258,7 +244,6 @@ class ScheduleRepositoryTest extends TestCase
             $entries = iterator_to_array(
                 TimeperiodEntry::on($db)
                     ->filter(Filter::equal('timeperiod.owned_by_rotation_id', $rotation->id))
-                    ->filter(Filter::equal('deleted', false))
             );
             $this->assertNotEmpty($entries, 'A regenerated rotation should have timeperiod entries');
             foreach ($entries as $entry) {
@@ -325,9 +310,9 @@ class ScheduleRepositoryTest extends TestCase
         $this->assertNull($repository->find($id), 'A deleted schedule must not be found anymore');
 
         // But it's only soft-deleted: the row still exists, flagged deleted
-        $schedule = $this->loadSchedule($db, $id);
+        $schedule = $this->loadRawEntity($db, $id, Schedule::class);
         $this->assertNotNull($schedule, 'The schedule row should still exist');
-        $this->assertTrue($schedule->deleted, 'The schedule should be soft-deleted, not removed');
+        $this->assertSame('y', $schedule->deleted, 'The schedule should be soft-deleted, not removed');
     }
 
     #[DataProvider('sharedDatabases')]
@@ -408,7 +393,6 @@ class ScheduleRepositoryTest extends TestCase
             $entries = iterator_to_array(
                 TimeperiodEntry::on($db)
                     ->filter(Filter::equal('timeperiod.owned_by_rotation_id', $rotation->id))
-                    ->filter(Filter::equal('deleted', false))
             );
             $this->assertNotEmpty($entries, 'A copied rotation should have timeperiod entries');
             foreach ($entries as $entry) {
@@ -435,8 +419,9 @@ class ScheduleRepositoryTest extends TestCase
         $repository->delete($scheduleId);
 
         $this->assertNull($repository->find($scheduleId), 'The schedule should be deleted');
-        $this->assertTrue(
-            Rotation::on($db)->filter(Filter::equal('id', $rotationId))->first()->deleted,
+        $this->assertSame(
+            'y',
+            $this->loadRawEntity($db, $rotationId, Rotation::class)->deleted,
             'The schedule\'s rotation should be soft-deleted'
         );
         $this->assertNull(

--- a/test/php/library/Notifications/Repository/SourceRepositoryTest.php
+++ b/test/php/library/Notifications/Repository/SourceRepositoryTest.php
@@ -18,6 +18,7 @@ use ipl\Sql\Test\SharedDatabases\TransactionIsolation;
 use ipl\Stdlib\Filter;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use Tests\Icinga\Module\Notifications\Lib\DatabaseUtils;
 
 /**
  * Tests for {@see SourceRepository}.
@@ -31,6 +32,7 @@ use PHPUnit\Framework\TestCase;
 #[TransactionIsolation]
 class SourceRepositoryTest extends TestCase
 {
+    use DatabaseUtils;
     use DbTestBackends;
 
     protected static function initializeNotificationsDb(Connection $db): void
@@ -300,9 +302,9 @@ class SourceRepositoryTest extends TestCase
         (new SourceRepository($db))->delete($id);
 
         // It's only soft-deleted: the row still exists, flagged deleted with its username freed
-        $stored = $this->loadSource($db, $id);
+        $stored = $this->loadRawEntity($db, $id, Source::class);
         $this->assertNotNull($stored, 'The source row should still exist');
-        $this->assertTrue($stored->deleted, 'The source should be soft-deleted, not removed');
+        $this->assertSame('y', $stored->deleted, 'The source should be soft-deleted, not removed');
         $this->assertNull($stored->listener_username, 'The unique listener_username should be nulled on deletion');
     }
 
@@ -326,11 +328,15 @@ class SourceRepositoryTest extends TestCase
         (new SourceRepository($db))->delete($sourceId);
 
         // The linked rule is soft-deleted along with the source
-        $rule = Rule::on($db)->filter(Filter::equal('id', $ruleId))->first();
+        $rule = $this->loadRawEntity($db, $ruleId, Rule::class);
         $this->assertNotNull($rule, 'The rule row should still exist');
-        $this->assertTrue($rule->deleted, 'The linked rule must be soft-deleted with the source');
+        $this->assertSame('y', $rule->deleted, 'The linked rule must be soft-deleted with the source');
 
-        $this->assertTrue($this->loadSource($db, $sourceId)->deleted, 'The source itself must be soft-deleted');
+        $this->assertSame(
+            'y',
+            $this->loadRawEntity($db, $sourceId, Source::class)->deleted,
+            'The source itself must be soft-deleted'
+        );
     }
 
     #[DataProvider('sharedDatabases')]
@@ -368,7 +374,7 @@ class SourceRepositoryTest extends TestCase
 
         (new SourceRepository($db))->delete($id);
 
-        $source = $this->loadSource($db, $id);
+        $source = $this->loadRawEntity($db, $id, Source::class);
         $this->assertNotNull($source, 'The source row should still exist');
         $this->assertNull(
             $source->client_certificate_subject,


### PR DESCRIPTION
This introduces a proper way to hide deleted entities automatically. The previous work-around only affected a query's base table and thus didn't restrict joins the same way. Now, joins are covered as well, as are any sub-queries made by the ORM. And that is the only behavior related change: Queries made by ipl-sql are not automatically filtered anymore.

Related changes are introduced as well:
* Added `LEFT` join types to relations that were always meant to have it
* Introduced various guards when accessing relation properties as now they may be `NULL`

requires https://github.com/Icinga/ipl-orm/pull/165