### PR TITLE
Fix creation of orphan links by the `EntityManager`

### DIFF
--- a/library/Notifications/Common/Collection.php
+++ b/library/Notifications/Common/Collection.php
@@ -189,7 +189,11 @@ class Collection implements IteratorAggregate, Countable
             return array_values($this->attach);
         }
 
-        return array_values(array_merge($this->base ?? [], $this->attach));
+        $members = array_filter($this->base ?? [], function ($model) {
+            return $model->isModified();
+        });
+
+        return array_values(array_merge($members, $this->attach));
     }
 
     /**
@@ -200,6 +204,17 @@ class Collection implements IteratorAggregate, Countable
     public function getDetachments(): array
     {
         return array_values($this->detach);
+    }
+
+    /**
+     * Get the members that must be part of the relation after a save and were explicitly attached by
+     * {@see self::attach()} or {@see self::sync()}
+     *
+     * @return array
+     */
+    public function getAttachments(): array
+    {
+        return array_values($this->attach);
     }
 
     /**

--- a/library/Notifications/Common/EntityManager.php
+++ b/library/Notifications/Common/EntityManager.php
@@ -470,16 +470,15 @@ class EntityManager
             }
 
             $attach = [];
-            foreach ($collection->getMembersToSave() as $target) {
-                // Models are marked as new when they are hard deleted, so cache the value before saving
-                $isDeleted = $target->isMarkedForDeletion();
+            foreach ($collection->getAttachments() as $attachment) {
+                if (! $attachment->isMarkedForDeletion()) {
+                    $attach[] = $attachment;
+                }
+            }
 
+            foreach ($collection->getMembersToSave() as $target) {
                 if ($target->isMutable()) {
                     $this->saveGraph($target);
-                }
-
-                if (! $isDeleted) {
-                    $attach[] = $target;
                 }
             }
 

--- a/test/php/library/Notifications/Common/EntityManagerTest.php
+++ b/test/php/library/Notifications/Common/EntityManagerTest.php
@@ -725,6 +725,44 @@ class EntityManagerTest extends TestCase
         );
     }
 
+    public function testDetachingALoadedTargetDoesNotReviveALinkSoftDeletedOutOfBand()
+    {
+        $gadget = (new Gadget())->setNew();
+        $gadget->name = 'Spanner';
+        $sharp = (new Badge())->setNew();
+        $sharp->name = 'sharp';
+        $heavy = (new Badge())->setNew();
+        $heavy->name = 'heavy';
+        $gadget->badge = Collection::create([$sharp, $heavy]);
+        $this->em()->save($gadget);                         // two links inserted -> changed_at 1000, 2000
+
+        // Load the gadget and materialize its membership while both links are still live, so the loaded
+        // "heavy" instance lands in the collection's base, then detach it.
+        $loaded = Gadget::on($this->db)->first()->setNew(false);
+        foreach ($loaded->badge as $badge) {
+            if ((int) $badge->id === $heavy->id) {
+                $loaded->badge->detach($badge);
+            }
+        }
+
+        // Out of band (as a second repository would), soft-delete heavy's link before this save runs.
+        $this->db->prepexec(
+            "UPDATE gadget_badge SET deleted = 'y', changed_at = 7777 WHERE gadget_id = ? AND badge_id = ?",
+            [$gadget->id, $heavy->id]
+        );
+
+        $this->em()->save($loaded);
+
+        $this->assertSame(
+            [
+                ['badge_id' => $sharp->id, 'deleted' => 'n', 'changed_at' => 1000],
+                ['badge_id' => $heavy->id, 'deleted' => 'y', 'changed_at' => 7777],
+            ],
+            $this->rows('SELECT badge_id, deleted, changed_at FROM gadget_badge ORDER BY badge_id'),
+            'A detached, already soft-deleted link must stay deleted - not be revived by the merge-mode save'
+        );
+    }
+
     public function testSoftDeleteHasManyChildrenAreSoftDeletedOnSyncAndDetach()
     {
         // stamped_note is a HasMany child carrying a `deleted` column, so removing a note keeps its row and


### PR DESCRIPTION
While testing https://github.com/Icinga/icinga-notifications-web/pull/494 I noticed the following behavior:
Deleting the last member of an escalation deletes the escalation but leaves a `rule_escalation_recipient` link with `deleted` = `n`.
If the contact was not the last member of the escalation the link was properly soft deleted.

This is the snippet from `ContactRepository::delete()`
```
foreach ($model->rule_escalation as $escalation) {
    $model->rule_escalation->detach($escalation);

    $otherRecipient = $escalation->rule_escalation_recipient
        ->query()
        ->columns([new Expression('1')])
        ->filter(Filter::all(
            Filter::unequal('contact_id', $id),
            Filter::equal('deleted', 'n')
        ))
        ->first();
    if ($otherRecipient === null) {
        (new EscalationRepository($this->db))->delete($escalation->id); // The rule_escalation_recipient row is deleted here already
    }
}

(new EntityManager($this->db))->save($model);
```

Iterating the `rule_escalation` relation materializes its `$base`, so the detached escalation is included in `Collection::getMembersToSave()`.
`EntityManager::saveManyToMany()` therefore passes it to `reconcileJunction()` both in `$attach` and `$detach`.
When `reconcileSoftDeleteJunction()` queries the existing `rule_escalation_recipient` rows, the link is already soft deleted by the `EscalationRepository`, so it is not added to the `$toRemove` set.
But because the same escalation is also in the `$desired` set, the link is revived.


The problem is that the desired set of links is derived from `getMembersToSave()` instead of the explicit attachments.

So `getMembersToSave()` now only returns members that were attached or actually modified in place for collections in merge mode. Their changes are persisted in `saveManyToMany`.

`reconcileJunction()` is called with only the explicit attachments of a `Collection` exposed by `Collection::getAttachments()`, so it no longer writes to links that were never meant to be touched.