### PR TITLE
api/v1/contactgroups: Assert name uniqueness

### DIFF
--- a/library/Notifications/Api/V1/ContactGroups.php
+++ b/library/Notifications/Api/V1/ContactGroups.php
@@ -619,6 +619,10 @@ class ContactGroups extends ApiV1 implements RequestHandlerInterface, EndpointIn
      */
     private function addContactgroup(array $requestBody): void
     {
+        if (! empty($requestBody['name'])) {
+            $this->assertUniqueName($requestBody['name']);
+        }
+
         Database::get()->insert('contactgroup', [
             'name'          => $requestBody['name'],
             'external_uuid' => $requestBody['id'],
@@ -634,6 +638,10 @@ class ContactGroups extends ApiV1 implements RequestHandlerInterface, EndpointIn
 
     private function updateContactgroup(array $requestBody, int $contactgroupId): void
     {
+        if (! empty($requestBody['name'])) {
+            $this->assertUniqueName($requestBody['name'], $contactgroupId);
+        }
+
         $storedValues = $this->fetchDbValues($contactgroupId);
 
         $changedAt = (int) (new DateTime())->format("Uv");
@@ -772,7 +780,7 @@ class ContactGroups extends ApiV1 implements RequestHandlerInterface, EndpointIn
         $user = Database::get()->fetchOne($stmt);
 
         if ($user) {
-            throw new HttpException(422, sprintf('Username %s already exists', $name));
+            throw new HttpException(422, sprintf('Name %s already exists', $name));
         }
     }
 

--- a/test/php/application/controllers/ApiV1ContactGroupsTest.php
+++ b/test/php/application/controllers/ApiV1ContactGroupsTest.php
@@ -306,7 +306,7 @@ YAML;
             'v1/contact-groups',
             json: [
                 'id' => BaseApiV1TestCase::GROUP_UUID_3,
-                'name' => 'Test'
+                'name' => 'Test3'
             ]
         );
         $content = $response->getBody()->getContents();
@@ -332,7 +332,7 @@ YAML;
         $this->assertSame(200, $response->getStatusCode(), $content);
         $this->assertJsonStringEqualsJsonString($this->jsonEncodeResult([
             'id' => BaseApiV1TestCase::GROUP_UUID_3,
-            'name' => 'Test',
+            'name' => 'Test3',
             'users' => []
         ]), $content);
     }
@@ -451,7 +451,7 @@ YAML;
             'v1/contact-groups',
             json: [
                 'id' => BaseApiV1TestCase::GROUP_UUID_3,
-                'name' => 'Test',
+                'name' => 'Test3',
                 'users' => [BaseApiV1TestCase::CONTACT_UUID]
             ]
         );
@@ -478,7 +478,7 @@ YAML;
         $this->assertSame(200, $response->getStatusCode(), $content);
         $this->assertJsonStringEqualsJsonString($this->jsonEncodeResult([
             'id' => BaseApiV1TestCase::GROUP_UUID_3,
-            'name' => 'Test',
+            'name' => 'Test3',
             'users' => [BaseApiV1TestCase::CONTACT_UUID]
         ]), $content);
     }
@@ -535,7 +535,7 @@ YAML;
             'v1/contact-groups/',
             json: [
                 'id' => [BaseApiV1TestCase::GROUP_UUID_3],
-                'name' => 'Test',
+                'name' => 'Test3',
                 'users' => []
             ]
         );
@@ -596,7 +596,7 @@ YAML;
             'v1/contact-groups',
             json: [
                 'id' => BaseApiV1TestCase::GROUP_UUID_3,
-                'name' => 'Test',
+                'name' => 'Test3',
                 'users' => [BaseApiV1TestCase::CONTACT_UUID_3]
             ]
         );
@@ -862,7 +862,7 @@ YAML;
             'v1/contact-groups/' . BaseApiV1TestCase::GROUP_UUID_3,
             json: [
                 'id' => BaseApiV1TestCase::GROUP_UUID_3,
-                'name' => 'Test'
+                'name' => 'Test3'
             ]
         );
         $content = $response->getBody()->getContents();
@@ -888,7 +888,7 @@ YAML;
         $this->assertSame(200, $response->getStatusCode(), $content);
         $this->assertJsonStringEqualsJsonString($this->jsonEncodeResult([
             'id' => BaseApiV1TestCase::GROUP_UUID_3,
-            'name' => 'Test',
+            'name' => 'Test3',
             'users' => []
         ]), $content);
     }
@@ -959,7 +959,7 @@ YAML;
             'v1/contact-groups/' . BaseApiV1TestCase::GROUP_UUID_3,
             json: [
                 'id' => BaseApiV1TestCase::GROUP_UUID_3,
-                'name' => 'Test',
+                'name' => 'Test3',
                 'users' => [BaseApiV1TestCase::CONTACT_UUID]
             ]
         );
@@ -986,7 +986,7 @@ YAML;
         $this->assertSame(200, $response->getStatusCode(), $content);
         $this->assertJsonStringEqualsJsonString($this->jsonEncodeResult([
             'id' => BaseApiV1TestCase::GROUP_UUID_3,
-            'name' => 'Test',
+            'name' => 'Test3',
             'users' => [BaseApiV1TestCase::CONTACT_UUID]
         ]), $content);
     }
@@ -1043,7 +1043,7 @@ YAML;
             'v1/contact-groups/' . BaseApiV1TestCase::GROUP_UUID_3,
             json: [
                 'id' => [BaseApiV1TestCase::GROUP_UUID_3],
-                'name' => 'Test',
+                'name' => 'Test3',
                 'users' => []
             ]
         );


### PR DESCRIPTION
The API now responds with HTTP 422, as documented, in case a name is re-used.