### PR TITLE
Let the channel configuration also rely on the `EntityManager`

### DIFF
--- a/application/controllers/ChannelController.php
+++ b/application/controllers/ChannelController.php
@@ -7,8 +7,10 @@ namespace Icinga\Module\Notifications\Controllers;
 
 use Icinga\Module\Notifications\Common\Database;
 use Icinga\Module\Notifications\Forms\ChannelForm;
+use Icinga\Module\Notifications\Repository\ChannelRepository;
 use Icinga\Web\Notification;
 use ipl\Html\Contract\Form;
+use ipl\Sql\Connection;
 use ipl\Web\Compat\CompatController;
 
 class ChannelController extends CompatController
@@ -20,29 +22,47 @@ class ChannelController extends CompatController
 
     public function indexAction(): void
     {
-        $channelId = $this->params->getRequired('id');
-        $form = (new ChannelForm(Database::get()))
-            ->loadChannel($channelId)
+        (new ChannelForm(Database::get()))
+            ->on(Form::ON_REQUEST, function ($_, ChannelForm $form) {
+                $channel = (new ChannelRepository(Database::get()))
+                    ->find((int) $this->params->getRequired('id'));
+                if ($channel === null) {
+                    $this->httpNotFound($this->translate('Channel not found'));
+                }
+
+                $form->setChannel($channel);
+
+                $this->addTitleTab(sprintf($this->translate('Channel: %s'), $channel->name));
+
+                $this->addContent($form);
+            })
             ->on(Form::ON_SUBMIT, function (ChannelForm $form) {
+                $channel = $form->getChannel();
+
                 if ($form->getPressedSubmitElement()->getName() === 'delete') {
-                    $form->removeChannel();
+                    Database::get()->transaction(
+                        fn(Connection $db) => (new ChannelRepository($db))->delete($channel->id)
+                    );
                     Notification::success(sprintf(
-                        t('Deleted channel "%s" successfully'),
-                        $form->getValue('name')
+                        $this->translate('Deleted channel "%s" successfully'),
+                        $channel->name
                     ));
                 } else {
-                    $form->editChannel();
+                    Database::get()->transaction(
+                        fn(Connection $db) => (new ChannelRepository($db))->update($channel)
+                    );
                     Notification::success(sprintf(
-                        t('Channel "%s" has successfully been saved'),
-                        $form->getValue('name')
+                        $this->translate('Channel "%s" has successfully been saved'),
+                        $channel->name
                     ));
                 }
 
                 $this->redirectNow('__CLOSE__');
+            })->on(Form::ON_SENT, function (ChannelForm $form) {
+                // TODO: I feel this should be part of CompatForm or CompatController (e.g. $this->sendForm())
+                if (! $this->getResponse()->isRedirect()) {
+                    $this->addPart($form, $this->content->getAttribute('id')->getValue());
+                }
             })->handleRequest($this->getServerRequest());
-
-        $this->addTitleTab(sprintf(t('Channel: %s'), $form->getChannelName()));
-
-        $this->addContent($form);
     }
 }

--- a/application/controllers/ChannelsController.php
+++ b/application/controllers/ChannelsController.php
@@ -10,12 +10,14 @@ use Icinga\Module\Notifications\Common\Links;
 use Icinga\Module\Notifications\Forms\ChannelForm;
 use Icinga\Module\Notifications\Model\AvailableChannelType;
 use Icinga\Module\Notifications\Model\Channel;
+use Icinga\Module\Notifications\Repository\ChannelRepository;
 use Icinga\Module\Notifications\View\ChannelRenderer;
 use Icinga\Module\Notifications\Web\Control\SearchBar\ObjectSuggestions;
 use Icinga\Module\Notifications\Widget\ItemList\ObjectList;
 use Icinga\Web\Notification;
 use Icinga\Web\Widget\Tabs;
 use ipl\Html\Contract\Form;
+use ipl\Sql\Connection;
 use ipl\Sql\Expression;
 use ipl\Web\Compat\CompatController;
 use ipl\Web\Compat\SearchControls;
@@ -105,21 +107,27 @@ class ChannelsController extends CompatController
 
     public function addAction(): void
     {
-        $this->addTitleTab(t('Add Channel'));
-        $form = (new ChannelForm(Database::get()))
+        (new ChannelForm(Database::get()))
+            ->on(Form::ON_REQUEST, function ($_, ChannelForm $form) {
+                $this->addTitleTab(t('Add Channel'));
+                $this->addContent($form);
+            })
             ->on(Form::ON_SUBMIT, function (ChannelForm $form) {
-                $form->addChannel();
+                $channel = $form->getChannel();
+                Database::get()->transaction(fn(Connection $db) => (new ChannelRepository($db))->create($channel));
                 Notification::success(
                     sprintf(
                         t('New channel %s has successfully been added'),
-                        $form->getValue('name')
+                        $channel->name
                     )
                 );
                 $this->switchToSingleColumnLayout();
-            })
-            ->handleRequest($this->getServerRequest());
-
-        $this->addContent($form);
+            })->on(Form::ON_SENT, function (ChannelForm $form) {
+                // TODO: I feel this should be part of CompatForm or CompatController (e.g. $this->sendForm())
+                if (! $this->getResponse()->isRedirect()) {
+                    $this->addPart($form, $this->content->getAttribute('id')->getValue());
+                }
+            })->handleRequest($this->getServerRequest());
     }
 
     public function completeAction(): void

--- a/application/forms/ChannelForm.php
+++ b/application/forms/ChannelForm.php
@@ -17,6 +17,7 @@ use ipl\Html\Contract\Form;
 use ipl\Html\Contract\FormSubmitElement;
 use ipl\Html\FormElement\BaseFormElement;
 use ipl\Html\FormElement\FieldsetElement;
+use ipl\Html\HtmlDocument;
 use ipl\Html\HtmlElement;
 use ipl\I18n\GettextTranslator;
 use ipl\I18n\StaticTranslator;
@@ -52,6 +53,8 @@ class ChannelForm extends CompatForm
     public function __construct(Connection $db)
     {
         $this->db = $db;
+
+        $this->applyDefaultElementDecorators();
     }
 
     /**
@@ -200,8 +203,7 @@ class ChannelForm extends CompatForm
 
             $this->registerElement($deleteButton);
             $this->getElement('submit')
-                ->getWrapper()
-                ->prepend($deleteButton);
+                ->prependWrapper((new HtmlDocument())->addHtml($deleteButton));
         }
     }
 

--- a/application/forms/ChannelForm.php
+++ b/application/forms/ChannelForm.php
@@ -5,15 +5,15 @@
 
 namespace Icinga\Module\Notifications\Forms;
 
-use DateTime;
 use Icinga\Exception\ConfigurationError;
-use Icinga\Exception\Http\HttpNotFoundException;
+use Icinga\Module\Notifications\Form\Data\Channel as ChannelData;
 use Icinga\Module\Notifications\Model\AvailableChannelType;
 use Icinga\Module\Notifications\Model\Channel;
 use Icinga\Module\Notifications\Model\Contact;
 use Icinga\Module\Notifications\Model\RuleEscalationRecipient;
 use Icinga\Web\Session;
 use ipl\Html\Attributes;
+use ipl\Html\Contract\Form;
 use ipl\Html\Contract\FormSubmitElement;
 use ipl\Html\FormElement\BaseFormElement;
 use ipl\Html\FormElement\FieldsetElement;
@@ -26,7 +26,6 @@ use ipl\Stdlib\Filter;
 use ipl\Validator\EmailAddressValidator;
 use ipl\Web\Common\CsrfCounterMeasure;
 use ipl\Web\Compat\CompatForm;
-use Ramsey\Uuid\Uuid;
 
 /**
  * @phpstan-type ChannelOptionConfig array{
@@ -47,15 +46,49 @@ class ChannelForm extends CompatForm
 
     private Connection $db;
 
-    /** @var ?int Channel ID */
-    private ?int $channelId = null;
-
     /** @var array<string, mixed> */
     private array $defaultChannelOptions = [];
 
     public function __construct(Connection $db)
     {
         $this->db = $db;
+    }
+
+    /**
+     * Set the channel to populate the form with
+     *
+     * @param Channel $channel
+     *
+     * @return $this
+     */
+    public function setChannel(Channel $channel): static
+    {
+        $this->populate($this->channelToFormData($channel));
+
+        return $this;
+    }
+
+    /**
+     * Get the channel as it's currently configured
+     *
+     * @return ChannelData
+     */
+    public function getChannel(): ChannelData
+    {
+        $id = $this->getValue('id') ?: null;
+        if ($id !== null) {
+            $id = (int) $id;
+        }
+
+        /** @var array<string, mixed> $config */
+        $config = $this->hasElement('config') ? $this->getElement('config')->getValue() : [];
+
+        return new ChannelData(
+            $id,
+            $this->getValue('name'),
+            $this->getValue('type'),
+            $this->filterConfig($config)
+        );
     }
 
     /**
@@ -73,6 +106,12 @@ class ChannelForm extends CompatForm
 
         $this->addAttributes(['class' => 'channel-form']);
         $this->addCsrfCounterMeasure(Session::getSession()->getId());
+
+        $this->addElement('hidden', 'id');
+        $channelId = $this->getPopulatedValue('id') ?: null;
+        if ($channelId !== null) {
+            $channelId = (int) $channelId;
+        }
 
         $this->addElement(
             'text',
@@ -122,22 +161,22 @@ class ChannelForm extends CompatForm
             'submit',
             'submit',
             [
-                'label' => $this->channelId === null ?
+                'label' => $channelId === null ?
                     $this->translate('Add Channel') :
                     $this->translate('Save Changes')
             ]
         );
 
-        if ($this->channelId !== null) {
+        if ($channelId !== null) {
             $isInUse = Contact::on($this->db)
                 ->columns([new Expression('1')])
-                ->filter(Filter::equal('default_channel_id', $this->channelId))
+                ->filter(Filter::equal('default_channel_id', $channelId))
                 ->first();
 
             if ($isInUse === null) {
                 $isInUse = RuleEscalationRecipient::on($this->db)
                     ->columns([new Expression('1')])
-                    ->filter(Filter::equal('channel_id', $this->channelId))
+                    ->filter(Filter::equal('channel_id', $channelId))
                     ->first();
             }
 
@@ -188,86 +227,6 @@ class ChannelForm extends CompatForm
         }
 
         return parent::hasBeenSubmitted();
-    }
-
-    /**
-     * Load the channel with given id
-     *
-     * @param int $id
-     *
-     * @return $this
-     *
-     * @throws HttpNotFoundException
-     */
-    public function loadChannel(int $id): static
-    {
-        $this->channelId = $id;
-        $this->populate($this->fetchDbValues());
-
-        return $this;
-    }
-
-    /**
-     * Add the new channel
-     */
-    public function addChannel(): void
-    {
-        $channel = $this->getValues();
-        $channel['config'] = json_encode($this->filterConfig($channel['config']), JSON_FORCE_OBJECT);
-        $channel['changed_at'] = (int) (new DateTime())->format("Uv");
-        $channel['external_uuid'] = Uuid::uuid4()->toString();
-
-        $this->db->transaction(function (Connection $db) use ($channel): void {
-            $db->insert('channel', $channel);
-        });
-    }
-
-    /**
-     * Edit the channel
-     *
-     * @return void
-     */
-    public function editChannel(): void
-    {
-        $this->db->beginTransaction();
-
-        $channel = $this->getValues();
-        $storedValues = $this->fetchDbValues();
-
-        $channel['config'] = json_encode($this->filterConfig($channel['config']), JSON_FORCE_OBJECT);
-        $storedValues['config'] = json_encode($storedValues['config'], JSON_FORCE_OBJECT);
-
-        if (! empty(array_diff_assoc($channel, $storedValues))) {
-            $channel['changed_at'] = (int) (new DateTime())->format("Uv");
-
-            $this->db->update('channel', $channel, ['id = ?' => $this->channelId]);
-        }
-
-        $this->db->commitTransaction();
-    }
-
-    /**
-     * Remove the channel
-     */
-    public function removeChannel(): void
-    {
-        $this->db->transaction(function (Connection $db): void {
-            $db->update(
-                'channel',
-                ['changed_at' => (int) (new DateTime())->format("Uv"), 'deleted' => 'y'],
-                ['id = ?' => $this->channelId]
-            );
-        });
-    }
-
-    /**
-     * Get the channel name
-     *
-     * @return string
-     */
-    public function getChannelName(): string
-    {
-        return $this->getValue('name');
     }
 
     /**
@@ -442,27 +401,19 @@ class ChannelForm extends CompatForm
     }
 
     /**
-     * Fetch the values from the database
+     * Transform the given channel into form data
      *
-     * @return array
+     * @param Channel $channel
      *
-     * @throws HttpNotFoundException
+     * @return array<string, mixed>
      */
-    private function fetchDbValues(): array
+    private function channelToFormData(Channel $channel): array
     {
-        /** @var Channel $channel */
-        $channel = Channel::on($this->db)
-            ->filter(Filter::equal('id', $this->channelId))
-            ->first();
-
-        if ($channel === null) {
-            throw new HttpNotFoundException($this->translate('Channel not found'));
-        }
-
         return [
+            'id'        => $channel->id,
             'name'      => $channel->name,
             'type'      => $channel->type,
-            'config'    => json_decode($channel->config, true) ?? []
+            'config'    => json_decode($channel->config ?? '', true) ?? []
         ];
     }
 
@@ -480,5 +431,11 @@ class ChannelForm extends CompatForm
         }
 
         return $this;
+    }
+
+    protected function onError()
+    {
+        // TODO: I feel like this should be the case in ipl-html already
+        $this->emit(Form::ON_SENT, [$this]);
     }
 }

--- a/library/Notifications/Form/Data/Channel.php
+++ b/library/Notifications/Form/Data/Channel.php
@@ -1,0 +1,23 @@
+<?php
+
+// SPDX-FileCopyrightText: 2026 Icinga GmbH <https://icinga.com>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+namespace Icinga\Module\Notifications\Form\Data;
+
+readonly class Channel
+{
+    /**
+     * @param ?int $id The primary database key value, NULL for new channels
+     * @param string $name The channel name
+     * @param string $type The channel type
+     * @param array<string, mixed> $config The type specific configuration of the channel
+     */
+    public function __construct(
+        public ?int $id,
+        public string $name,
+        public string $type,
+        public array $config
+    ) {
+    }
+}

--- a/library/Notifications/Model/Channel.php
+++ b/library/Notifications/Model/Channel.php
@@ -16,6 +16,7 @@ use ipl\Web\Widget\Icon;
 
 /**
  * @property int $id
+ * @property string $external_uuid
  * @property string $name
  * @property string $type
  * @property ?string $config

--- a/library/Notifications/Repository/ChannelRepository.php
+++ b/library/Notifications/Repository/ChannelRepository.php
@@ -1,0 +1,125 @@
+<?php
+
+// SPDX-FileCopyrightText: 2026 Icinga GmbH <https://icinga.com>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+namespace Icinga\Module\Notifications\Repository;
+
+use Icinga\Module\Notifications\Common\EntityManager;
+use Icinga\Module\Notifications\Form\Data\Channel as ChannelData;
+use Icinga\Module\Notifications\Model\Channel;
+use Icinga\Util\Json;
+use InvalidArgumentException;
+use ipl\Sql\Connection;
+use ipl\Stdlib\Filter;
+use Ramsey\Uuid\Uuid;
+
+final class ChannelRepository
+{
+    /**
+     * Create a `ChannelRepository` instance
+     *
+     * @param Connection $db Database to operate on
+     */
+    public function __construct(
+        private Connection $db
+    ) {
+    }
+
+    /**
+     * Fetch the channel with the given ID
+     *
+     * @param int $id
+     *
+     * @return ?Channel
+     */
+    public function find(int $id): ?Channel
+    {
+        return Channel::on($this->db)
+            ->filter(Filter::equal('id', $id))
+            ->filter(Filter::equal('deleted', false))
+            ->first();
+    }
+
+    /**
+     * Store a new channel
+     *
+     * @param ChannelData $channel
+     *
+     * @return int The ID of the given channel
+     */
+    public function create(ChannelData $channel): int
+    {
+        $model = (new Channel())->setNew();
+        $model->external_uuid = Uuid::uuid4()->toString();
+
+        return $this->upsert($channel, $model);
+    }
+
+    /**
+     * Update the given channel
+     *
+     * @param ChannelData $channel
+     *
+     * @return void
+     *
+     * @throws InvalidArgumentException In case the given channel has no ID or does not exist
+     */
+    public function update(ChannelData $channel): void
+    {
+        if (! isset($channel->id)) {
+            throw new InvalidArgumentException('Cannot update a channel that does not have an ID');
+        }
+
+        $model = $this->find($channel->id)?->setNew(false);
+        if ($model === null) {
+            throw new InvalidArgumentException('Cannot update a channel that does not exist in the database');
+        }
+
+        $this->upsert($channel, $model);
+    }
+
+    /**
+     * Delete the channel with the given ID
+     *
+     * The caller is responsible to ensure that the channel is not referenced anymore,
+     * neither as a contact's default channel nor in an event rule's escalation.
+     *
+     * @param int $id
+     *
+     * @return void
+     *
+     * @throws InvalidArgumentException In case the given channel does not exist
+     */
+    public function delete(int $id): void
+    {
+        $model = $this->find($id)?->setNew(false);
+        if ($model === null) {
+            throw new InvalidArgumentException('Cannot delete a channel that does not exist in the database');
+        }
+
+        (new EntityManager($this->db))->save($model->delete());
+    }
+
+    /**
+     * Create or update the given channel
+     *
+     * This method centralizes the shared persistence logic required by both
+     * the {@see self::create()} and {@see self::update()} operations to avoid code duplication.
+     *
+     * @param ChannelData $channel
+     * @param Channel $model
+     *
+     * @return int The channel's ID
+     */
+    private function upsert(ChannelData $channel, Channel $model): int
+    {
+        $model->name = $channel->name;
+        $model->type = $channel->type;
+        $model->config = Json::encode($channel->config, JSON_FORCE_OBJECT);
+
+        (new EntityManager($this->db))->save($model);
+
+        return $model->id;
+    }
+}

--- a/phpstan-baseline-standard.neon
+++ b/phpstan-baseline-standard.neon
@@ -25,12 +25,6 @@ parameters:
 			path: application/forms/ChannelForm.php
 
 		-
-			message: '#^Cannot call method prepend\(\) on ipl\\Html\\Contract\\Wrappable\|null\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: application/forms/ChannelForm.php
-
-		-
 			message: '#^Argument of an invalid type array\|null supplied for foreach, only iterables are supported\.$#'
 			identifier: foreach.nonIterable
 			count: 1

--- a/phpstan-baseline-standard.neon
+++ b/phpstan-baseline-standard.neon
@@ -7,18 +7,6 @@ parameters:
 			path: application/controllers/ChannelController.php
 
 		-
-			message: '#^Parameter \#2 \.\.\.\$values of function sprintf expects bool\|float\|int\|string\|null, mixed given\.$#'
-			identifier: argument.type
-			count: 2
-			path: application/controllers/ChannelController.php
-
-		-
-			message: '#^Parameter \#2 \.\.\.\$values of function sprintf expects bool\|float\|int\|string\|null, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: application/controllers/ChannelsController.php
-
-		-
 			message: '#^Cannot call method getUsername\(\) on Icinga\\User\|null\.$#'
 			identifier: method.nonObject
 			count: 1

--- a/test/php/library/Notifications/Repository/ChannelRepositoryTest.php
+++ b/test/php/library/Notifications/Repository/ChannelRepositoryTest.php
@@ -1,0 +1,213 @@
+<?php
+
+// SPDX-FileCopyrightText: 2026 Icinga GmbH <https://icinga.com>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+namespace Tests\Icinga\Module\Notifications\Repository;
+
+use DateTime;
+use Icinga\Module\Notifications\Form\Data\Channel as ChannelData;
+use Icinga\Module\Notifications\Model\Channel;
+use Icinga\Module\Notifications\Repository\ChannelRepository;
+use Icinga\Module\Notifications\Test\DbTestBackends;
+use InvalidArgumentException;
+use ipl\Sql\Connection;
+use ipl\Sql\Test\SharedDatabases\TransactionIsolation;
+use ipl\Stdlib\Filter;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for {@see ChannelRepository}.
+ *
+ * These run against real databases — once for MySQL and once for PostgreSQL (see {@see DbTestBackends} /
+ * `#[DataProvider('sharedDatabases')]`). Each test runs inside its own transaction which is rolled back afterwards,
+ * so its writes don't leak into the next test. The channel types a channel references are seeded in
+ * {@see self::initializeNotificationsDb()}, as `channel.type` is a foreign key.
+ *
+ * What these tests do not cover:
+ * - The dereferencing of a deleted channel, as a channel can only be deleted once it isn't referenced anymore
+ */
+#[TransactionIsolation]
+class ChannelRepositoryTest extends TestCase
+{
+    use DbTestBackends;
+
+    protected static function initializeNotificationsDb(Connection $db): void
+    {
+        // channel.type references available_channel_type.type
+        $db->insert('available_channel_type', [
+            'type' => 'email', 'name' => 'Email', 'version' => '1', 'author' => 'Test', 'config_attrs' => ''
+        ]);
+        $db->insert('available_channel_type', [
+            'type' => 'rocketchat', 'name' => 'Rocket.Chat', 'version' => '1', 'author' => 'Test',
+            'config_attrs' => ''
+        ]);
+    }
+
+    /**
+     * Insert a channel row directly (bypassing the repository) and return its id
+     *
+     * @param Connection $db
+     * @param string $uuid The channel's external uuid, which is unique
+     * @param array<string, mixed> $overrides
+     *
+     * @return int
+     */
+    private function insertChannel(Connection $db, string $uuid, array $overrides = []): int
+    {
+        $db->insert('channel', array_merge([
+            'external_uuid'  => $uuid,
+            'name'           => 'Mail',
+            'type'           => 'email',
+            'changed_at'     => (int) (new DateTime())->format('Uv')
+        ], $overrides));
+
+        return (int) $db->lastInsertId();
+    }
+
+    /**
+     * Load a channel row directly, bypassing the repository's `deleted` filter
+     *
+     * @param Connection $db
+     * @param int $id
+     *
+     * @return ?Channel
+     */
+    private function loadChannel(Connection $db, int $id): ?Channel
+    {
+        return Channel::on($db)->filter(Filter::equal('channel.id', $id))->first();
+    }
+
+    #[DataProvider('sharedDatabases')]
+    public function testFindReturnsTheChannel(Connection $db): void
+    {
+        $id = $this->insertChannel($db, '00000000-0000-0000-0000-000000000001', [
+            'name' => 'Support', 'config' => '{"sender_mail":"noreply@example.com"}'
+        ]);
+
+        $channel = (new ChannelRepository($db))->find($id);
+
+        $this->assertNotNull($channel, 'find() did not return the channel');
+        $this->assertEquals($id, $channel->id);
+        $this->assertSame('Support', $channel->name);
+        $this->assertSame('email', $channel->type);
+        $this->assertSame('{"sender_mail":"noreply@example.com"}', $channel->config);
+        $this->assertFalse($channel->deleted, 'The deleted flag should be cast to a bool');
+    }
+
+    #[DataProvider('sharedDatabases')]
+    public function testFindReturnsNullIfTheChannelDoesNotExist(Connection $db): void
+    {
+        $this->assertNull((new ChannelRepository($db))->find(404));
+    }
+
+    #[DataProvider('sharedDatabases')]
+    public function testFindReturnsNullIfTheChannelIsDeleted(Connection $db): void
+    {
+        $id = $this->insertChannel($db, '00000000-0000-0000-0000-000000000002', ['deleted' => 'y']);
+
+        $this->assertNull((new ChannelRepository($db))->find($id), 'find() returned a deleted channel');
+    }
+
+    #[DataProvider('sharedDatabases')]
+    public function testCreateStoresTheChannel(Connection $db): void
+    {
+        $channelId = (new ChannelRepository($db))->create(new ChannelData(
+            null,
+            'Support',
+            'email',
+            ['sender_mail' => 'noreply@example.com']
+        ));
+
+        $stored = $this->loadChannel($db, $channelId);
+        $this->assertNotNull($stored, 'The created channel was not found');
+        $this->assertSame('Support', $stored->name);
+        $this->assertSame('email', $stored->type);
+        $this->assertSame('{"sender_mail":"noreply@example.com"}', $stored->config);
+        $this->assertFalse($stored->deleted);
+        $this->assertNotEmpty($stored->external_uuid, 'The channel should have been assigned an external uuid');
+    }
+
+    #[DataProvider('sharedDatabases')]
+    public function testCreateStoresAnEmptyConfigAsObject(Connection $db): void
+    {
+        $channelId = (new ChannelRepository($db))->create(new ChannelData(null, 'Chat', 'rocketchat', []));
+
+        $this->assertSame('{}', $this->loadChannel($db, $channelId)->config);
+    }
+
+    #[DataProvider('sharedDatabases')]
+    public function testUpdateChangesTheChannel(Connection $db): void
+    {
+        $id = $this->insertChannel($db, '00000000-0000-0000-0000-000000000003', [
+            'name' => 'Old Name', 'config' => '{}'
+        ]);
+
+        (new ChannelRepository($db))->update(new ChannelData($id, 'Renamed', 'rocketchat', ['url' => 'localhost']));
+
+        $stored = $this->loadChannel($db, $id);
+        $this->assertSame('Renamed', $stored->name);
+        $this->assertSame('rocketchat', $stored->type);
+        $this->assertSame('{"url":"localhost"}', $stored->config);
+    }
+
+    #[DataProvider('sharedDatabases')]
+    public function testUpdateThrowsWhenTheChannelHasNoId(Connection $db): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        (new ChannelRepository($db))->update(new ChannelData(null, 'Support', 'email', []));
+    }
+
+    #[DataProvider('sharedDatabases')]
+    public function testUpdateThrowsWhenTheChannelDoesNotExist(Connection $db): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        (new ChannelRepository($db))->update(new ChannelData(999, 'Support', 'email', []));
+    }
+
+    #[DataProvider('sharedDatabases')]
+    public function testUpdateDoesNotTouchTheChannelIfNothingChanged(Connection $db): void
+    {
+        $id = $this->insertChannel($db, '00000000-0000-0000-0000-000000000004', [
+            'name' => 'Support', 'config' => '{"sender_mail":"noreply@example.com"}'
+        ]);
+        $changedAt = $this->loadChannel($db, $id)->changed_at;
+
+        (new ChannelRepository($db))->update(new ChannelData(
+            $id,
+            'Support',
+            'email',
+            ['sender_mail' => 'noreply@example.com']
+        ));
+
+        $this->assertEquals(
+            $changedAt,
+            $this->loadChannel($db, $id)->changed_at,
+            'changed_at should not have been bumped as the channel did not change'
+        );
+    }
+
+    #[DataProvider('sharedDatabases')]
+    public function testDeleteSoftDeletesTheChannel(Connection $db): void
+    {
+        $id = $this->insertChannel($db, '00000000-0000-0000-0000-000000000005');
+
+        (new ChannelRepository($db))->delete($id);
+
+        // It's only soft-deleted: the row still exists, flagged deleted
+        $stored = $this->loadChannel($db, $id);
+        $this->assertNotNull($stored, 'The channel row should still exist');
+        $this->assertTrue($stored->deleted, 'The channel should be soft-deleted, not removed');
+    }
+
+    #[DataProvider('sharedDatabases')]
+    public function testDeleteThrowsWhenTheChannelDoesNotExist(Connection $db): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        (new ChannelRepository($db))->delete(999);
+    }
+}


### PR DESCRIPTION
resolves #525

## Overview

Channels were the last configuration object that still assembled their own `INSERT`/`UPDATE` statements inside the form. They now use the same persistence layer as everything else: a DTO the form produces, and a repository that maps it onto the model and hands it to the `EntityManager`.

- **`Form\Data\Channel`** — plain readonly DTO (`id`, `name`, `type`, `config`).
- **`ChannelRepository`** — `find()`/`create()`/`update()`/`delete()`, with a private `upsert()` shared by create and update. It owns what the form did before: generating the `external_uuid`, encoding the config (`Json::encode()` with `JSON_FORCE_OBJECT`) and soft-deleting. It does not open transactions itself, the controller does.
- **`ChannelForm`** — `loadChannel()`, `addChannel()`, `editChannel()`, `removeChannel()` and `getChannelName()` are gone in favor of `setChannel()`/`getChannel()`. The channel id is now a hidden element, as in `SourceForm` and `ContactForm`. The only query left in the form is the one that determines whether the channel is still referenced and the delete button hence has to be disabled. The form also applies the default element decorators now, like the other forms already do, which is why the delete button is prepended by means of `prependWrapper()`.
- **`ChannelController`/`ChannelsController`** — load and persist by means of the repository, within a transaction they own. Both actions now follow the structure of the other configuration controllers: the form is populated in `ON_REQUEST`, i.e. only upon its first request, and re-rendered as a part in `ON_SENT` otherwise. `ChannelForm::onError()` emits `ON_SENT` as well, so that a failed validation still updates the form.

Note that no longer bumping `changed_at` if nothing changed, which the form did by diffing against the stored values, is now the `EntityManager`'s doing, as it only writes modified properties.

`Common\Database` still listens on assembled `INSERT`/`UPDATE` statements, as the V1 API and the incident widgets continue to use them.

## Testing

`ChannelRepositoryTest` covers find/create/update/delete against real MySQL and PostgreSQL databases, including the soft delete and that an unchanged channel isn't touched at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
