### PR TITLE
Let api endpoints use repositories 530

### DIFF
--- a/library/Notifications/Api/V1/ContactGroups.php
+++ b/library/Notifications/Api/V1/ContactGroups.php
@@ -5,7 +5,6 @@
 
 namespace Icinga\Module\Notifications\Api\V1;
 
-use DateTime;
 use Icinga\Exception\Http\HttpBadRequestException;
 use Icinga\Exception\Http\HttpException;
 use Icinga\Exception\Http\HttpNotFoundException;
@@ -21,14 +20,10 @@ use Icinga\Module\Notifications\Api\OpenApiDescriptionElement\Parameter\QueryPar
 use Icinga\Module\Notifications\Api\OpenApiDescriptionElement\Response\Example\ResponseExample;
 use Icinga\Module\Notifications\Api\OpenApiDescriptionElement\Schema\SchemaUUID;
 use Icinga\Module\Notifications\Common\Database;
-use Icinga\Module\Notifications\Model\Contactgroup;
-use Icinga\Module\Notifications\Model\Rotation;
-use Icinga\Module\Notifications\Model\RotationMember;
-use Icinga\Module\Notifications\Model\RuleEscalationRecipient;
-use Icinga\Module\Notifications\Repository\RotationRepository;
+use Icinga\Module\Notifications\Form\Data\ContactGroup as ContactGroupData;
+use Icinga\Module\Notifications\Repository\ContactGroupRepository;
 use Icinga\Util\Json;
 use ipl\Sql\Select;
-use ipl\Stdlib\Filter;
 use OpenApi\Attributes as OA;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Server\RequestHandlerInterface;
@@ -358,7 +353,7 @@ class ContactGroups extends ApiV1 implements RequestHandlerInterface, EndpointIn
         }
 
         if (! $emptyIdentifier) {
-            $this->removeContactgroup($groupId);
+            (new ContactGroupRepository(Database::get()))->delete($groupId);
         }
 
         $this->addContactgroup($requestBody);
@@ -409,7 +404,7 @@ class ContactGroups extends ApiV1 implements RequestHandlerInterface, EndpointIn
         }
 
         Database::get()->beginTransaction();
-        $this->removeContactgroup($contactgroupId);
+        (new ContactGroupRepository(Database::get()))->delete($contactgroupId);
         Database::get()->commitTransaction();
 
         return $this->createResponse(204);
@@ -468,101 +463,6 @@ class ContactGroups extends ApiV1 implements RequestHandlerInterface, EndpointIn
 //            ->fetchCol('SELECT id FROM contactgroup WHERE external_uuid = ?', [$identifier]);
 //
 //        return $group[0] ?? null;
-    }
-
-    /**
-     * Remove the Contact Group with the given id and all its references
-     *
-     * @param int $id
-     *
-     * @return void
-     */
-    private function removeContactgroup(int $id): void
-    {
-        $markAsDeleted = ['changed_at' => (int) (new DateTime())->format("Uv"), 'deleted' => 'y'];
-        $markEntityAsDeleted = array_merge(
-            $markAsDeleted,
-            ['external_uuid' => substr_replace(Uuid::uuid4()->toString(), '0', 14, 1)]
-        );
-        $updateCondition = ['contactgroup_id = ?' => $id, 'deleted = ?' => 'n'];
-
-        $rotationAndMemberIds = Database::get()->fetchPairs(
-            RotationMember::on(Database::get())
-                ->columns(['id', 'rotation_id'])
-                ->filter(Filter::equal('contactgroup_id', $id))
-                ->assembleSelect()
-        );
-
-        $rotationMemberIds = array_keys($rotationAndMemberIds);
-        $rotationIds = array_values($rotationAndMemberIds);
-
-        Database::get()->update('rotation_member', $markAsDeleted + ['position' => null], $updateCondition);
-
-        if (! empty($rotationMemberIds)) {
-            Database::get()->update(
-                'timeperiod_entry',
-                $markAsDeleted,
-                ['rotation_member_id IN (?)' => $rotationMemberIds, 'deleted = ?' => 'n']
-            );
-        }
-
-        if (! empty($rotationIds)) {
-            $rotationIdsWithOtherMembers = Database::get()->fetchCol(
-                RotationMember::on(Database::get())
-                    ->columns('rotation_id')
-                    ->filter(
-                        Filter::all(
-                            Filter::equal('rotation_id', $rotationIds),
-                            Filter::unequal('contactgroup_id', $id)
-                        )
-                    )->assembleSelect()
-            );
-
-            $toRemoveRotations = array_diff($rotationIds, $rotationIdsWithOtherMembers);
-            foreach ($toRemoveRotations as $rotationId) {
-                (new RotationRepository(Database::get()))->delete($rotationId);
-            }
-        }
-
-        $escalationIds = Database::get()->fetchCol(
-            RuleEscalationRecipient::on(Database::get())
-                ->columns('rule_escalation_id')
-                ->filter(Filter::equal('contactgroup_id', $id))
-                ->assembleSelect()
-        );
-
-        Database::get()->update('rule_escalation_recipient', $markAsDeleted, $updateCondition);
-
-        if (! empty($escalationIds)) {
-            $escalationIdsWithOtherRecipients = Database::get()->fetchCol(
-                RuleEscalationRecipient::on(Database::get())
-                    ->columns('rule_escalation_id')
-                    ->filter(
-                        Filter::all(
-                            Filter::equal('rule_escalation_id', $escalationIds),
-                            Filter::unequal('contactgroup_id', $id)
-                        )
-                    )->assembleSelect()
-            );
-
-            $toRemoveEscalations = array_diff($escalationIds, $escalationIdsWithOtherRecipients);
-
-            if (! empty($toRemoveEscalations)) {
-                Database::get()->update(
-                    'rule_escalation',
-                    $markAsDeleted + ['position' => null],
-                    ['id IN (?)' => $toRemoveEscalations]
-                );
-            }
-        }
-
-        Database::get()->update('contactgroup_member', $markAsDeleted, $updateCondition);
-
-        Database::get()->update(
-            'contactgroup',
-            $markEntityAsDeleted,
-            ['id = ?' => $id, 'deleted = ?' => 'n']
-        );
     }
 
     /**
@@ -626,130 +526,58 @@ class ContactGroups extends ApiV1 implements RequestHandlerInterface, EndpointIn
             $this->assertUniqueName($requestBody['name']);
         }
 
-        Database::get()->insert('contactgroup', [
-            'name'          => $requestBody['name'],
-            'external_uuid' => $requestBody['id'],
-            'changed_at'    => (int) (new DateTime())->format("Uv"),
-        ]);
-
-        $id = Database::get()->lastInsertId();
-
-        if (! empty($requestBody['users'])) {
-            $this->addUsers($id, $requestBody['users']);
-        }
+        (new ContactGroupRepository(Database::get()))->create($this->createContactGroupData($requestBody));
     }
 
+    /**
+     * Update the Contact Group with the given id with the given data
+     *
+     * @param requestBody $requestBody
+     * @param int $contactgroupId
+     *
+     * @return void
+     *
+     * @throws HttpException
+     */
     private function updateContactgroup(array $requestBody, int $contactgroupId): void
     {
         if (! empty($requestBody['name'])) {
             $this->assertUniqueName($requestBody['name'], $contactgroupId);
         }
 
-        $storedValues = $this->fetchDbValues($contactgroupId);
-
-        $changedAt = (int) (new DateTime())->format("Uv");
-
-        if ($requestBody['name'] !== $storedValues['group_name']) {
-            Database::get()->update(
-                'contactgroup',
-                ['name' => $requestBody['name'], 'changed_at' => $changedAt],
-                ['id = ?' => $contactgroupId]
-            );
-        }
-
-        $storedContacts = [];
-        if (! empty($storedValues['group_members'])) {
-            $storedContacts = explode(',', $storedValues['group_members']);
-        }
-
-        $newContacts = [];
-        if (! empty($requestBody['users'])) {
-            foreach ($requestBody['users'] as $identifier) {
-                $contactId = Contacts::getContactId($identifier);
-                if ($contactId === null) {
-                    throw new HttpException(422, sprintf('User with identifier %s not found', $identifier));
-                }
-                $newContacts[] = $contactId;
-            }
-        }
-
-        $toDelete = array_diff($storedContacts, $newContacts);
-        $toAdd = array_diff($newContacts, $storedContacts);
-
-        if (! empty($toDelete)) {
-            Database::get()->update(
-                'contactgroup_member',
-                ['changed_at' => $changedAt, 'deleted' => 'y'],
-                [
-                    'contactgroup_id = ?'   => $contactgroupId,
-                    'contact_id IN (?)'     => $toDelete,
-                    'deleted = ?'           => 'n'
-                ]
-            );
-        }
-
-        if (! empty($toAdd)) {
-            $contactsMarkedAsDeleted = Database::get()->fetchCol(
-                (new Select())
-                    ->from('contactgroup_member')
-                    ->columns(['contact_id'])
-                    ->where([
-                        'contactgroup_id = ?'   => $contactgroupId,
-                        'deleted = ?'           => 'y',
-                        'contact_id IN (?)'     => $toAdd
-                    ])
-            );
-
-            $toAdd = array_diff($toAdd, $contactsMarkedAsDeleted);
-            foreach ($toAdd as $contactId) {
-                Database::get()->insert(
-                    'contactgroup_member',
-                    [
-                        'contactgroup_id'   => $contactgroupId,
-                        'contact_id'        => $contactId,
-                        'changed_at'        => $changedAt
-                    ]
-                );
-            }
-
-            if (! empty($contactsMarkedAsDeleted)) {
-                Database::get()->update(
-                    'contactgroup_member',
-                    ['changed_at' => $changedAt, 'deleted' => 'n'],
-                    [
-                        'contactgroup_id = ?'   => $contactgroupId,
-                        'contact_id IN (?)'     => $contactsMarkedAsDeleted
-                    ]
-                );
-            }
-        }
+        (new ContactGroupRepository(Database::get()))
+            ->update($this->createContactGroupData($requestBody, $contactgroupId));
     }
 
     /**
-     * Add the given users as contactgroup_member with the given id
+     * Transform the given request body into what the {@see ContactGroupRepository} expects
      *
-     * @param int $contactgroupId
-     * @param string[] $users
+     * @param requestBody $requestBody
+     * @param ?int $contactgroupId The id of the Contact Group to update, NULL to create a new one
      *
-     * @return void
+     * @return ContactGroupData
      *
-     * @throws HttpException
+     * @throws HttpException If a referenced user does not exist
      */
-    private function addUsers(int $contactgroupId, array $users): void
+    private function createContactGroupData(array $requestBody, ?int $contactgroupId = null): ContactGroupData
     {
-        foreach ($users as $identifier) {
+        $members = [];
+        foreach ($requestBody['users'] ?? [] as $identifier) {
             $contactId = Contacts::getContactId($identifier);
 
             if ($contactId === null) {
                 throw new HttpException(422, sprintf('User with identifier %s not found', $identifier));
             }
 
-            Database::get()->insert('contactgroup_member', [
-                'contactgroup_id' => $contactgroupId,
-                'contact_id'      => $contactId,
-                'changed_at'      => (int) (new DateTime())->format("Uv"),
-            ]);
+            $members[] = $contactId;
         }
+
+        return new ContactGroupData(
+            id: $contactgroupId,
+            name: $requestBody['name'],
+            members: $members,
+            externalUuid: $requestBody['id']
+        );
     }
 
     public function prepareRow(stdClass $row): void
@@ -788,37 +616,5 @@ class ContactGroups extends ApiV1 implements RequestHandlerInterface, EndpointIn
         if ($user) {
             throw new HttpException(422, sprintf('Name %s already exists', $name));
         }
-    }
-
-    /**
-     * Fetch the values from the database
-     *
-     * @param int $contactgroupId
-     *
-     * @return array
-     *
-     * @throws HttpNotFoundException
-     */
-    private function fetchDbValues(int $contactgroupId): array
-    {
-        $query = Contactgroup::on(Database::get())
-            ->columns(['id', 'name'])
-            ->filter(Filter::equal('id', $contactgroupId));
-
-        /** @var ?Contactgroup $group */
-        $group = $query->first();
-        if ($group === null) {
-            throw new HttpNotFoundException('Contact group not found');
-        }
-
-        $groupMembers = [];
-        foreach ($group->contactgroup_member as $contact) {
-            $groupMembers[] = $contact->contact_id;
-        }
-
-        return [
-            'group_name'        => $group->name,
-            'group_members'     => implode(',', $groupMembers)
-        ];
     }
 }

--- a/library/Notifications/Api/V1/Contacts.php
+++ b/library/Notifications/Api/V1/Contacts.php
@@ -5,7 +5,6 @@
 
 namespace Icinga\Module\Notifications\Api\V1;
 
-use DateTime;
 use Icinga\Exception\Http\HttpBadRequestException;
 use Icinga\Exception\Http\HttpException;
 use Icinga\Exception\Http\HttpNotFoundException;
@@ -21,14 +20,10 @@ use Icinga\Module\Notifications\Api\OpenApiDescriptionElement\Parameter\QueryPar
 use Icinga\Module\Notifications\Api\OpenApiDescriptionElement\Response\Example\ResponseExample;
 use Icinga\Module\Notifications\Api\OpenApiDescriptionElement\Schema\SchemaUUID;
 use Icinga\Module\Notifications\Common\Database;
-use Icinga\Module\Notifications\Model\Contact;
-use Icinga\Module\Notifications\Model\Rotation;
-use Icinga\Module\Notifications\Model\RotationMember;
-use Icinga\Module\Notifications\Model\RuleEscalationRecipient;
-use Icinga\Module\Notifications\Repository\RotationRepository;
+use Icinga\Module\Notifications\Form\Data\Contact as ContactData;
+use Icinga\Module\Notifications\Repository\ContactRepository;
 use Icinga\Util\Json;
 use ipl\Sql\Select;
-use ipl\Stdlib\Filter;
 use OpenApi\Attributes as OA;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Server\RequestHandlerInterface;
@@ -450,7 +445,7 @@ class Contacts extends ApiV1 implements RequestHandlerInterface, EndpointInterfa
         }
 
         if (! $emptyIdentifier) {
-            $this->removeContact($contactId);
+            (new ContactRepository(Database::get()))->delete($contactId);
         }
 
         $this->addContact($requestBody);
@@ -501,7 +496,7 @@ class Contacts extends ApiV1 implements RequestHandlerInterface, EndpointInterfa
         }
 
         Database::get()->beginTransaction();
-        $this->removeContact($contactId);
+        (new ContactRepository(Database::get()))->delete($contactId);
         Database::get()->commitTransaction();
 
         return $this->createResponse(204);
@@ -576,56 +571,6 @@ class Contacts extends ApiV1 implements RequestHandlerInterface, EndpointInterfa
     }
 
     /**
-     * Add the groups to the given contact
-     *
-     * @param int $contactId
-     * @param string[] $groups
-     *
-     * @return void
-     *
-     * @throws HttpException
-     */
-    private function addGroups(int $contactId, array $groups): void
-    {
-        foreach ($groups as $groupIdentifier) {
-            $groupId = ContactGroups::getGroupId($groupIdentifier);
-
-            if ($groupId === null) {
-                throw new HttpException(
-                    422,
-                    sprintf('Contact Group with identifier %s does not exist', $groupIdentifier)
-                );
-            }
-
-            Database::get()->insert('contactgroup_member', [
-                'contact_id'      => $contactId,
-                'contactgroup_id' => $groupId,
-                'changed_at'      => (int) (new DateTime())->format("Uv"),
-            ]);
-        }
-    }
-
-    /**
-     * Add the addresses to the given contact
-     *
-     * @param int $contactId
-     * @param array<string, string> $addresses
-     *
-     * @return void
-     */
-    private function addAddresses(int $contactId, array $addresses): void
-    {
-        foreach ($addresses as $type => $address) {
-            Database::get()->insert('contact_address', [
-                'contact_id' => $contactId,
-                'type'       => $type,
-                'address'    => $address,
-                'changed_at' => (int) (new DateTime())->format("Uv"),
-            ]);
-        }
-    }
-
-    /**
      * Add a new contact with the given data
      *
      * @param requestBody $requestBody
@@ -640,214 +585,64 @@ class Contacts extends ApiV1 implements RequestHandlerInterface, EndpointInterfa
             $this->assertUniqueUsername($requestBody['username']);
         }
 
-        Database::get()->insert('contact', [
-            'full_name'          => $requestBody['full_name'],
-            'username'           => $requestBody['username'] ?? null,
-            'default_channel_id' => Channels::getChannelId($requestBody['default_channel']),
-            'external_uuid'      => $requestBody['id'],
-            'changed_at'         => (int) (new DateTime())->format("Uv"),
-        ]);
-
-        $contactId = Database::get()->lastInsertId();
-
-        if (! empty($requestBody['addresses'])) {
-            $this->addAddresses($contactId, $requestBody['addresses']);
-        }
-
-        if (! empty($requestBody['groups'])) {
-            $this->addGroups($contactId, $requestBody['groups']);
-        }
+        (new ContactRepository(Database::get()))->create($this->createContactData($requestBody));
     }
 
+    /**
+     * Update the contact with the given id with the given data
+     *
+     * @param requestBody $requestBody
+     * @param int $contactId
+     *
+     * @return void
+     *
+     * @throws HttpException
+     */
     private function updateContact(array $requestBody, int $contactId): void
     {
         if (! empty($requestBody['username'])) {
             $this->assertUniqueUsername($requestBody['username'], $contactId);
         }
 
-        $changedAt = (int) (new DateTime())->format("Uv");
-        Database::get()->update('contact', [
-            'full_name'          => $requestBody['full_name'],
-            'username'           => $requestBody['username'] ?? null,
-            'default_channel_id' => Channels::getChannelId($requestBody['default_channel']),
-            'changed_at'         => $changedAt,
-        ], ['id = ?' => $contactId]);
-
-        $markAsDeleted = ['deleted' => 'y'];
-        Database::get()->update(
-            'contact_address',
-            $markAsDeleted,
-            ['contact_id = ?' => $contactId, 'deleted = ?' => 'n']
-        );
-
-        if (! empty($requestBody['addresses'])) {
-            $this->addAddresses($contactId, $requestBody['addresses']);
-        }
-
-        $storedValues = $this->fetchDbValues($contactId);
-        $storedContacts = [];
-        if (! empty($storedValues['group_members'])) {
-            $storedContacts = explode(',', $storedValues['group_members']);
-        }
-
-        $newContactgroups = [];
-        if (! empty($requestBody['groups'])) {
-            foreach ($requestBody['groups'] as $identifier) {
-                $contactgroupId = ContactGroups::getGroupId($identifier);
-                if ($contactgroupId === null) {
-                    throw new HttpException(
-                        422,
-                        sprintf('Contact Group with identifier %s does not exist', $identifier)
-                    );
-                }
-                $newContactgroups[] = $contactgroupId;
-            }
-        }
-
-        $toDelete = array_diff($storedContacts, $newContactgroups);
-        $toAdd = array_diff($newContactgroups, $storedContacts);
-
-        if (! empty($toDelete)) {
-            Database::get()->update(
-                'contactgroup_member',
-                ['changed_at' => $changedAt, 'deleted' => 'y'],
-                [
-                    'contactgroup_id = ?'   => $toDelete,
-                    'contact_id IN (?)'     => $contactId,
-                    'deleted = ?'           => 'n'
-                ]
-            );
-        }
-
-        if (! empty($toAdd)) {
-            $contactgroupsMarkedAsDeleted = Database::get()->fetchCol(
-                (new Select())
-                    ->from('contactgroup_member')
-                    ->columns(['contactgroup_id'])
-                    ->where([
-                        'contact_id = ?' => $contactId,
-                        'deleted = ?' => 'y',
-                        'contactgroup_id IN (?)' => $toAdd
-                    ])
-            );
-
-            $toAdd = array_diff($toAdd, $contactgroupsMarkedAsDeleted);
-            foreach ($toAdd as $contactgroupId) {
-                Database::get()->insert(
-                    'contactgroup_member',
-                    [
-                        'contactgroup_id' => $contactgroupId,
-                        'contact_id' => $contactId,
-                        'changed_at' => $changedAt
-                    ]
-                );
-            }
-
-            if (! empty($contactgroupsMarkedAsDeleted)) {
-                Database::get()->update(
-                    'contactgroup_member',
-                    ['changed_at' => $changedAt, 'deleted' => 'n'],
-                    [
-                        'contact_id = ?' => $contactId,
-                        'contactgroup_id IN (?)' => $contactgroupsMarkedAsDeleted
-                    ]
-                );
-            }
-        }
+        (new ContactRepository(Database::get()))->update($this->createContactData($requestBody, $contactId));
     }
 
     /**
-     * Remove the contact with the given id
+     * Transform the given request body into what the {@see ContactRepository} expects
      *
-     * @param int $id
+     * @param requestBody $requestBody
+     * @param ?int $contactId The id of the contact to update, NULL to create a new one
      *
-     * @return void
+     * @return ContactData
+     *
+     * @throws HttpException If a referenced contact group does not exist
      */
-    private function removeContact(int $id): void
+    private function createContactData(array $requestBody, ?int $contactId = null): ContactData
     {
-        //TODO: "remove rotations|escalations with no members" taken from form. Is it properly?
+        $groups = [];
+        foreach ($requestBody['groups'] ?? [] as $groupIdentifier) {
+            $groupId = ContactGroups::getGroupId($groupIdentifier);
 
-        $markAsDeleted = ['changed_at' => (int) (new DateTime())->format("Uv"), 'deleted' => 'y'];
-        $markEntityAsDeleted = array_merge(
-            $markAsDeleted,
-            ['external_uuid' => substr_replace(Uuid::uuid4()->toString(), '0', 14, 1)]
-        );
-        $updateCondition = ['contact_id = ?' => $id, 'deleted = ?' => 'n'];
-
-        $rotationAndMemberIds = Database::get()->fetchPairs(
-            RotationMember::on(Database::get())
-                ->columns(['id', 'rotation_id'])
-                ->filter(Filter::equal('contact_id', $id))
-                ->assembleSelect()
-        );
-
-        $rotationMemberIds = array_keys($rotationAndMemberIds);
-        $rotationIds = array_values($rotationAndMemberIds);
-
-        Database::get()->update('rotation_member', $markAsDeleted + ['position' => null], $updateCondition);
-
-        if (! empty($rotationMemberIds)) {
-            Database::get()->update(
-                'timeperiod_entry',
-                $markAsDeleted,
-                ['rotation_member_id IN (?)' => $rotationMemberIds, 'deleted = ?' => 'n']
-            );
-        }
-
-        if (! empty($rotationIds)) {
-            $rotationIdsWithOtherMembers = Database::get()->fetchCol(
-                RotationMember::on(Database::get())
-                    ->columns('rotation_id')
-                    ->filter(
-                        Filter::all(
-                            Filter::equal('rotation_id', $rotationIds),
-                            Filter::unequal('contact_id', $id)
-                        )
-                    )->assembleSelect()
-            );
-
-            $toRemoveRotations = array_diff($rotationIds, $rotationIdsWithOtherMembers);
-            foreach ($toRemoveRotations as $rotationId) {
-                (new RotationRepository(Database::get()))->delete($rotationId);
-            }
-        }
-
-        $escalationIds = Database::get()->fetchCol(
-            RuleEscalationRecipient::on(Database::get())
-                ->columns('rule_escalation_id')
-                ->filter(Filter::equal('contact_id', $id))
-                ->assembleSelect()
-        );
-
-        Database::get()->update('rule_escalation_recipient', $markAsDeleted, $updateCondition);
-
-        if (! empty($escalationIds)) {
-            $escalationIdsWithOtherRecipients = Database::get()->fetchCol(
-                RuleEscalationRecipient::on(Database::get())
-                    ->columns('rule_escalation_id')
-                    ->filter(
-                        Filter::all(
-                            Filter::equal('rule_escalation_id', $escalationIds),
-                            Filter::unequal('contact_id', $id)
-                        )
-                    )->assembleSelect()
-            );
-
-            $toRemoveEscalations = array_diff($escalationIds, $escalationIdsWithOtherRecipients);
-
-            if (! empty($toRemoveEscalations)) {
-                Database::get()->update(
-                    'rule_escalation',
-                    $markAsDeleted + ['position' => null],
-                    ['id IN (?)' => $toRemoveEscalations]
+            if ($groupId === null) {
+                throw new HttpException(
+                    422,
+                    sprintf('Contact Group with identifier %s does not exist', $groupIdentifier)
                 );
             }
+
+            $groups[] = $groupId;
         }
 
-        Database::get()->update('contactgroup_member', $markAsDeleted, $updateCondition);
-        Database::get()->update('contact_address', $markAsDeleted, $updateCondition);
-
-        Database::get()->update('contact', $markEntityAsDeleted + ['username' => null], ['id = ?' => $id]);
+        return new ContactData(
+            id: $contactId,
+            fullName: $requestBody['full_name'],
+            username: $requestBody['username'] ?? null,
+            // The channel's existence is verified by assertValidRequestBody()
+            channelId: (int) Channels::getChannelId($requestBody['default_channel']),
+            addresses: $requestBody['addresses'] ?? [],
+            groups: $groups,
+            externalUuid: $requestBody['id']
+        );
     }
 
     /**
@@ -993,36 +788,5 @@ class Contacts extends ApiV1 implements RequestHandlerInterface, EndpointInterfa
                 ->where(['cgm.contactgroup_id = ?' => $contactgroupId, 'cgm.deleted = ?' => 'n'])
                 ->groupBy('co.external_uuid')
         );
-    }
-
-    /**
-     * Fetch the values from the database
-     *
-     * @param int $contactId
-     *
-     * @return array
-     *
-     * @throws HttpNotFoundException
-     */
-    private function fetchDbValues(int $contactId): array
-    {
-        $query = Contact::on(Database::get())
-            ->columns(['id', 'full_name', 'default_channel_id'])
-            ->filter(Filter::equal('id', $contactId));
-
-        /** @var ?Contact $contact */
-        $contact = $query->first();
-        if ($contact === null) {
-            throw new HttpNotFoundException('Contact contact not found');
-        }
-
-        $groupMembers = [];
-        foreach ($contact->contactgroup_member as $group) {
-            $groupMembers[] = $group->contactgroup_id;
-        }
-
-        return [
-            'group_members' => implode(',', $groupMembers)
-        ];
     }
 }

--- a/library/Notifications/Common/Database.php
+++ b/library/Notifications/Common/Database.php
@@ -13,10 +13,8 @@ use ipl\Sql\Adapter\Pgsql;
 use ipl\Sql\Config as SqlConfig;
 use ipl\Sql\Connection;
 use ipl\Sql\Expression;
-use ipl\Sql\Insert;
 use ipl\Sql\QueryBuilder;
 use ipl\Sql\Select;
-use ipl\Sql\Update;
 use Pdo\Mysql;
 use PDO;
 
@@ -122,55 +120,7 @@ final class Database
                 });
         }
 
-        $db->getQueryBuilder()
-            ->on(QueryBuilder::ON_ASSEMBLE_INSERT, function (Insert $insert) use ($db): void {
-                $columns = $insert->getColumns();
-                $pos = array_search('changed_at', $columns);
-
-                if ($pos === false) {
-                    return;
-                }
-
-                $values = $insert->getValues();
-                $values[$pos] = self::getNextChangedAt($db, $insert->getInto(), $values[$pos]);
-                $insert->values(array_combine($columns, $values));
-            })
-            ->on(QueryBuilder::ON_ASSEMBLE_UPDATE, function (Update $update) use ($db): void {
-                $set = $update->getSet();
-
-                if (! isset($set['changed_at'])) {
-                    return;
-                }
-
-                $set['changed_at'] = self::getNextChangedAt($db, $update->getTable()[0], $set['changed_at']);
-                $update->set($set);
-            });
-
         return $db;
-    }
-
-    /**
-     * Return the next changed_at value for the given database and table
-     *
-     * @param Connection $db
-     * @param string $table
-     * @param mixed $nowUnixMilli
-     *
-     * @return int The given timestamp or 1 + the maximum changed_at value in the table, whichever is greater
-     */
-    private static function getNextChangedAt(Connection $db, string $table, $nowUnixMilli): int
-    {
-        return $db->select(
-            (new Select())
-                ->from($table)
-                ->columns(
-                    ['changed_at' => new Expression(
-                        'GREATEST(?, 1 + COALESCE(MAX(changed_at), 0))',
-                        null,
-                        $nowUnixMilli
-                    )]
-                )
-        )->fetchColumn();
     }
 
     /**

--- a/library/Notifications/Form/Data/Contact.php
+++ b/library/Notifications/Form/Data/Contact.php
@@ -13,13 +13,19 @@ readonly class Contact
      * @param ?string $username The Icinga Web user associated with the contact
      * @param int $channelId Id of the default channel for the contact
      * @param array<string, string> $addresses Type identifiers as keys and addresses as values
+     * @param ?int[] $groups Ids of the contact groups the contact is a member of,
+     *                       NULL to leave existing memberships untouched
+     * @param ?string $externalUuid How external systems reference the contact, NULL to generate one.
+     *                              Only honored when the contact is created
      */
     public function __construct(
         public ?int $id,
         public string $fullName,
         public ?string $username,
         public int $channelId,
-        public array $addresses
+        public array $addresses,
+        public ?array $groups = null,
+        public ?string $externalUuid = null
     ) {
     }
 }

--- a/library/Notifications/Form/Data/ContactGroup.php
+++ b/library/Notifications/Form/Data/ContactGroup.php
@@ -11,11 +11,14 @@ readonly class ContactGroup
      * @param ?int $id The primary database key value, NULL for new contact groups
      * @param string $name The name of the contact group
      * @param int[] $members The group's members, a list of contact IDs
+     * @param ?string $externalUuid How external systems reference the group, NULL to generate one.
+     *                              Only honored when the group is created
      */
     public function __construct(
         public ?int $id,
         public string $name,
-        public array $members = []
+        public array $members = [],
+        public ?string $externalUuid = null
     ) {
     }
 }

--- a/library/Notifications/Model/Channel.php
+++ b/library/Notifications/Model/Channel.php
@@ -18,7 +18,7 @@ use ipl\Web\Widget\Icon;
 
 /**
  * @property int $id
- * @property string $external_uuid
+ * @property ?string $external_uuid
  * @property string $name
  * @property string $type
  * @property ?string $config

--- a/library/Notifications/Model/Contact.php
+++ b/library/Notifications/Model/Contact.php
@@ -22,7 +22,7 @@ use ipl\Stdlib\Filter;
  * @property int $default_channel_id
  * @property DateTime $changed_at
  * @property bool $deleted
- * @property string $external_uuid
+ * @property ?string $external_uuid
  *
  * @property Query<Channel>|Channel $channel
  * @property Query<Incident>|Collection<Incident> $incident

--- a/library/Notifications/Model/Contactgroup.php
+++ b/library/Notifications/Model/Contactgroup.php
@@ -22,7 +22,7 @@ use ipl\Stdlib\Filter;
  * @property string $name
  * @property DateTime $changed_at
  * @property bool $deleted
- * @property string $external_uuid
+ * @property ?string $external_uuid
  *
  * @property Query<Contact>|Collection<Contact> $contact
  * @property Query<Rotation>|Collection<Rotation> $rotation

--- a/library/Notifications/Repository/ChannelRepository.php
+++ b/library/Notifications/Repository/ChannelRepository.php
@@ -97,6 +97,8 @@ final class ChannelRepository
             throw new InvalidArgumentException('Cannot delete a channel that does not exist in the database');
         }
 
+        $model->external_uuid = null;
+
         (new EntityManager($this->db))->save($model->delete());
     }
 

--- a/library/Notifications/Repository/ContactGroupRepository.php
+++ b/library/Notifications/Repository/ContactGroupRepository.php
@@ -57,7 +57,7 @@ final class ContactGroupRepository
     {
         $model = (new Contactgroup())->setNew();
         $model->name = $group->name;
-        $model->external_uuid = Uuid::uuid4()->toString();
+        $model->external_uuid = $group->externalUuid ?? Uuid::uuid4()->toString();
         $model->contact = Collection::create(
             Contact::class,
             array_map(fn($id) => new Contact(['id' => $id]), $group->members)

--- a/library/Notifications/Repository/ContactGroupRepository.php
+++ b/library/Notifications/Repository/ContactGroupRepository.php
@@ -109,6 +109,7 @@ final class ContactGroupRepository
         }
 
         $model->contact = [];
+        $model->external_uuid = null;
         $model->delete();
 
         $model->rotation

--- a/library/Notifications/Repository/ContactRepository.php
+++ b/library/Notifications/Repository/ContactRepository.php
@@ -13,6 +13,7 @@ use Icinga\Module\Notifications\Form\Data\Contact as ContactData;
 use Icinga\Module\Notifications\Form\Data\Rotation;
 use Icinga\Module\Notifications\Model\Contact;
 use Icinga\Module\Notifications\Model\ContactAddress;
+use Icinga\Module\Notifications\Model\Contactgroup;
 use InvalidArgumentException;
 use ipl\Sql\Connection;
 use ipl\Sql\Expression;
@@ -75,7 +76,7 @@ final class ContactRepository
         $model->full_name = $contact->fullName;
         $model->username = $contact->username;
         $model->default_channel_id = $contact->channelId;
-        $model->external_uuid = Uuid::uuid4()->toString();
+        $model->external_uuid = $contact->externalUuid ?? Uuid::uuid4()->toString();
 
         $addresses = [];
         foreach ($contact->addresses as $type => $address) {
@@ -87,13 +88,20 @@ final class ContactRepository
 
         $model->contact_address = Collection::create(ContactAddress::class, $addresses);
 
+        if ($contact->groups !== null) {
+            $model->contactgroup = Collection::create(
+                Contactgroup::class,
+                array_map(fn($id) => new Contactgroup(['id' => $id]), $contact->groups)
+            );
+        }
+
         (new EntityManager($this->db))->save($model);
 
         return $model->id;
     }
 
     /**
-     * Update the given contact and perform a differential update on the associated addresses
+     * Update the given contact and perform a differential update on the associated addresses and groups
      *
      * @param ContactData $contact
      *
@@ -134,6 +142,10 @@ final class ContactRepository
                 'type' => $type,
                 'address' => $address
             ]))->setNew());
+        }
+
+        if ($contact->groups !== null) {
+            $model->contactgroup = array_map(fn($id) => new Contactgroup(['id' => $id]), $contact->groups);
         }
 
         (new EntityManager($this->db))->save($model);

--- a/library/Notifications/Repository/ContactRepository.php
+++ b/library/Notifications/Repository/ContactRepository.php
@@ -156,6 +156,7 @@ final class ContactRepository
 
         $model->contact_address = [];
         $model->contactgroup = []; // TODO: Unsure whether this is it or whether the manager should implicitly clean up
+        $model->external_uuid = null;
         $model->username = null;
         $model->delete();
 

--- a/test/php/application/controllers/ApiV1ContactGroupsTest.php
+++ b/test/php/application/controllers/ApiV1ContactGroupsTest.php
@@ -1207,6 +1207,41 @@ YAML;
     }
 
     #[DataProvider('apiTestBackends')]
+    public function testDeleteFreesTheIdentifier(Connection $db, Url $endpoint): void
+    {
+        $response = $this->sendRequest('DELETE', $endpoint, 'v1/contact-groups/' . BaseApiV1TestCase::GROUP_UUID);
+        $this->assertSame(204, $response->getStatusCode(), $response->getBody()->getContents());
+
+        // A deleted Contact Group must not occupy its identifier anymore, so it can be used for a new one
+        $response = $this->sendRequest(
+            'POST',
+            $endpoint,
+            'v1/contact-groups',
+            json: [
+                'id' => BaseApiV1TestCase::GROUP_UUID,
+                'name' => 'Test (recreated)'
+            ]
+        );
+        $content = $response->getBody()->getContents();
+
+        $this->assertSame(201, $response->getStatusCode(), $content);
+        $this->assertJsonStringEqualsJsonString(
+            $this->jsonEncodeSuccessMessage('Contact Group created successfully'),
+            $content
+        );
+
+        $response = $this->sendRequest('GET', $endpoint, 'v1/contact-groups/' . BaseApiV1TestCase::GROUP_UUID);
+        $content = $response->getBody()->getContents();
+
+        $this->assertSame(200, $response->getStatusCode(), $content);
+        $this->assertJsonStringEqualsJsonString($this->jsonEncodeResult([
+            'id' => BaseApiV1TestCase::GROUP_UUID,
+            'name' => 'Test (recreated)',
+            'users' => []
+        ]), $content);
+    }
+
+    #[DataProvider('apiTestBackends')]
     public function testDeleteWithFilter(Connection $db, Url $endpoint): void
     {
         $response = $this->sendRequest('DELETE', $endpoint, 'v1/contact-groups', ['name~*']);

--- a/test/php/application/controllers/ApiV1ContactsTest.php
+++ b/test/php/application/controllers/ApiV1ContactsTest.php
@@ -2042,6 +2042,46 @@ YAML;
     }
 
     #[DataProvider('apiTestBackends')]
+    public function testDeleteFreesTheIdentifier(Connection $db, Url $endpoint): void
+    {
+        $response = $this->sendRequest('DELETE', $endpoint, 'v1/contacts/' . BaseApiV1TestCase::CONTACT_UUID);
+        $this->assertSame(204, $response->getStatusCode(), $response->getBody()->getContents());
+
+        // A deleted contact must not occupy its identifier anymore, so it can be used for a new one
+        $response = $this->sendRequest(
+            'POST',
+            $endpoint,
+            'v1/contacts',
+            json: [
+                'id' => BaseApiV1TestCase::CONTACT_UUID,
+                'full_name' => 'Test (recreated)',
+                'default_channel' => BaseApiV1TestCase::CHANNEL_UUID,
+                'addresses' => ['email' => 'test@example.com']
+            ]
+        );
+        $content = $response->getBody()->getContents();
+
+        $this->assertSame(201, $response->getStatusCode(), $content);
+        $this->assertJsonStringEqualsJsonString(
+            $this->jsonEncodeSuccessMessage('Contact created successfully'),
+            $content
+        );
+
+        $response = $this->sendRequest('GET', $endpoint, 'v1/contacts/' . BaseApiV1TestCase::CONTACT_UUID);
+        $content = $response->getBody()->getContents();
+
+        $this->assertSame(200, $response->getStatusCode(), $content);
+        $this->assertJsonStringEqualsJsonString($this->jsonEncodeResult([
+            'id' => BaseApiV1TestCase::CONTACT_UUID,
+            'full_name' => 'Test (recreated)',
+            'username' => null,
+            'default_channel' => BaseApiV1TestCase::CHANNEL_UUID,
+            'groups' => [],
+            'addresses' => ['email' => 'test@example.com']
+        ]), $content);
+    }
+
+    #[DataProvider('apiTestBackends')]
     public function testDeleteWithFilter(Connection $db, Url $endpoint): void
     {
         $response = $this->sendRequest('DELETE', $endpoint, 'v1/contacts', ['name~*']);

--- a/test/php/application/controllers/ApiV1ContactsTest.php
+++ b/test/php/application/controllers/ApiV1ContactsTest.php
@@ -8,6 +8,7 @@ namespace Tests\Icinga\Module\Notifications\Controllers;
 use Icinga\Module\Notifications\Test\BaseApiV1TestCase;
 use Icinga\Web\Url;
 use ipl\Sql\Connection;
+use ipl\Sql\Select;
 use PHPUnit\Framework\Attributes\DataProvider;
 
 class ApiV1ContactsTest extends BaseApiV1TestCase
@@ -2079,6 +2080,51 @@ YAML;
             'groups' => [],
             'addresses' => ['email' => 'test@example.com']
         ]), $content);
+    }
+
+    #[DataProvider('apiTestBackends')]
+    public function testPutRestampsDroppedAddresses(Connection $db, Url $endpoint): void
+    {
+        $addresses = $db->fetchPairs(
+            (new Select())
+                ->from('contact_address ca')
+                ->columns(['ca.id', 'ca.changed_at'])
+                ->joinLeft('contact co', 'co.id = ca.contact_id')
+                ->where(['co.external_uuid = ?' => BaseApiV1TestCase::CONTACT_UUID])
+        );
+        $this->assertCount(1, $addresses, 'The contact should have exactly one seeded address');
+
+        // The default channel is a webhook one, hence no address is required at all
+        $response = $this->sendRequest(
+            'PUT',
+            $endpoint,
+            'v1/contacts/' . BaseApiV1TestCase::CONTACT_UUID,
+            json: [
+                'id' => BaseApiV1TestCase::CONTACT_UUID,
+                'full_name' => 'Test',
+                'default_channel' => BaseApiV1TestCase::CHANNEL_UUID_2,
+                'addresses' => []
+            ]
+        );
+
+        $this->assertSame(204, $response->getStatusCode(), $response->getBody()->getContents());
+
+        // A soft-deleted address must carry a fresh changed_at, otherwise the daemon never learns it's gone
+        $dropped = $db->fetchPairs(
+            (new Select())
+                ->from('contact_address')
+                ->columns(['id', 'changed_at'])
+                ->where(['id IN (?)' => array_keys($addresses), 'deleted = ?' => 'y'])
+        );
+
+        $this->assertSame(array_keys($addresses), array_keys($dropped), 'The address should be soft-deleted');
+        foreach ($dropped as $id => $changedAt) {
+            $this->assertGreaterThan(
+                $addresses[$id],
+                $changedAt,
+                'The changed_at of a soft-deleted address must have been bumped'
+            );
+        }
     }
 
     #[DataProvider('apiTestBackends')]

--- a/test/php/library/Notifications/Repository/ChannelRepositoryTest.php
+++ b/test/php/library/Notifications/Repository/ChannelRepositoryTest.php
@@ -201,6 +201,7 @@ class ChannelRepositoryTest extends TestCase
         $stored = $this->loadRawEntity($db, $id, Channel::class);
         $this->assertNotNull($stored, 'The channel row should still exist');
         $this->assertSame('y', $stored->deleted, 'The channel should be soft-deleted, not removed');
+        $this->assertNull($stored->external_uuid, 'The channel\'s external uuid should be cleared on deletion');
     }
 
     #[DataProvider('sharedDatabases')]

--- a/test/php/library/Notifications/Repository/ContactGroupRepositoryTest.php
+++ b/test/php/library/Notifications/Repository/ContactGroupRepositoryTest.php
@@ -208,11 +208,10 @@ class ContactGroupRepositoryTest extends TestCase
         $repository->delete($groupId);
 
         $this->assertNull($repository->find($groupId), 'The group should have been deleted');
-        $this->assertSame(
-            'y',
-            $this->loadRawEntity($db, $groupId, Contactgroup::class)->deleted,
-            'The group should be soft-deleted'
-        );
+
+        $group = $this->loadRawEntity($db, $groupId, Contactgroup::class);
+        $this->assertSame('y', $group->deleted, 'The group should be soft-deleted');
+        $this->assertNull($group->external_uuid, 'The group\'s external uuid should be cleared on deletion');
     }
 
     #[DataProvider('sharedDatabases')]

--- a/test/php/library/Notifications/Repository/ContactGroupRepositoryTest.php
+++ b/test/php/library/Notifications/Repository/ContactGroupRepositoryTest.php
@@ -115,6 +115,17 @@ class ContactGroupRepositoryTest extends TestCase
     }
 
     #[DataProvider('sharedDatabases')]
+    public function testCreateStoresTheGivenExternalUuid(Connection $db): void
+    {
+        // The V1 API lets clients choose the UUID a group is referenced by, so a given one must win
+        // over a generated one
+        $uuid = '00000000-0000-4000-8000-0000000000e1';
+        $id = (new ContactGroupRepository($db))->create(new ContactGroupData(null, 'Group A', [], $uuid));
+
+        $this->assertSame($uuid, (new ContactGroupRepository($db))->find($id)->external_uuid);
+    }
+
+    #[DataProvider('sharedDatabases')]
     public function testUpdateSyncsNameAndMembers(Connection $db): void
     {
         $repository = new ContactGroupRepository($db);

--- a/test/php/library/Notifications/Repository/ContactRepositoryTest.php
+++ b/test/php/library/Notifications/Repository/ContactRepositoryTest.php
@@ -66,6 +66,27 @@ class ContactRepositoryTest extends TestCase
     }
 
     /**
+     * Get the ids of the contact groups the contact is currently (non-deleted) a member of, sorted
+     *
+     * @param Connection $db
+     * @param int $contactId
+     *
+     * @return list<int>
+     */
+    private function groupsOf(Connection $db, int $contactId): array
+    {
+        $groups = [];
+        $query = ContactgroupMember::on($db)
+            ->filter(Filter::equal('contact_id', $contactId))
+            ->orderBy('contactgroup_id');
+        foreach ($query as $member) {
+            $groups[] = (int) $member->contactgroup_id;
+        }
+
+        return $groups;
+    }
+
+    /**
      * Get the contact's non-deleted addresses as a type => address map
      *
      * @param Connection $db
@@ -158,6 +179,95 @@ class ContactRepositoryTest extends TestCase
 
         $this->assertNull($repository->find($first)->username, 'The first contact\'s username must be null');
         $this->assertNull($repository->find($second)->username, 'The second contact\'s username must be null');
+    }
+
+    #[DataProvider('sharedDatabases')]
+    public function testCreateStoresTheGivenExternalUuid(Connection $db): void
+    {
+        // The V1 API lets clients choose the UUID a contact is referenced by, so a given one must win
+        // over a generated one
+        $uuid = '00000000-0000-4000-8000-0000000000e1';
+        $id = (new ContactRepository($db))->create(new ContactData(
+            null,
+            'Chosen',
+            'chosen',
+            self::$channelId,
+            [],
+            externalUuid: $uuid
+        ));
+
+        $this->assertSame($uuid, (new ContactRepository($db))->find($id)->external_uuid);
+    }
+
+    #[DataProvider('sharedDatabases')]
+    public function testCreateStoresTheGroupMemberships(Connection $db): void
+    {
+        $repository = new ContactRepository($db);
+        $groupRepository = new ContactGroupRepository($db);
+        $groupId = $groupRepository->create(new ContactGroupData(null, 'Group'));
+
+        $id = $repository->create(new ContactData(null, 'Member', 'member', self::$channelId, [], [$groupId]));
+
+        $this->assertSame([$groupId], $this->groupsOf($db, $id), 'The contact was not linked to the group');
+    }
+
+    #[DataProvider('sharedDatabases')]
+    public function testUpdatePerformsADifferentialGroupUpdate(Connection $db): void
+    {
+        $repository = new ContactRepository($db);
+        $groupRepository = new ContactGroupRepository($db);
+        $dropped = $groupRepository->create(new ContactGroupData(null, 'Dropped'));
+        $retained = $groupRepository->create(new ContactGroupData(null, 'Retained'));
+        $added = $groupRepository->create(new ContactGroupData(null, 'Added'));
+
+        $id = $repository->create(
+            new ContactData(null, 'Member', 'member', self::$channelId, [], [$dropped, $retained])
+        );
+
+        $repository->update(new ContactData(
+            $id,
+            'Member',
+            'member',
+            self::$channelId,
+            [],
+            [$retained, $added]
+        ));
+
+        $this->assertSame(
+            [$retained, $added],
+            $this->groupsOf($db, $id),
+            'The membership set was not synced (kept, added, removed)'
+        );
+
+        // A membership that is re-established must revive the soft-deleted link instead of inserting a
+        // second one, as (contactgroup_id, contact_id) is the primary key of contactgroup_member
+        $repository->update(new ContactData(
+            $id,
+            'Member',
+            'member',
+            self::$channelId,
+            [],
+            [$dropped, $retained, $added]
+        ));
+
+        $this->assertSame(
+            [$dropped, $retained, $added],
+            $this->groupsOf($db, $id),
+            'A dropped membership was not revived'
+        );
+    }
+
+    #[DataProvider('sharedDatabases')]
+    public function testUpdateLeavesGroupMembershipsUntouchedIfNotGiven(Connection $db): void
+    {
+        // The contact form doesn't manage memberships, hence NULL must not be mistaken for "no groups"
+        $repository = new ContactRepository($db);
+        $groupId = (new ContactGroupRepository($db))->create(new ContactGroupData(null, 'Group'));
+        $id = $repository->create(new ContactData(null, 'Member', 'member', self::$channelId, [], [$groupId]));
+
+        $repository->update(new ContactData($id, 'Member Renamed', 'member', self::$channelId, []));
+
+        $this->assertSame([$groupId], $this->groupsOf($db, $id), 'The memberships should have been left alone');
     }
 
     #[DataProvider('sharedDatabases')]

--- a/test/php/library/Notifications/Repository/ContactRepositoryTest.php
+++ b/test/php/library/Notifications/Repository/ContactRepositoryTest.php
@@ -245,7 +245,7 @@ class ContactRepositoryTest extends TestCase
     }
 
     #[DataProvider('sharedDatabases')]
-    public function testDeleteNullsTheUsername(Connection $db): void
+    public function testDeleteNullsTheUsernameAndExternalUUID(Connection $db): void
     {
         $repository = new ContactRepository($db);
         $id = $repository->create(new ContactData(null, 'Named', 'named', self::$channelId, []));
@@ -256,6 +256,7 @@ class ContactRepositoryTest extends TestCase
         $contact = $this->loadRawEntity($db, $id, Contact::class);
         $this->assertSame('y', $contact->deleted);
         $this->assertNull($contact->username, 'The unique username must be nulled on deletion so it can be reused');
+        $this->assertNull($contact->external_uuid, 'The contact\'s external_uuid should be cleared on deletion');
     }
 
     #[DataProvider('sharedDatabases')]


### PR DESCRIPTION
Repositories are now the central component for each entity to handle updates. In order to not keep duplicated code and avoid accidental deviations in how updates are persisted the api endpoints now use the repositories as well.

Requires the database schema to support `NULL` for all `external_uuid` columns (`contact`, `contactgroup` and `channel`) as previously the api did not allow to re-create such by re-using UUIDs.

requires https://github.com/Icinga/icinga-notifications/pull/482