### PR TITLE
Let integrations check for a contact and rework the recipient shape

### DIFF
--- a/library/Notifications/Integrations/Incident.php
+++ b/library/Notifications/Integrations/Incident.php
@@ -124,7 +124,7 @@ class Incident
      *
      * @return Generator<int, array{
      *     name: string,
-     *     full_name: string,
+     *     username: ?string,
      *     role: 'manager'|'subscriber',
      *     roleChangedAt: DateTime}>
      */
@@ -133,7 +133,7 @@ class Incident
         foreach ($this->resolveRecipients(['manager', 'subscriber']) as $recipient) {
             yield [
                 'name'          => $recipient['name'],
-                'full_name'     => $recipient['full_name'],
+                'username'      => $recipient['username'],
                 'role'          => $recipient['role'],
                 'roleChangedAt' => $recipient['roleChangedAt'],
             ];
@@ -146,7 +146,7 @@ class Incident
      * @return Generator<int, array{
      *     type: 'contact'|'contactgroup'|'schedule',
      *     name: string,
-     *     full_name: ?string,
+     *     username: ?string,
      *     roleChangedAt: DateTime}>
      */
     public function getRecipients(): Generator
@@ -155,7 +155,7 @@ class Incident
             yield [
                 'type'          => $recipient['type'],
                 'name'          => $recipient['name'],
-                'full_name'     => $recipient['full_name'],
+                'username'      => $recipient['username'],
                 'roleChangedAt' => $recipient['roleChangedAt']
             ];
         }
@@ -220,7 +220,7 @@ class Incident
      *     type: 'contact'|'contactgroup'|'schedule',
      *     id: int,
      *     name: string,
-     *     full_name: ?string,
+     *     username: ?string,
      *     role: 'manager'|'subscriber'|'recipient',
      *     roleChangedAt: DateTime
      * }>
@@ -245,8 +245,8 @@ class Incident
                 $recipients[] = [
                     'type'      => 'contact',
                     'id'        => $entry->contact_id,
-                    'name'      => $entry->contact->username,
-                    'full_name' => $entry->contact->full_name,
+                    'name'      => $entry->contact->full_name,
+                    'username'  => $entry->contact->username,
                     'role'      => $entry->role,
                     'roleChangedAt' => $entry->changed_at
                 ];
@@ -255,7 +255,7 @@ class Incident
                     'type'      => 'contactgroup',
                     'id'        => $entry->contactgroup_id,
                     'name'      => $entry->contactgroup->name,
-                    'full_name' => null,
+                    'username'  => null,
                     'role'      => $entry->role,
                     'roleChangedAt' => $entry->changed_at
                 ];
@@ -264,7 +264,7 @@ class Incident
                     'type'      => 'schedule',
                     'id'        => $entry->schedule_id,
                     'name'      => $entry->schedule->name,
-                    'full_name' => null,
+                    'username'  => null,
                     'role'      => $entry->role,
                     'roleChangedAt' => $entry->changed_at
                 ];

--- a/library/Notifications/Integrations/Incidents.php
+++ b/library/Notifications/Integrations/Incidents.php
@@ -9,6 +9,8 @@ use Countable;
 use Generator;
 use Icinga\Module\Notifications\Common\Database;
 use Icinga\Module\Notifications\Model\Incident as IncidentModel;
+use Icinga\Module\Notifications\Repository\ContactRepository;
+use Icinga\User;
 use ipl\Orm\Query;
 use ipl\Orm\ResultSet;
 use ipl\Sql\Connection;
@@ -56,6 +58,30 @@ class Incidents implements IteratorAggregate, Countable
     public static function find(array $tags): static
     {
         return new static($tags, Database::get());
+    }
+
+    /**
+     * Get whether the given user can manage incidents
+     *
+     * @param User $user
+     *
+     * @return bool
+     */
+    public static function canManage(User $user): bool
+    {
+        return (new ContactRepository(Database::get()))->findByUsername($user->getUsername()) !== null;
+    }
+
+    /**
+     * Get whether the given user can subscribe to incidents
+     *
+     * @param User $user
+     *
+     * @return bool
+     */
+    public static function canSubscribe(User $user): bool
+    {
+        return (new ContactRepository(Database::get()))->findByUsername($user->getUsername()) !== null;
     }
 
     /**

--- a/library/Notifications/Repository/ContactRepository.php
+++ b/library/Notifications/Repository/ContactRepository.php
@@ -48,6 +48,21 @@ final class ContactRepository
     }
 
     /**
+     * Fetch the contact with the given username
+     *
+     * @param string $username
+     *
+     * @return ?Contact
+     */
+    public function findByUsername(string $username): ?Contact
+    {
+        return Contact::on($this->db)
+            ->filter(Filter::equal('username', $username))
+            ->filter(Filter::equal('deleted', false))
+            ->first();
+    }
+
+    /**
      * Store a new contact
      *
      * The given contact is assigned an ID after successful creation.

--- a/test/php/library/Notifications/Integrations/IncidentTest.php
+++ b/test/php/library/Notifications/Integrations/IncidentTest.php
@@ -23,7 +23,7 @@ use Tests\Icinga\Module\Notifications\Lib\EntityManager\RecordingConnection;
  * yields the active subscribers (roles `manager` and `subscriber`), {@see Incident::getRecipients()} the
  * configured recipients (role `recipient`). Both are polymorphic — a recipient may be a contact, contact
  * group or schedule — and yield a uniform shape carrying a `type` discriminator, the display `name` and a
- * nullable `full_name`. Subscribers additionally carry their `role` and the `roleChangedAt` time their
+ * nullable `username`. Subscribers additionally carry their `role` and the `roleChangedAt` time their
  * current role was last changed; deleted contact groups and schedules are omitted from both.
  */
 class IncidentTest extends TestCase
@@ -69,7 +69,7 @@ class IncidentTest extends TestCase
         $incident->addManager('uname');
 
         $this->assertSame(
-            [['name' => 'uname', 'full_name' => 'Uname Example', 'role' => 'manager']],
+            [['name' => 'Uname Example', 'username' => 'uname', 'role' => 'manager']],
             $this->withoutRoleChangedAt($incident->getSubscribers())
         );
         $this->assertSame(
@@ -98,7 +98,7 @@ class IncidentTest extends TestCase
         $incident->removeManager('uname');
 
         $this->assertSame(
-            [['name' => 'uname', 'full_name' => 'Uname Example', 'role' => 'subscriber']],
+            [['name' => 'Uname Example', 'username' => 'uname', 'role' => 'subscriber']],
             $this->withoutRoleChangedAt($incident->getSubscribers())
         );
         $this->assertSame(
@@ -117,7 +117,7 @@ class IncidentTest extends TestCase
         $incident->addSubscriber('uname');
 
         $this->assertSame(
-            [['name' => 'uname', 'full_name' => 'Uname Example', 'role' => 'subscriber']],
+            [['name' => 'Uname Example', 'username' => 'uname', 'role' => 'subscriber']],
             $this->withoutRoleChangedAt($incident->getSubscribers())
         );
         $this->assertSame(
@@ -151,7 +151,7 @@ class IncidentTest extends TestCase
         $this->seedIncidentContact($id, $this->seedContact('bob'), 'recipient');
 
         $this->assertSame(
-            [['name' => 'alice', 'full_name' => 'Alice Example', 'role' => 'manager']],
+            [['name' => 'Alice Example', 'username' => 'alice', 'role' => 'manager']],
             $this->withoutRoleChangedAt($this->incident($id)->getSubscribers())
         );
     }
@@ -164,7 +164,7 @@ class IncidentTest extends TestCase
         $this->seedIncidentContact($id, null, 'subscriber');
 
         $this->assertSame(
-            [['name' => 'alice', 'full_name' => 'Alice Example', 'role' => 'manager']],
+            [['name' => 'Alice Example', 'username' => 'alice', 'role' => 'manager']],
             $this->withoutRoleChangedAt($this->incident($id)->getSubscribers())
         );
     }
@@ -188,7 +188,7 @@ class IncidentTest extends TestCase
         );
 
         $this->assertSame(
-            [['name' => 'alice', 'full_name' => 'Alice Example', 'role' => 'subscriber']],
+            [['name' => 'Alice Example', 'username' => 'alice', 'role' => 'subscriber']],
             $this->withoutRoleChangedAt($this->incident($id)->getSubscribers())
         );
     }
@@ -207,7 +207,7 @@ class IncidentTest extends TestCase
 
         unset($subscribers[0]['roleChangedAt']);
         $this->assertSame(
-            ['name' => 'alice', 'full_name' => 'Alice Example', 'role' => 'manager'],
+            ['name' => 'Alice Example', 'username' => 'alice', 'role' => 'manager'],
             $subscribers[0],
             'Apart from roleChangedAt the entry carries the uniform recipient shape'
         );
@@ -222,9 +222,9 @@ class IncidentTest extends TestCase
 
         $this->assertSame(
             [
-                ['type' => 'contact', 'name' => 'alice', 'full_name' => 'Alice Example'],
-                ['type' => 'contactgroup', 'name' => 'windows-admins', 'full_name' => null],
-                ['type' => 'schedule', 'name' => 'On-Call', 'full_name' => null],
+                ['type' => 'contact', 'name' => 'Alice Example', 'username' => 'alice'],
+                ['type' => 'contactgroup', 'name' => 'windows-admins', 'username' => null],
+                ['type' => 'schedule', 'name' => 'On-Call', 'username' => null],
             ],
             $this->withoutRoleChangedAt($this->sortedByTypeAndName($this->incident($id)->getRecipients()))
         );
@@ -238,7 +238,7 @@ class IncidentTest extends TestCase
         $this->seedIncidentContact($id, $this->seedContact('carol'), 'recipient');
 
         $this->assertSame(
-            [['type' => 'contact', 'name' => 'carol', 'full_name' => 'Carol Example']],
+            [['type' => 'contact', 'name' => 'Carol Example', 'username' => 'carol']],
             $this->withoutRoleChangedAt($this->incident($id)->getRecipients())
         );
     }
@@ -262,7 +262,7 @@ class IncidentTest extends TestCase
         );
 
         $this->assertSame(
-            [['type' => 'contact', 'name' => 'alice', 'full_name' => 'Alice Example']],
+            [['type' => 'contact', 'name' => 'Alice Example', 'username' => 'alice']],
             $this->withoutRoleChangedAt($this->incident($id)->getRecipients())
         );
     }
@@ -473,7 +473,7 @@ class IncidentTest extends TestCase
      * Insert a contact with the given username and return its generated id.
      *
      * The full name defaults to a distinct value derived from the username (e.g. "Alice Example" for
-     * "alice"), so the readers' username/full_name pairing can be asserted unambiguously.
+     * "alice"), so the readers' name/username pairing can be asserted unambiguously.
      */
     private function seedContact(string $username, bool $deleted = false): int
     {

--- a/test/php/library/Notifications/Repository/ContactRepositoryTest.php
+++ b/test/php/library/Notifications/Repository/ContactRepositoryTest.php
@@ -105,6 +105,29 @@ class ContactRepositoryTest extends TestCase
     }
 
     #[DataProvider('sharedDatabases')]
+    public function testFindByUsernameFindsTheContactOfTheGivenUser(Connection $db): void
+    {
+        $repository = new ContactRepository($db);
+        $id = $repository->create(new ContactData(null, 'John Doe', 'finder', self::$channelId, []));
+
+        $contact = $repository->findByUsername('finder');
+        $this->assertNotNull($contact, 'The contact of the given user was not found');
+        $this->assertEquals($id, $contact->id);
+
+        $this->assertNull($repository->findByUsername('nobody'), 'A user without a contact must not match one');
+    }
+
+    #[DataProvider('sharedDatabases')]
+    public function testFindByUsernameIgnoresDeletedContacts(Connection $db): void
+    {
+        $repository = new ContactRepository($db);
+        $id = $repository->create(new ContactData(null, 'John Doe', 'doomed', self::$channelId, []));
+        $db->update('contact', ['deleted' => 'y'], ['id = ?' => $id]);
+
+        $this->assertNull($repository->findByUsername('doomed'), 'A deleted contact must not be found anymore');
+    }
+
+    #[DataProvider('sharedDatabases')]
     public function testCreateStoresTheContactWithAddresses(Connection $db): void
     {
         $repository = new ContactRepository($db);


### PR DESCRIPTION
resolve #529 
resolve #531 

Add `Incidents::canSubscribe()` and `Incidents::canManage()` so integrations can check if a subscribe/manage action is possible before attempting it.
To allow this `ContactRepository::findByUsername()` is introduced.

The  arrays yielded by `Incident::getSubscribers()` and `Incident::getRecipients()` are adjusted as suggested in #531 