### PR TITLE
Update `@property` annotations in models to support generics

### DIFF
--- a/library/Notifications/Common/Collection.php
+++ b/library/Notifications/Common/Collection.php
@@ -7,9 +7,11 @@ namespace Icinga\Module\Notifications\Common;
 
 use ArrayIterator;
 use Countable;
+use InvalidArgumentException;
 use ipl\Orm\Query;
 use IteratorAggregate;
 use LogicException;
+use RuntimeException;
 use Traversable;
 
 /**
@@ -28,6 +30,7 @@ use Traversable;
  * been modified.
  *
  * @template TModel of Model
+ * @implements IteratorAggregate<int, TModel>
  */
 class Collection implements IteratorAggregate, Countable
 {
@@ -56,16 +59,30 @@ class Collection implements IteratorAggregate, Countable
     /** @var bool Whether {@see self::sync()} requested a replace (remove whatever is not in {@see self::$attach}) */
     private bool $replace = false;
 
+    /** @param class-string<TModel> $memberType */
+    public function __construct(
+        private string $memberType
+    ) {
+        if (! is_a($this->memberType, Model::class, true)) {
+            throw new LogicException(
+                'Collection member type must be a subclass of ' . Model::class
+            );
+        }
+    }
+
     /**
      * Create a collection whose members are merged with existing ones on the next save
      *
-     * @param Traversable<int, TModel> $values
+     * @template TValue of Model
      *
-     * @return static<TModel>
+     * @param class-string<TValue> $memberType
+     * @param iterable<TValue> $values
+     *
+     * @return static<TValue>
      */
-    public static function create(iterable $values): static
+    public static function create(string $memberType, iterable $values): static
     {
-        $collection = new static();
+        $collection = new static($memberType);
         foreach ($values as $model) {
             $collection->attach($model);
         }
@@ -76,16 +93,30 @@ class Collection implements IteratorAggregate, Countable
     /**
      * Create a collection from members who are treated as already existing db rows
      *
-     * @param Query<TModel> $source
+     * @template TRow of Model
      *
-     * @return static<TModel>
+     * @param Query<TRow> $source
+     *
+     * @return static<TRow>
      */
     public static function fromLoaded(Query $source): static
     {
-        $collection = new static();
-        $collection->source = $source;
+        $collection = new static($source->getModel()::class);
+        $collection->setSource($source);
 
         return $collection;
+    }
+
+    /**
+     * Set the source to materialize the base from
+     *
+     * @param Query<TModel> $source
+     *
+     * @return void
+     */
+    private function setSource(Query $source): void
+    {
+        $this->source = $source;
     }
 
     /**
@@ -117,9 +148,12 @@ class Collection implements IteratorAggregate, Countable
      * @param TModel $model
      *
      * @return $this
+     * @throws InvalidArgumentException If the model is not of the correct type
      */
     public function attach(Model $model): static
     {
+        $this->assertMemberType($model);
+
         $id = $this->identify($model);
         unset($this->detach[$id]);
         if (! isset($this->base[$id])) {
@@ -139,9 +173,12 @@ class Collection implements IteratorAggregate, Countable
      * @param TModel $model
      *
      * @return $this
+     * @throws InvalidArgumentException If the model is not of the correct type
      */
     public function detach(Model $model): static
     {
+        $this->assertMemberType($model);
+
         $id = $this->identify($model);
         unset($this->attach[$id]);
         $this->detach[$id] = $model;
@@ -154,7 +191,7 @@ class Collection implements IteratorAggregate, Countable
      *
      * Anything currently stored that is not in $models is removed on save.
      *
-     * @param Traversable<int, TModel> $models
+     * @param iterable<TModel> $models
      *
      * @return $this
      */
@@ -318,6 +355,7 @@ class Collection implements IteratorAggregate, Countable
      * @param TModel $model
      *
      * @return string
+     * @throws RuntimeException In case the model's primary key is not a string or int
      */
     private function identify(Model $model): string
     {
@@ -325,11 +363,36 @@ class Collection implements IteratorAggregate, Countable
         foreach ((array) $model->getKeyName() as $column) {
             if (! $model->hasProperty($column) || $model->$column === null) {
                 return 'obj#' . spl_object_id($model);
+            } elseif (! is_string($model->$column) && ! is_int($model->$column)) {
+                throw new RuntimeException(sprintf(
+                    'Primary key column %s of model %s must be a string or int, got %s',
+                    $column,
+                    get_class($model),
+                    get_debug_type($model->$column)
+                ));
             }
 
-            $values[] = $model->$column;
+            $values[] = (string) $model->$column;
         }
 
         return 'pk#' . implode('|', $values);
+    }
+
+    /**
+     * Assert the given model is of the expected type
+     *
+     * @param Model $model
+     *
+     * @return void
+     */
+    private function assertMemberType(Model $model): void
+    {
+        if (! is_a($model, $this->memberType)) {
+            throw new InvalidArgumentException(sprintf(
+                'Collection of %s is incompatible with type %s',
+                $this->memberType,
+                get_class($model)
+            ));
+        }
     }
 }

--- a/library/Notifications/Common/Collection.php
+++ b/library/Notifications/Common/Collection.php
@@ -26,6 +26,8 @@ use Traversable;
  *
  * Members may also be edited in place and will be cascaded by {@see EntityManager::save()} if they have
  * been modified.
+ *
+ * @template TModel of Model
  */
 class Collection implements IteratorAggregate, Countable
 {
@@ -34,21 +36,21 @@ class Collection implements IteratorAggregate, Countable
      *
      * Drained into {@see self::$base} once on first read, so the query is not run eagerly.
      *
-     * @var ?Query
+     * @var ?Query<TModel>
      */
     private ?Query $source = null;
 
     /**
      * Stored members once {@see self::$source} has been read, cached for repeated reads
      *
-     * @var ?array<string, Model>
+     * @var ?array<string, TModel>
      */
     private ?array $base = null;
 
-    /** @var array<string, Model> Models whose links/rows must exist after the next {@see EntityManager::save()} */
+    /** @var array<string, TModel> Models whose links/rows must exist after the next {@see EntityManager::save()} */
     private array $attach = [];
 
-    /** @var array<string, Model> Models whose links/rows must be removed on the next {@see EntityManager::save()} */
+    /** @var array<string, TModel> Models whose links/rows must be removed on the next {@see EntityManager::save()} */
     private array $detach = [];
 
     /** @var bool Whether {@see self::sync()} requested a replace (remove whatever is not in {@see self::$attach}) */
@@ -57,9 +59,9 @@ class Collection implements IteratorAggregate, Countable
     /**
      * Create a collection whose members are merged with existing ones on the next save
      *
-     * @param iterable $values
+     * @param Traversable<int, TModel> $values
      *
-     * @return static
+     * @return static<TModel>
      */
     public static function create(iterable $values): static
     {
@@ -74,9 +76,9 @@ class Collection implements IteratorAggregate, Countable
     /**
      * Create a collection from members who are treated as already existing db rows
      *
-     * @param Query $source
+     * @param Query<TModel> $source
      *
-     * @return static
+     * @return static<TModel>
      */
     public static function fromLoaded(Query $source): static
     {
@@ -96,7 +98,7 @@ class Collection implements IteratorAggregate, Countable
      * Traverse the collection and modify models in place, or pass a modified {@see Model} to {@see self::attach()}
      * if changes should be persisted.
      *
-     * @return Query
+     * @return Query<TModel>
      *
      * @throws LogicException If the collection was not created from a query, or the query has already been read
      */
@@ -112,7 +114,7 @@ class Collection implements IteratorAggregate, Countable
     /**
      * Additively register the given model as a member of this relation
      *
-     * @param Model $model
+     * @param TModel $model
      *
      * @return $this
      */
@@ -134,7 +136,7 @@ class Collection implements IteratorAggregate, Countable
     /**
      * Register the given model to be removed from this relation
      *
-     * @param Model $model
+     * @param TModel $model
      *
      * @return $this
      */
@@ -152,7 +154,7 @@ class Collection implements IteratorAggregate, Countable
      *
      * Anything currently stored that is not in $models is removed on save.
      *
-     * @param iterable<Model> $models
+     * @param Traversable<int, TModel> $models
      *
      * @return $this
      */
@@ -181,7 +183,7 @@ class Collection implements IteratorAggregate, Countable
     /**
      * Get the members to persist on save: staged attachments plus in-place-modified loaded members
      *
-     * @return Model[]
+     * @return array<int, TModel>
      */
     public function getMembersToSave(): array
     {
@@ -199,7 +201,7 @@ class Collection implements IteratorAggregate, Countable
     /**
      * Get the models to delete/unlink on save
      *
-     * @return Model[]
+     * @return array<int, TModel>
      */
     public function getDetachments(): array
     {
@@ -210,7 +212,7 @@ class Collection implements IteratorAggregate, Countable
      * Get the members that must be part of the relation after a save and were explicitly attached by
      * {@see self::attach()} or {@see self::sync()}
      *
-     * @return array
+     * @return array<int, TModel>
      */
     public function getAttachments(): array
     {
@@ -250,7 +252,7 @@ class Collection implements IteratorAggregate, Countable
     }
 
     /**
-     * @return Traversable<Model>
+     * @return Traversable<int, TModel>
      */
     public function getIterator(): Traversable
     {
@@ -265,7 +267,7 @@ class Collection implements IteratorAggregate, Countable
     /**
      * The staged members: base merged with attachments, minus detachments
      *
-     * @return Model[]
+     * @return array<int, TModel>
      */
     private function all(): array
     {
@@ -294,7 +296,7 @@ class Collection implements IteratorAggregate, Countable
     /**
      * The stored members, read from the source query once and cached
      *
-     * @return array<string, Model>
+     * @return array<string, TModel>
      */
     private function materializeBase(): array
     {
@@ -313,7 +315,7 @@ class Collection implements IteratorAggregate, Countable
     /**
      * Return the primary key of the model, or an object hash if it is not set
      *
-     * @param Model $model
+     * @param TModel $model
      *
      * @return string
      */

--- a/library/Notifications/Common/Model.php
+++ b/library/Notifications/Common/Model.php
@@ -236,6 +236,7 @@ abstract class Model extends \ipl\Orm\Model
                 if ($value instanceof Query) {
                     // Queries are accepted since the only justifiable reason
                     // to expect them is when a closure is being resolved
+                    /** @var Query<Model> $value */
                     if (! $this->isAToOneRelation($value, $key)) {
                         $value = Collection::fromLoaded($value);
                     }
@@ -266,7 +267,7 @@ abstract class Model extends \ipl\Orm\Model
      * In the far future this should be easier to detect as the model
      * should not be responsible for collection transformation anymore.
      *
-     * @param Query $query
+     * @param Query<*> $query
      * @param string $relationName
      *
      * @return bool

--- a/library/Notifications/Model/AvailableChannelType.php
+++ b/library/Notifications/Model/AvailableChannelType.php
@@ -5,6 +5,7 @@
 
 namespace Icinga\Module\Notifications\Model;
 
+use Icinga\Module\Notifications\Common\Collection;
 use Icinga\Module\Notifications\Common\Model;
 use ipl\Orm\Query;
 use ipl\Orm\Relations;
@@ -16,7 +17,7 @@ use ipl\Orm\Relations;
  * @property string $author
  * @property string $config_attrs
  *
- * @property Query|Channel $channel
+ * @property Query<Channel>|Collection<Channel> $channel
  */
 class AvailableChannelType extends Model
 {

--- a/library/Notifications/Model/Channel.php
+++ b/library/Notifications/Model/Channel.php
@@ -6,6 +6,7 @@
 namespace Icinga\Module\Notifications\Model;
 
 use DateTime;
+use Icinga\Module\Notifications\Common\Collection;
 use Icinga\Module\Notifications\Common\Model;
 use ipl\Orm\Behavior\BoolCast;
 use ipl\Orm\Behavior\MillisecondTimestamp;
@@ -23,10 +24,10 @@ use ipl\Web\Widget\Icon;
  * @property DateTime $changed_at
  * @property bool $deleted
  *
- * @property Query|IncidentHistory $incident_history
- * @property Query|RuleEscalationRecipient $rule_escalation_recipient
- * @property Query|Contact $contact
- * @property Query|AvailableChannelType $available_channel_type
+ * @property Query<IncidentHistory>|Collection<IncidentHistory> $incident_history
+ * @property Query<RuleEscalationRecipient>|Collection<RuleEscalationRecipient> $rule_escalation_recipient
+ * @property Query<Contact>|Collection<Contact> $contact
+ * @property Query<AvailableChannelType>|AvailableChannelType $available_channel_type
  */
 class Channel extends Model
 {

--- a/library/Notifications/Model/Contact.php
+++ b/library/Notifications/Model/Contact.php
@@ -6,6 +6,7 @@
 namespace Icinga\Module\Notifications\Model;
 
 use DateTime;
+use Icinga\Module\Notifications\Common\Collection;
 use Icinga\Module\Notifications\Common\Model;
 use ipl\Orm\Behavior\BoolCast;
 use ipl\Orm\Behavior\MillisecondTimestamp;
@@ -22,17 +23,17 @@ use ipl\Orm\Relations;
  * @property bool $deleted
  * @property string $external_uuid
  *
- * @property Query|Channel $channel
- * @property Query|Incident $incident
- * @property Query|Rotation $rotation
- * @property Query|RuleEscalation $rule_escalation
- * @property Query|IncidentContact $incident_contact
- * @property Query|IncidentHistory $incident_history
- * @property Query|RotationMember $rotation_member
- * @property Query|ContactAddress $contact_address
- * @property Query|RuleEscalationRecipient $rule_escalation_recipient
- * @property Query|ContactgroupMember $contactgroup_member
- * @property Query|Contactgroup $contactgroup
+ * @property Query<Channel>|Channel $channel
+ * @property Query<Incident>|Collection<Incident> $incident
+ * @property Query<Rotation>|Collection<Rotation> $rotation
+ * @property Query<RuleEscalation>|Collection<RuleEscalation> $rule_escalation
+ * @property Query<IncidentContact>|Collection<IncidentContact> $incident_contact
+ * @property Query<IncidentHistory>|Collection<IncidentHistory> $incident_history
+ * @property Query<RotationMember>|Collection<RotationMember> $rotation_member
+ * @property Query<ContactAddress>|Collection<ContactAddress> $contact_address
+ * @property Query<RuleEscalationRecipient>|Collection<RuleEscalationRecipient> $rule_escalation_recipient
+ * @property Query<ContactgroupMember>|Collection<ContactgroupMember> $contactgroup_member
+ * @property Query<Contactgroup>|Collection<Contactgroup> $contactgroup
  */
 class Contact extends Model
 {

--- a/library/Notifications/Model/ContactAddress.php
+++ b/library/Notifications/Model/ContactAddress.php
@@ -21,7 +21,7 @@ use ipl\Orm\Relations;
  * @property DateTime $changed_at
  * @property bool $deleted
  *
- * @property Query|Contact $contact
+ * @property Query<Contact>|Contact $contact
  */
 class ContactAddress extends Model
 {

--- a/library/Notifications/Model/Contactgroup.php
+++ b/library/Notifications/Model/Contactgroup.php
@@ -6,6 +6,7 @@
 namespace Icinga\Module\Notifications\Model;
 
 use DateTime;
+use Icinga\Module\Notifications\Common\Collection;
 use Icinga\Module\Notifications\Common\Model;
 use ipl\Orm\Behavior\BoolCast;
 use ipl\Orm\Behavior\MillisecondTimestamp;
@@ -22,12 +23,12 @@ use ipl\Orm\Relations;
  * @property bool $deleted
  * @property string $external_uuid
  *
- * @property Query|Contact $contact
- * @property Query|Rotation $rotation
- * @property Query|RuleEscalation $rule_escalation
- * @property Query|ContactgroupMember $contactgroup_member
- * @property Query|RuleEscalationRecipient $rule_escalation_recipient
- * @property Query|IncidentHistory $incident_history
+ * @property Query<Contact>|Collection<Contact> $contact
+ * @property Query<Rotation>|Collection<Rotation> $rotation
+ * @property Query<RuleEscalation>|Collection<RuleEscalation> $rule_escalation
+ * @property Query<ContactgroupMember>|Collection<ContactgroupMember> $contactgroup_member
+ * @property Query<RuleEscalationRecipient>|Collection<RuleEscalationRecipient> $rule_escalation_recipient
+ * @property Query<IncidentHistory>|Collection<IncidentHistory> $incident_history
  */
 class Contactgroup extends Model
 {

--- a/library/Notifications/Model/ContactgroupMember.php
+++ b/library/Notifications/Model/ContactgroupMember.php
@@ -21,8 +21,8 @@ use ipl\Orm\Relations;
  * @param DateTime $changed_at
  * @param bool $deleted
  *
- * @property Query|Contactgroup $contactgroup
- * @property Query|Contact $contact
+ * @property Query<Contactgroup>|Contactgroup $contactgroup
+ * @property Query<Contact>|Contact $contact
  */
 class ContactgroupMember extends Model
 {

--- a/library/Notifications/Model/Incident.php
+++ b/library/Notifications/Model/Incident.php
@@ -6,6 +6,7 @@
 namespace Icinga\Module\Notifications\Model;
 
 use DateTime;
+use Icinga\Module\Notifications\Common\Collection;
 use Icinga\Module\Notifications\Common\Database;
 use Icinga\Module\Notifications\Common\Model;
 use Icinga\Module\Notifications\Common\Severity;
@@ -28,12 +29,12 @@ use ipl\Sql\Select;
  * @property Severity $severity
  * @property ?string $mute_reason
  *
- * @property Query|Objects $object
- * @property Query|Contact $contact
- * @property Query|IncidentContact $incident_contact
- * @property Query|IncidentHistory $incident_history
- * @property Query|Rule $rule
- * @property Query|RuleEscalation $rule_escalation
+ * @property Query<Objects>|Objects $object
+ * @property Query<Contact>|Collection<Contact> $contact
+ * @property Query<IncidentContact>|Collection<IncidentContact> $incident_contact
+ * @property Query<IncidentHistory>|Collection<IncidentHistory> $incident_history
+ * @property Query<Rule>|Collection<Rule> $rule
+ * @property Query<RuleEscalation>|Collection<RuleEscalation> $rule_escalation
  */
 class Incident extends Model
 {

--- a/library/Notifications/Model/IncidentContact.php
+++ b/library/Notifications/Model/IncidentContact.php
@@ -20,10 +20,10 @@ use ipl\Orm\Relations;
  * @property string $role
  * @property DateTime $changed_at
  *
- * @property Query|Incident $incident
- * @property Query|Contact $contact
- * @property Query|Contactgroup $contactgroup
- * @property Query|Schedule $schedule
+ * @property Query<Incident>|Incident $incident
+ * @property Query<Contact>|Contact $contact
+ * @property Query<Contactgroup>|Contactgroup $contactgroup
+ * @property Query<Schedule>|Schedule $schedule
  */
 class IncidentContact extends Model
 {

--- a/library/Notifications/Model/IncidentHistory.php
+++ b/library/Notifications/Model/IncidentHistory.php
@@ -38,13 +38,13 @@ use ipl\Sql\Select;
  * @property ?string $notification_state
  * @property ?DateTime $sent_at
  *
- * @property Query|Incident $incident
- * @property Query|Contact $contact
- * @property Query|Contactgroup $contactgroup
- * @property Query|Schedule $schedule
- * @property Query|Rule $rule
- * @property Query|RuleEscalation $rule_escalation
- * @property Query|Channel $channel
+ * @property Query<Incident>|Incident $incident
+ * @property Query<Contact>|Contact $contact
+ * @property Query<Contactgroup>|Contactgroup $contactgroup
+ * @property Query<Schedule>|Schedule $schedule
+ * @property Query<Rule>|Rule $rule
+ * @property Query<RuleEscalation>|RuleEscalation $rule_escalation
+ * @property Query<Channel>|Channel $channel
  */
 class IncidentHistory extends Model
 {

--- a/library/Notifications/Model/ObjectIdTag.php
+++ b/library/Notifications/Model/ObjectIdTag.php
@@ -9,6 +9,7 @@ use Icinga\Module\Notifications\Common\Model;
 use ipl\Orm\Behavior\Binary;
 use ipl\Orm\Behaviors;
 use ipl\Orm\Contract\RewriteFilterBehavior;
+use ipl\Orm\Query;
 use ipl\Orm\Relations;
 use ipl\Stdlib\Filter;
 use ipl\Stdlib\Filter\Condition;
@@ -19,6 +20,8 @@ use ipl\Stdlib\Filter\Condition;
  * @property string $object_id
  * @property string $tag
  * @property string $value
+ *
+ * @property Query<Objects>|Objects $object
  */
 class ObjectIdTag extends Model
 {

--- a/library/Notifications/Model/Objects.php
+++ b/library/Notifications/Model/Objects.php
@@ -5,6 +5,7 @@
 
 namespace Icinga\Module\Notifications\Model;
 
+use Icinga\Module\Notifications\Common\Collection;
 use Icinga\Module\Notifications\Common\Model;
 use Icinga\Module\Notifications\Hook\ObjectsRendererHook;
 use Icinga\Module\Notifications\Model\Behavior\IdTagAggregator;
@@ -22,9 +23,10 @@ use ipl\Orm\Relations;
  * @property string $name
  * @property ?string $url
  *
- * @property Query|Incident $incident
- * @property Query|Tag $tag
- * @property Query|Source $source
+ * @property Query<Incident>|Collection<Incident> $incident
+ * @property Query<ObjectIdTag>|Collection<ObjectIdTag> $object_id_tag
+ * @property Query<Tag>|Collection<Tag> $tag
+ * @property Query<Source>|Source $source
  * @property array<string, string> $id_tags
  */
 class Objects extends Model

--- a/library/Notifications/Model/Rotation.php
+++ b/library/Notifications/Model/Rotation.php
@@ -6,6 +6,7 @@
 namespace Icinga\Module\Notifications\Model;
 
 use DateTime;
+use Icinga\Module\Notifications\Common\Collection;
 use Icinga\Module\Notifications\Common\Model;
 use Icinga\Util\Json;
 use ipl\Orm\Behavior\BoolCast;
@@ -29,9 +30,11 @@ use ipl\Orm\Relations;
  * @property DateTime $changed_at
  * @property bool $deleted
  *
- * @property Query|Schedule $schedule
- * @property Query|RotationMember $member
- * @property Query|Timeperiod $timeperiod
+ * @property Query<Schedule>|Schedule $schedule
+ * @property Query<RotationMember>|Collection<RotationMember> $member
+ * @property Query<Timeperiod>|Timeperiod $timeperiod
+ * @property Query<Contact>|Collection<Contact> $contact
+ * @property Query<Contactgroup>|Collection<Contactgroup> $contactgroup
  */
 class Rotation extends Model
 {

--- a/library/Notifications/Model/RotationMember.php
+++ b/library/Notifications/Model/RotationMember.php
@@ -24,9 +24,9 @@ use ipl\Orm\Relations;
  * @property DateTime $changed_at
  * @property bool $deleted
  *
- * @property Query|Rotation $rotation
- * @property Query|Contact $contact
- * @property Query|Contactgroup $contactgroup
+ * @property Query<Rotation>|Rotation $rotation
+ * @property Query<Contact>|Contact $contact
+ * @property Query<Contactgroup>|Contactgroup $contactgroup
  */
 class RotationMember extends Model
 {

--- a/library/Notifications/Model/Rule.php
+++ b/library/Notifications/Model/Rule.php
@@ -6,6 +6,7 @@
 namespace Icinga\Module\Notifications\Model;
 
 use DateTime;
+use Icinga\Module\Notifications\Common\Collection;
 use Icinga\Module\Notifications\Common\Model;
 use ipl\Orm\Behavior\BoolCast;
 use ipl\Orm\Behavior\MillisecondTimestamp;
@@ -22,10 +23,10 @@ use ipl\Orm\Relations;
  * @property DateTime $changed_at
  * @property bool $deleted
  *
- * @property Query|Source $source
- * @property Query|RuleEscalation $rule_escalation
- * @property Query|Incident $incident
- * @property Query|IncidentHistory $incident_history
+ * @property Query<Source>|Source $source
+ * @property Query<RuleEscalation>|Collection<RuleEscalation> $rule_escalation
+ * @property Query<Incident>|Collection<Incident> $incident
+ * @property Query<IncidentHistory>|Collection<IncidentHistory> $incident_history
  */
 class Rule extends Model
 {

--- a/library/Notifications/Model/RuleEscalation.php
+++ b/library/Notifications/Model/RuleEscalation.php
@@ -6,6 +6,7 @@
 namespace Icinga\Module\Notifications\Model;
 
 use DateTime;
+use Icinga\Module\Notifications\Common\Collection;
 use Icinga\Module\Notifications\Common\Model;
 use ipl\Orm\Behavior\BoolCast;
 use ipl\Orm\Behavior\MillisecondTimestamp;
@@ -23,13 +24,13 @@ use ipl\Orm\Relations;
  * @property DateTime $changed_at
  * @property bool $deleted
  *
- * @property Query|Rule $rule
- * @property Query|Incident $incident
- * @property Query|Contact $contact
- * @property Query|Contactgroup $contactgroup
- * @property Query|Schedule $schedule
- * @property Query|RuleEscalationRecipient $rule_escalation_recipient
- * @property Query|IncidentHistory $incident_history
+ * @property Query<Rule>|Rule $rule
+ * @property Query<Incident>|Collection<Incident> $incident
+ * @property Query<Contact>|Collection<Contact> $contact
+ * @property Query<Contactgroup>|Collection<Contactgroup> $contactgroup
+ * @property Query<Schedule>|Collection<Schedule> $schedule
+ * @property Query<RuleEscalationRecipient>|Collection<RuleEscalationRecipient> $rule_escalation_recipient
+ * @property Query<IncidentHistory>|Collection<IncidentHistory> $incident_history
  */
 class RuleEscalation extends Model
 {

--- a/library/Notifications/Model/RuleEscalationRecipient.php
+++ b/library/Notifications/Model/RuleEscalationRecipient.php
@@ -23,11 +23,11 @@ use ipl\Orm\Relations;
  * @property DateTime $changed_at
  * @property bool $deleted
  *
- * @property Query|RuleEscalation $rule_escalation
- * @property Query|Contact $contact
- * @property Query|Schedule $schedule
- * @property Query|Contactgroup $contactgroup
- * @property Query|Channel $channel
+ * @property Query<RuleEscalation>|RuleEscalation $rule_escalation
+ * @property Query<Contact>|Contact $contact
+ * @property Query<Schedule>|Schedule $schedule
+ * @property Query<Contactgroup>|Contactgroup $contactgroup
+ * @property Query<Channel>|Channel $channel
  */
 class RuleEscalationRecipient extends Model
 {

--- a/library/Notifications/Model/Schedule.php
+++ b/library/Notifications/Model/Schedule.php
@@ -6,6 +6,7 @@
 namespace Icinga\Module\Notifications\Model;
 
 use DateTime;
+use Icinga\Module\Notifications\Common\Collection;
 use Icinga\Module\Notifications\Common\Model;
 use ipl\Orm\Behavior\BoolCast;
 use ipl\Orm\Behavior\MillisecondTimestamp;
@@ -20,10 +21,10 @@ use ipl\Orm\Relations;
  * @property DateTime $changed_at
  * @property bool $deleted
  *
- * @property Query|Rotation $rotation
- * @property Query|RuleEscalationRecipient $rule_escalation_recipient
- * @property Query|IncidentHistory $incident_history
- * @property Query|RuleEscalation $rule_escalation
+ * @property Query<Rotation>|Collection<Rotation> $rotation
+ * @property Query<RuleEscalationRecipient>|Collection<RuleEscalationRecipient> $rule_escalation_recipient
+ * @property Query<IncidentHistory>|Collection<IncidentHistory> $incident_history
+ * @property Query<RuleEscalation>|Collection<RuleEscalation> $rule_escalation
  */
 class Schedule extends Model
 {

--- a/library/Notifications/Model/Source.php
+++ b/library/Notifications/Model/Source.php
@@ -7,6 +7,7 @@ namespace Icinga\Module\Notifications\Model;
 
 use DateTime;
 use Icinga\Application\Logger;
+use Icinga\Module\Notifications\Common\Collection;
 use Icinga\Module\Notifications\Common\Model;
 use Icinga\Module\Notifications\Common\SourceHookLocator;
 use Icinga\Module\Notifications\Hook\V2\SourceHook;
@@ -34,8 +35,8 @@ use Throwable;
  * @property bool $deleted
  * @property bool $locked
  *
- * @property Query|Objects $object
- * @property Query|Rule $rule
+ * @property Query<Objects>|Collection<Objects> $object
+ * @property Query<Rule>|Collection<Rule> $rule
  */
 class Source extends Model
 {

--- a/library/Notifications/Model/Timeperiod.php
+++ b/library/Notifications/Model/Timeperiod.php
@@ -6,6 +6,7 @@
 namespace Icinga\Module\Notifications\Model;
 
 use DateTime;
+use Icinga\Module\Notifications\Common\Collection;
 use Icinga\Module\Notifications\Common\Model;
 use ipl\Orm\Behavior\BoolCast;
 use ipl\Orm\Behavior\MillisecondTimestamp;
@@ -21,8 +22,8 @@ use ipl\Orm\Relations;
  * @property DateTime $changed_at
  * @property bool $deleted
  *
- * @property Query|Rotation $rotation
- * @property Query|TimeperiodEntry $timeperiod_entry
+ * @property Query<Rotation>|Rotation $rotation
+ * @property Query<TimeperiodEntry>|Collection<TimeperiodEntry> $timeperiod_entry
  */
 class Timeperiod extends Model
 {

--- a/library/Notifications/Model/TimeperiodEntry.php
+++ b/library/Notifications/Model/TimeperiodEntry.php
@@ -27,8 +27,8 @@ use Recurr\Rule;
  * @property string $timezone
  * @property ?string $rrule
  *
- * @property Query|Timeperiod $timeperiod
- * @property Query|RotationMember $member
+ * @property Query<Timeperiod>|Timeperiod $timeperiod
+ * @property Query<RotationMember>|RotationMember $member
  */
 class TimeperiodEntry extends Model
 {

--- a/library/Notifications/Repository/ContactGroupRepository.php
+++ b/library/Notifications/Repository/ContactGroupRepository.php
@@ -59,7 +59,10 @@ final class ContactGroupRepository
         $model = (new Contactgroup())->setNew();
         $model->name = $group->name;
         $model->external_uuid = Uuid::uuid4()->toString();
-        $model->contact = Collection::create(array_map(fn($id) => new Contact(['id' => $id]), $group->members));
+        $model->contact = Collection::create(
+            Contact::class,
+            array_map(fn($id) => new Contact(['id' => $id]), $group->members)
+        );
 
         (new EntityManager($this->db))->save($model);
 

--- a/library/Notifications/Repository/ContactRepository.php
+++ b/library/Notifications/Repository/ContactRepository.php
@@ -87,7 +87,7 @@ final class ContactRepository
             ]))->setNew();
         }
 
-        $model->contact_address = Collection::create($addresses);
+        $model->contact_address = Collection::create(ContactAddress::class, $addresses);
 
         (new EntityManager($this->db))->save($model);
 

--- a/library/Notifications/Repository/EscalationRepository.php
+++ b/library/Notifications/Repository/EscalationRepository.php
@@ -71,7 +71,7 @@ final class EscalationRepository
             $recipients[] = $recipientModel;
         }
 
-        $model->rule_escalation_recipient = Collection::create($recipients);
+        $model->rule_escalation_recipient = Collection::create(RuleEscalationRecipient::class, $recipients);
 
         (new EntityManager($this->db))->save($model);
 

--- a/library/Notifications/Repository/RotationRepository.php
+++ b/library/Notifications/Repository/RotationRepository.php
@@ -145,7 +145,7 @@ final class RotationRepository
         $model->first_handoff = $rotation->firstHandoff->format('Y-m-d');
         $model->actual_handoff = max($firstHandoff, new DateTime());
         $model->timeperiod = (new Timeperiod())->setNew();
-        $model->timeperiod->timeperiod_entry = new Collection();
+        $model->timeperiod->timeperiod_entry = Collection::create(TimeperiodEntry::class, []);
 
         $knownMembers = [];
         foreach ($rules as $position => [$rrule, $shiftDuration]) {
@@ -184,7 +184,7 @@ final class RotationRepository
             $model->timeperiod->timeperiod_entry->attach($entry->setNew());
         }
 
-        $model->member = Collection::create($knownMembers);
+        $model->member = Collection::create(RotationMember::class, $knownMembers);
 
         (new EntityManager($this->db))->save($model);
     }

--- a/phpstan-baseline-standard.neon
+++ b/phpstan-baseline-standard.neon
@@ -187,24 +187,6 @@ parameters:
 			path: library/Notifications/Web/Control/SearchBar/ObjectSuggestions.php
 
 		-
-			message: '#^Cannot access property \$address on mixed\.$#'
-			identifier: property.nonObject
-			count: 2
-			path: library/Notifications/Web/Form/ContactForm.php
-
-		-
-			message: '#^Cannot access property \$id on mixed\.$#'
-			identifier: property.nonObject
-			count: 1
-			path: library/Notifications/Web/Form/ContactForm.php
-
-		-
-			message: '#^Cannot access property \$type on mixed\.$#'
-			identifier: property.nonObject
-			count: 2
-			path: library/Notifications/Web/Form/ContactForm.php
-
-		-
 			message: '#^Method Icinga\\Module\\Notifications\\Widget\\Calendar\:\:getModeStart\(\) should return DateTime but returns DateTime\|false\.$#'
 			identifier: return.type
 			count: 2

--- a/test/php/library/Notifications/Common/CollectionTest.php
+++ b/test/php/library/Notifications/Common/CollectionTest.php
@@ -1,0 +1,99 @@
+<?php
+
+// SPDX-FileCopyrightText: 2026 Icinga GmbH <https://icinga.com>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+namespace Tests\Icinga\Module\Notifications\Common;
+
+use Icinga\Module\Notifications\Common\Collection;
+use ipl\Orm\Query;
+use ipl\Sql\Connection;
+use PHPUnit\Framework\TestCase;
+use Tests\Icinga\Module\Notifications\Lib\EntityManager\Sticker;
+use Tests\Icinga\Module\Notifications\Lib\EntityManager\Tag;
+
+class CollectionTest extends TestCase
+{
+    public function testCollectionWithoutAModelSubclassThrows(): void
+    {
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('Collection member type must be a subclass of');
+
+        new Collection(\LogicException::class);
+    }
+
+    public function testCollectionAttachThrowsWithInvalidType(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        $collection = new Collection(Tag::class);
+        $collection->attach(new Sticker());
+    }
+
+    public function testCollectionDetachThrowsWithInvalidType(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        $collection = new Collection(Tag::class);
+        $collection->detach(new Sticker());
+    }
+
+    public function testCollectionAttachWithValidTypeWorks(): void
+    {
+        $collection = new Collection(Tag::class);
+        $collection->attach(new Tag());
+
+        $this->assertCount(1, $collection);
+    }
+
+    public function testCollectionDetachWithValidTypeWorks(): void
+    {
+        $tag = new Tag();
+        $collection = Collection::create(Tag::class, [$tag]);
+
+        $collection->detach($tag);
+
+        $this->assertCount(0, $collection);
+    }
+
+    public function testCollectionFromLoadedReturnsATypedCollection(): void
+    {
+        $selectStmt = $this->createMock(\PDOStatement::class);
+        $selectStmt->method('getIterator')->willReturn(new \ArrayIterator([[]]));
+
+        $dbMock = $this->createMock(Connection::class);
+        $dbMock->method('select')
+            ->willReturn($selectStmt);
+
+        $query = (new Query())
+            ->setDb($dbMock)
+            ->setModel(new Tag());
+
+        $collection = Collection::fromLoaded($query);
+
+        $collection->attach(new Tag());
+
+        $this->assertCount(2, $collection);
+    }
+
+    public function testCollectionThrowsInCaseOfUnsupportedKeyTypes(): void
+    {
+        $selectStmt = $this->createMock(\PDOStatement::class);
+        $selectStmt->method('getIterator')->willReturn(new \ArrayIterator([['id' => true]]));
+
+        $dbMock = $this->createMock(Connection::class);
+        $dbMock->method('select')
+            ->willReturn($selectStmt);
+
+        $query = (new Query())
+            ->setDb($dbMock)
+            ->setModel(new Tag());
+
+        $collection = Collection::fromLoaded($query);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('must be a string or int');
+
+        $collection->count(); // Materializes the query
+    }
+}

--- a/test/php/library/Notifications/Common/EntityManagerTest.php
+++ b/test/php/library/Notifications/Common/EntityManagerTest.php
@@ -352,7 +352,7 @@ class EntityManagerTest extends TestCase
 
         $charm = (new Charm())->setNew();
         $charm->label = 'rune';
-        $trinket->charm = Collection::create([$charm]);
+        $trinket->charm = Collection::create(Charm::class, [$charm]);
 
         $this->em()->save($trinket);
 
@@ -412,13 +412,13 @@ class EntityManagerTest extends TestCase
         $sharp = (new Tag())->setNew();
         $sharp->name = 'sharp';
 
-        $spanner->sticker = Collection::create([$shared]);
-        $spanner->tag = Collection::create([$sharp]);
-        $wrench->sticker = Collection::create([$shared]);
+        $spanner->sticker = Collection::create(Sticker::class, [$shared]);
+        $spanner->tag = Collection::create(Tag::class, [$sharp]);
+        $wrench->sticker = Collection::create(Sticker::class, [$shared]);
 
         $workshop = (new Workshop())->setNew();
         $workshop->name = 'Acme';
-        $workshop->gadget = Collection::create([$spanner, $wrench]);
+        $workshop->gadget = Collection::create(Gadget::class, [$spanner, $wrench]);
 
         $this->em()->save($workshop);
 
@@ -490,7 +490,7 @@ class EntityManagerTest extends TestCase
         $fragile->label = 'fragile';
         $heavy = (new Sticker())->setNew();
         $heavy->label = 'heavy';
-        $gadget->sticker = Collection::create([$fragile, $heavy]);
+        $gadget->sticker = Collection::create(Sticker::class, [$fragile, $heavy]);
         $this->em()->save($gadget);
 
         $loaded = Gadget::on($this->db)->first()->setNew(false);
@@ -548,7 +548,7 @@ class EntityManagerTest extends TestCase
         $gadget->name = 'Spanner';
         $fragile = (new Sticker())->setNew();
         $fragile->label = 'fragile';
-        $gadget->sticker = Collection::create([$fragile]);
+        $gadget->sticker = Collection::create(Sticker::class, [$fragile]);
         $this->em()->save($gadget);
 
         $this->assertFalse($fragile->isNew(), 'The target should be persisted');
@@ -559,7 +559,7 @@ class EntityManagerTest extends TestCase
         );
 
         $loaded = Gadget::on($this->db)->first()->setNew(false);
-        $loaded->sticker = Collection::create([$fragile]);
+        $loaded->sticker = Collection::create(Sticker::class, [$fragile]);
         $this->db->resetCalls();
         $this->em()->save($loaded);
         $this->assertSame(
@@ -571,7 +571,7 @@ class EntityManagerTest extends TestCase
         $heavy = (new Sticker())->setNew();
         $heavy->label = 'heavy';
         $loaded = Gadget::on($this->db)->first()->setNew(false);
-        $loaded->sticker = Collection::create([$heavy]);
+        $loaded->sticker = Collection::create(Sticker::class, [$heavy]);
         $this->em()->save($loaded);
         $this->assertSame(
             [['sticker_id' => $heavy->id]],
@@ -603,11 +603,11 @@ class EntityManagerTest extends TestCase
         $gadget->name = 'Spanner';
         $sticker = (new Sticker())->setNew();
         $sticker->label = 'fragile';
-        $gadget->sticker = Collection::create([$sticker]);
+        $gadget->sticker = Collection::create(Sticker::class, [$sticker]);
         (new TickingEntityManager($db))->save($gadget);
 
         $loaded = Gadget::on($db)->first()->setNew(false);
-        $loaded->sticker = Collection::create([$sticker]);
+        $loaded->sticker = Collection::create(Sticker::class, [$sticker]);
 
         $db->resetCalls();
         (new TickingEntityManager($db))->save($loaded);
@@ -634,11 +634,11 @@ class EntityManagerTest extends TestCase
         $sharp->name = 'sharp';
         $heavy = (new Tag())->setNew();
         $heavy->name = 'heavy';
-        $gadget->tag = Collection::create([$sharp, $heavy]);
+        $gadget->tag = Collection::create(Tag::class, [$sharp, $heavy]);
         $this->em()->save($gadget);                     // two links inserted -> changed_at 1000, 2000
 
         $loaded = Gadget::on($this->db)->first()->setNew(false);
-        $loaded->tag = Collection::create([$sharp, $heavy]);
+        $loaded->tag = Collection::create(Tag::class, [$sharp, $heavy]);
         $this->db->resetCalls();
         $this->em()->save($loaded);
         $this->assertSame([], $this->writesTo('gadget_tag'), 'Re-saving an unchanged active link should write nothing');
@@ -658,7 +658,7 @@ class EntityManagerTest extends TestCase
         );
 
         $readded = Gadget::on($this->db)->first()->setNew(false);
-        $readded->tag = Collection::create([$sharp, $heavy]);
+        $readded->tag = Collection::create(Tag::class, [$sharp, $heavy]);
         $this->em()->save($readded);                    // revived -> changed_at 4000
 
         $this->assertSame(
@@ -679,7 +679,7 @@ class EntityManagerTest extends TestCase
         $sharp->name = 'sharp';
         $heavy = (new Badge())->setNew();
         $heavy->name = 'heavy';
-        $gadget->badge = Collection::create([$sharp, $heavy]);
+        $gadget->badge = Collection::create(Badge::class, [$sharp, $heavy]);
         $this->em()->save($gadget);                     // two links inserted -> changed_at 1000, 2000
 
         $heavyLinkId = GadgetBadge::on($this->db)
@@ -690,7 +690,7 @@ class EntityManagerTest extends TestCase
         // Sync the membership down to just "sharp"; reconcile must soft-delete heavy's link scoped by its
         // surrogate id, not by gadget_id/badge_id
         $loaded = Gadget::on($this->db)->first()->setNew(false);
-        $loaded->badge = Collection::create([$sharp]);
+        $loaded->badge = Collection::create(Badge::class, [$sharp]);
         $this->em()->save($loaded);                     // heavy soft-deleted -> changed_at 3000
 
         $this->assertSame(
@@ -704,7 +704,7 @@ class EntityManagerTest extends TestCase
 
         // Re-add heavy; reconcile must revive the tombstoned row, again scoped by its surrogate id
         $readded = Gadget::on($this->db)->first()->setNew(false);
-        $readded->badge = Collection::create([$sharp, $heavy]);
+        $readded->badge = Collection::create(Badge::class, [$sharp, $heavy]);
         $this->em()->save($readded);                    // heavy revived -> changed_at 4000
 
         $this->assertSame(
@@ -733,7 +733,7 @@ class EntityManagerTest extends TestCase
         $sharp->name = 'sharp';
         $heavy = (new Badge())->setNew();
         $heavy->name = 'heavy';
-        $gadget->badge = Collection::create([$sharp, $heavy]);
+        $gadget->badge = Collection::create(Badge::class, [$sharp, $heavy]);
         $this->em()->save($gadget);                         // two links inserted -> changed_at 1000, 2000
 
         // Load the gadget and materialize its membership while both links are still live, so the loaded
@@ -773,11 +773,11 @@ class EntityManagerTest extends TestCase
         $first->text = 'first';
         $second = (new StampedNote())->setNew();
         $second->text = 'second';
-        $stamped->stamped_note = Collection::create([$first, $second]);
+        $stamped->stamped_note = Collection::create(StampedNote::class, [$first, $second]);
         $this->em()->save($stamped);
 
         $loaded = Stamped::on($this->db)->first()->setNew(false);
-        $loaded->stamped_note = (new Collection())->sync([]);
+        $loaded->stamped_note = (new Collection(StampedNote::class))->sync([]);
         $this->em()->save($loaded);
         $this->assertSame(
             [
@@ -790,7 +790,7 @@ class EntityManagerTest extends TestCase
 
         $third = (new StampedNote())->setNew();
         $third->text = 'third';
-        $loaded->stamped_note = Collection::create([$third]);
+        $loaded->stamped_note = Collection::create(StampedNote::class, [$third]);
         $this->em()->save($loaded);
         $this->assertSame(
             'n',
@@ -799,7 +799,7 @@ class EntityManagerTest extends TestCase
         );
 
         // Detaching soft-deletes the child rather than removing it, since a HasMany link is the child row itself.
-        $loaded->stamped_note = (new Collection())->detach($third);
+        $loaded->stamped_note = (new Collection(StampedNote::class))->detach($third);
         $this->em()->save($loaded);
         $this->assertSame(
             'y',
@@ -864,7 +864,7 @@ class EntityManagerTest extends TestCase
         // Reassigning only a relation leaves the parent row's own data untouched, so it is neither
         // re-stamped nor re-written.
         $loaded = Stamped::on($this->db)->first()->setNew(false);
-        $loaded->stamped_note = new Collection();
+        $loaded->stamped_note = new Collection(StampedNote::class);
         $this->db->resetCalls();
         $this->em()->save($loaded);
         $this->assertSame(
@@ -887,7 +887,7 @@ class EntityManagerTest extends TestCase
         $gadget->name = 'Spanner';
         $sticker = (new Sticker())->setNew();
         $sticker->label = 'fragile';
-        $gadget->sticker = Collection::create([$sticker]);
+        $gadget->sticker = Collection::create(Sticker::class, [$sticker]);
         $this->em()->save($gadget);
         $gadgetId = $gadget->id;
 
@@ -922,7 +922,7 @@ class EntityManagerTest extends TestCase
 
         /** @var Model $loadedWorkshop */
         $loadedWorkshop = Workshop::on($this->db)->filter(Filter::equal('name', 'Globex'))->first()->setNew(false);
-        $loadedWorkshop->gadget = Collection::create([$orphan]);
+        $loadedWorkshop->gadget = Collection::create(Gadget::class, [$orphan]);
 
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('should not carry attachments');
@@ -944,7 +944,7 @@ class EntityManagerTest extends TestCase
 
         /** @var Model $loaded */
         $loaded = Gadget::on($this->db)->first()->setNew(false);
-        $loaded->sticker = Collection::create([$late]);
+        $loaded->sticker = Collection::create(Sticker::class, [$late]);
 
         $this->db->resetCalls();
         $this->em()->save($loaded->delete());
@@ -978,7 +978,7 @@ class EntityManagerTest extends TestCase
         $gadget->workshop = $workshop;
         $tag = (new Tag())->setNew();
         $tag->name = 'sharp';
-        $gadget->tag = Collection::create([$tag]);
+        $gadget->tag = Collection::create(Tag::class, [$tag]);
         $this->em()->save($gadget);                     // link inserted -> changed_at 1000
         $gadgetId = $gadget->id;
         $workshopId = $workshop->id;
@@ -994,7 +994,7 @@ class EntityManagerTest extends TestCase
         $loaded = Gadget::on($this->db)->with('workshop')->first()->setNew(false);
         $loaded->workshop->setNew(false);
         $loaded->workshop->name = 'Globex';
-        $loaded->tag = Collection::create([$tag->delete()]);
+        $loaded->tag = Collection::create(Tag::class, [$tag->delete()]);
         $this->em()->save($loaded->delete());
 
         $this->assertSame([], $this->rows('SELECT * FROM gadget'), 'The explicitly deleted gadget should be gone');
@@ -1017,13 +1017,13 @@ class EntityManagerTest extends TestCase
         $workshop->name = 'Acme';
         $gadget = (new Gadget())->setNew();
         $gadget->name = 'Spanner';
-        $workshop->gadget = Collection::create([$gadget]);
+        $workshop->gadget = Collection::create(Gadget::class, [$gadget]);
         $this->em()->save($workshop);
         $this->assertNotEmpty($this->rows('SELECT * FROM gadget'), 'precondition: the child exists');
 
         $loadedWorkshop = Workshop::on($this->db)->first()->setNew(false);
         $loadedGadget = Gadget::on($this->db)->first()->setNew(false);
-        $loadedWorkshop->gadget = Collection::create([$loadedGadget->delete()]);
+        $loadedWorkshop->gadget = Collection::create(Gadget::class, [$loadedGadget->delete()]);
 
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('should not carry attachments');
@@ -1036,7 +1036,7 @@ class EntityManagerTest extends TestCase
         $stamped->name = 'Manual';
         $note = (new StampedNote())->setNew();
         $note->text = 'initial';
-        $stamped->stamped_note = Collection::create([$note]);
+        $stamped->stamped_note = Collection::create(StampedNote::class, [$note]);
         (new TickingEntityManager($this->db))->save($stamped);
         $this->em()->save($stamped);
 
@@ -1067,7 +1067,7 @@ class EntityManagerTest extends TestCase
         $loaded = Workshop::on($this->db)->first()->setNew(false);
 
         // Replace the (still-Closure) relation without first reading it, so its loader never runs.
-        $loaded->gadget = Collection::create([(new Gadget())->setNew()]);
+        $loaded->gadget = Collection::create(Gadget::class, [(new Gadget())->setNew()]);
 
         $this->assertTrue(
             $loaded->gadget->hasPendingChanges(),
@@ -1081,7 +1081,7 @@ class EntityManagerTest extends TestCase
         $workshop->name = 'Acme';
         $gadget = (new Gadget())->setNew();
         $gadget->name = 'Spanner';
-        $workshop->gadget = Collection::create([$gadget]);
+        $workshop->gadget = Collection::create(Gadget::class, [$gadget]);
         $this->em()->save($workshop);
 
         $this->db->resetCalls();
@@ -1127,7 +1127,7 @@ class EntityManagerTest extends TestCase
         $workshop->name = 'Acme';
 
         // A gadget without a name violates the NOT NULL constraint and fails mid-cascade.
-        $workshop->gadget = Collection::create([(new Gadget())->setNew()]);
+        $workshop->gadget = Collection::create(Gadget::class, [(new Gadget())->setNew()]);
 
         try {
             $this->em()->save($workshop);
@@ -1151,7 +1151,7 @@ class EntityManagerTest extends TestCase
         $gadget->name = 'Spanner';
 
         // Build a cycle: the workshop owns the gadget and the gadget points back at the same instance.
-        $workshop->gadget = Collection::create([$gadget]);
+        $workshop->gadget = Collection::create(Gadget::class, [$gadget]);
         $gadget->workshop = $workshop;
 
         $this->expectException(RuntimeException::class);
@@ -1216,7 +1216,7 @@ class EntityManagerTest extends TestCase
         $gadget->name = 'Spanner';
         $sharp = (new Tag())->setNew();
         $sharp->name = 'sharp';
-        $gadget->tag = Collection::create([$sharp]);
+        $gadget->tag = Collection::create(Tag::class, [$sharp]);
         (new TickingEntityManager($this->db))->save($gadget);   // link (gadget, sharp) stamped
 
         // The state Actor A sees: the newest junction changed_at across the gadget's links
@@ -1227,13 +1227,13 @@ class EntityManagerTest extends TestCase
         $heavy = (new Tag())->setNew();
         $heavy->name = 'heavy';
         $editedByB = Gadget::on($this->db)->first()->setNew(false);
-        $editedByB->tag = (new Collection())->attach($heavy);
+        $editedByB->tag = (new Collection(Tag::class))->attach($heavy);
         (new TickingEntityManager($this->db))->save($editedByB);
 
         // Actor A submits, syncing the gadget's tags down to just "sharp"; reconcile hits B's newer link
         $em = new TickingEntityManager($this->db, $baseline);
         $editedByA = Gadget::on($this->db)->first()->setNew(false);
-        $editedByA->tag = (new Collection())->sync([$sharp]);
+        $editedByA->tag = (new Collection(Tag::class))->sync([$sharp]);
 
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('has changed after baseline');
@@ -1246,7 +1246,7 @@ class EntityManagerTest extends TestCase
         $stamped->name = 'Manual';
         $first = (new StampedNote())->setNew();
         $first->text = 'first';
-        $stamped->stamped_note = Collection::create([$first]);
+        $stamped->stamped_note = Collection::create(StampedNote::class, [$first]);
         (new TickingEntityManager($this->db))->save($stamped);  // note "first" stamped
 
         // The state Actor A sees: the newest note changed_at
@@ -1257,13 +1257,13 @@ class EntityManagerTest extends TestCase
         $second = (new StampedNote())->setNew();
         $second->text = 'second';
         $editedByB = Stamped::on($this->db)->first()->setNew(false);
-        $editedByB->stamped_note = (new Collection())->attach($second);
+        $editedByB->stamped_note = (new Collection(StampedNote::class))->attach($second);
         (new TickingEntityManager($this->db))->save($editedByB);
 
         // Actor A submits, syncing the notes down to just "first"; reconcile hits B's newer note
         $em = new TickingEntityManager($this->db, $baseline);
         $editedByA = Stamped::on($this->db)->first()->setNew(false);
-        $editedByA->stamped_note = (new Collection())->sync([$first]);
+        $editedByA->stamped_note = (new Collection(StampedNote::class))->sync([$first]);
 
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('has changed after baseline');
@@ -1282,7 +1282,7 @@ class EntityManagerTest extends TestCase
         $stamped->name = 'Manual';
         $note = (new StampedNote())->setNew();
         $note->text = 'original';
-        $stamped->stamped_note = Collection::create([$note]);
+        $stamped->stamped_note = Collection::create(StampedNote::class, [$note]);
         $this->em()->save($stamped);
 
         $loaded = Stamped::on($this->db)->first()->setNew(false);
@@ -1305,7 +1305,7 @@ class EntityManagerTest extends TestCase
         $stamped->name = 'Manual';
         $note = (new StampedNote())->setNew();
         $note->text = 'original';
-        $stamped->stamped_note = Collection::create([$note]);
+        $stamped->stamped_note = Collection::create(StampedNote::class, [$note]);
         $this->em()->save($stamped);
 
         $loaded = Stamped::on($this->db)->first()->setNew(false);
@@ -1330,7 +1330,7 @@ class EntityManagerTest extends TestCase
         $keep->text = 'keep';
         $drop = (new StampedNote())->setNew();
         $drop->text = 'drop';
-        $stamped->stamped_note = Collection::create([$keep, $drop]);
+        $stamped->stamped_note = Collection::create(StampedNote::class, [$keep, $drop]);
         $this->em()->save($stamped);
 
         // Detach one child and delete the owner in a single save; the detached child must still be removed.
@@ -1358,7 +1358,7 @@ class EntityManagerTest extends TestCase
         $first->text = 'first';
         $second = (new StampedNote())->setNew();
         $second->text = 'second';
-        $stamped->stamped_note = Collection::create([$first, $second]);
+        $stamped->stamped_note = Collection::create(StampedNote::class, [$first, $second]);
         $this->em()->save($stamped);
 
         // Sync the children down to nothing and delete the owner in a single save.
@@ -1391,6 +1391,6 @@ class EntityManagerTest extends TestCase
     public function testQueryThrowsWhenThereIsNoPendingQuery()
     {
         $this->expectException(LogicException::class);
-        (new Collection())->query();
+        (new Collection(Tag::class))->query();
     }
 }


### PR DESCRIPTION
Adds various `@property` annotations or updates existing ones, to support generics added by https://github.com/Icinga/ipl-orm/pull/163.

It solves a long-standing problem when working with IDEs such as PHPStorm and allows the IDE now to show proper type hints, completions and doc where a model is being worked with.

Additionally updates `\Icinga\Module\Notifications\Common\Collection` which is the result of an experiment how to properly establish generics in an unconstrained environment. It now resembles a reference implementation for a generic item container to my understanding. But it involves strict type checks that are usually not *PHPish* and so the public interface isn't part of what I see as reference, but the behavior and how generics are supported.