### PR TITLE
Add `Incidents::getRoles()` method

### DIFF
--- a/library/Notifications/Integrations/Incidents.php
+++ b/library/Notifications/Integrations/Incidents.php
@@ -18,6 +18,9 @@ use ipl\Sql\Expression;
 use ipl\Stdlib\Filter;
 use IteratorAggregate;
 
+/**
+ * @implements IteratorAggregate<int, Incident>
+ */
 class Incidents implements IteratorAggregate, Countable
 {
     /** @var array<string, ?string> Required tags keyed by name; a null value requires the tag's absence */
@@ -92,7 +95,13 @@ class Incidents implements IteratorAggregate, Countable
      */
     public function hasIncident(): bool
     {
-        return $this->incidents()->hasResult();
+        if ($this->results !== null) {
+            return $this->incidents()->hasResult();
+        }
+
+        return $this->buildQuery()
+            ->columns([new Expression('1')])
+            ->first() !== null;
     }
 
     /**
@@ -119,7 +128,8 @@ class Incidents implements IteratorAggregate, Countable
     /**
      * Yield an interaction wrapper for each of the object's incidents
      *
-     * @return Generator<Incident>
+     * @return Generator<mixed, mixed, Incident, void>
+     * @phpstan-return Generator<mixed, Incident, mixed, void>
      */
     public function getIterator(): Generator
     {
@@ -130,9 +140,12 @@ class Incidents implements IteratorAggregate, Countable
 
     public function count(): int
     {
-        return $this->buildQuery()->count();
+        return $this->incidents()->count();
     }
 
+    /**
+     * @return ResultSet<IncidentModel>
+     */
     private function incidents(): ResultSet
     {
         if ($this->results === null) {

--- a/library/Notifications/Integrations/Incidents.php
+++ b/library/Notifications/Integrations/Incidents.php
@@ -14,6 +14,7 @@ use Icinga\User;
 use ipl\Orm\Query;
 use ipl\Orm\ResultSet;
 use ipl\Sql\Connection;
+use ipl\Sql\Expression;
 use ipl\Stdlib\Filter;
 use IteratorAggregate;
 
@@ -92,6 +93,27 @@ class Incidents implements IteratorAggregate, Countable
     public function hasIncident(): bool
     {
         return $this->incidents()->hasResult();
+    }
+
+    /**
+     * Get the given user's current incident roles
+     *
+     * Returns a generator that yields {@see Incident} as key and the user's role as string.
+     * The role can either be 'manager', 'recipient' or 'subscriber'.
+     *
+     * @param User $user
+     *
+     * @return Generator<mixed, Incident, 'manager|recipient|subscriber', void>
+     * @phpstan-return Generator<Incident, 'manager|recipient|subscriber', mixed, void>
+     */
+    public function getRoles(User $user): Generator
+    {
+        $incidents = $this->buildQuery()
+            ->withColumns(['role' => 'incident_contact.role'])
+            ->filter(Filter::equal('contact.username', $user->getUsername()));
+        foreach ($incidents as $incident) {
+            yield new Incident($incident, $this->db) => $incident->role;
+        }
     }
 
     /**

--- a/test/php/library/Notifications/Integrations/IncidentsTest.php
+++ b/test/php/library/Notifications/Integrations/IncidentsTest.php
@@ -5,23 +5,71 @@
 
 namespace Tests\Icinga\Module\Notifications\Integrations;
 
+use DateTime;
 use Icinga\Module\Notifications\Integrations\Incident;
 use Icinga\Module\Notifications\Integrations\Incidents;
+use Icinga\Module\Notifications\Model\Incident as IncidentModel;
+use Icinga\Module\Notifications\Test\DbTestBackends;
+use Icinga\User;
 use ipl\Orm\Query;
+use ipl\Sql\Adapter\Pgsql;
+use ipl\Sql\Connection;
+use ipl\Sql\Test\SharedDatabases\TransactionIsolation;
+use ipl\Sql\Test\TestConnection;
 use ipl\Stdlib\Filter\Chain;
 use ipl\Stdlib\Filter\Condition;
 use ipl\Stdlib\Filter\Equal;
 use ipl\Stdlib\Filter\Unlike;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use ReflectionMethod;
-use Tests\Icinga\Module\Notifications\Lib\EntityManager\RecordingConnection;
+use ReflectionProperty;
 
+/**
+ * Tests for {@see Incidents}.
+ *
+ * The tests that execute a query run against real databases — once for MySQL and once for PostgreSQL (see
+ * {@see DbTestBackends} / `#[DataProvider('sharedDatabases')]`). Each of them runs inside its own transaction which is
+ * rolled back afterwards, so the incidents, objects and sources it seeds don't leak into the next test. The
+ * prerequisite channel a contact requires is seeded once per driver in {@see self::initializeNotificationsDb()} and
+ * its id captured into {@see self::$channelId} (the id can't be assumed as rolled-back transactions still advance
+ * the auto-increment).
+ *
+ * The tests that only assert on the filter {@see Incidents} constructs don't need a database at all and use a
+ * {@see TestConnection} instead.
+ */
+#[TransactionIsolation]
 class IncidentsTest extends TestCase
 {
-    /** @var array<string, true> Object ids seeded into the current test's database, keyed by hex id */
+    use DbTestBackends;
+
+    /** @var int Id of the channel seeded per driver (auto-increment drifts across rolled-back transactions) */
+    private static int $channelId;
+
+    /**
+     * Object ids seeded into the current test's database, keyed by source id and object id
+     *
+     * @var array<int, array<string, true>>
+     */
     private array $seededObjects = [];
 
-    private RecordingConnection $db;
+    /** @var Connection The database of the current test, set by every test using the shared databases */
+    private Connection $db;
+
+    protected static function initializeNotificationsDb(Connection $db): void
+    {
+        $db->insert('available_channel_type', [
+            'type' => 'email', 'name' => 'Email', 'version' => '1', 'author' => 'Test', 'config_attrs' => ''
+        ]);
+        $db->insert('channel', [
+            'external_uuid' => '00000000-0000-0000-0000-0000000000c1',
+            'name'          => 'Test',
+            'type'          => 'email',
+            'changed_at'    => (int) (new DateTime())->format('Uv')
+        ]);
+
+        self::$channelId = (int) $db->lastInsertId();
+    }
 
     /**
      * Reset the set of seeded object ids so each test starts with a fresh, empty database
@@ -29,7 +77,10 @@ class IncidentsTest extends TestCase
     protected function setUp(): void
     {
         $this->seededObjects = [];
-        $this->db = $this->createDatabase();
+
+        // The trait's own setUp() is not used as this class defines one, so the previous test's transaction
+        // has to be rolled back here
+        $this->rollbackChanges();
     }
 
     public function testBuildsAnEqualFilterForEachTagWithAValue(): void
@@ -58,12 +109,15 @@ class IncidentsTest extends TestCase
         $this->assertSame([[Unlike::class, 'recovered_at', '*']], $this->conditions($this->builtFilter([])));
     }
 
-    public function testGetIterator(): void
+    #[DataProvider('sharedDatabases')]
+    public function testGetIterator(Connection $db): void
     {
+        $this->db = $db;
+
         $this->seedIncident(1, ['host' => 'a']);
         $this->seedIncident(2, ['host' => 'b']);
 
-        $incidents = iterator_to_array(new Incidents([], $this->db), false);
+        $incidents = iterator_to_array(new Incidents([], $db), false);
 
         $this->assertCount(2, $incidents);
         foreach ($incidents as $incident) {
@@ -71,58 +125,149 @@ class IncidentsTest extends TestCase
         }
     }
 
-    public function testHasIncident(): void
+    #[DataProvider('sharedDatabases')]
+    public function testHasIncident(Connection $db): void
     {
-        $this->assertFalse((new Incidents([], $this->db))->hasIncident());
+        $this->db = $db;
+
+        $this->assertFalse((new Incidents([], $db))->hasIncident());
 
         $this->seedIncident(1, ['host' => 'a']);
 
-        $this->assertTrue((new Incidents([], $this->db))->hasIncident());
+        $this->assertTrue((new Incidents([], $db))->hasIncident());
     }
 
-    public function testIteratingAfterHasIncidentYieldsAllMatchesFromTheSameInstance(): void
+    #[DataProvider('sharedDatabases')]
+    public function testGetRolesYieldsTheUsersRoleForEachIncidentTheyAreInvolvedIn(Connection $db): void
     {
+        $this->db = $db;
+
+        $managed = $this->seedIncident(1, ['host' => 'a']);
+        $subscribed = $this->seedIncident(2, ['host' => 'b']);
+        $foreign = $this->seedIncident(3, ['host' => 'c']);
+
+        $jdoe = $this->seedContact('jdoe');
+        $this->seedRole($managed, $jdoe, 'manager');
+        $this->seedRole($subscribed, $jdoe, 'subscriber');
+        $this->seedRole($foreign, $this->seedContact('jane'), 'recipient');
+
+        $roles = [];
+        foreach ((new Incidents([], $db))->getRoles(new User('jdoe')) as $incident => $role) {
+            $roles[$this->incidentId($incident)] = $role;
+        }
+
+        ksort($roles);
+
+        $expected = [$managed => 'manager', $subscribed => 'subscriber'];
+        ksort($expected);
+
+        $this->assertSame($expected, $roles, 'getRoles() did not yield the user\'s role for each of their incidents');
+    }
+
+    #[DataProvider('sharedDatabases')]
+    public function testGetRolesIgnoresClosedIncidents(Connection $db): void
+    {
+        $this->db = $db;
+
+        $recovered = $this->seedIncident(1, ['host' => 'a'], 1_700_000_000_000);
+        $this->seedRole($recovered, $this->seedContact('jdoe'), 'manager');
+
+        $this->assertSame([], iterator_to_array((new Incidents([], $db))->getRoles(new User('jdoe'))));
+    }
+
+    #[DataProvider('sharedDatabases')]
+    public function testGetRolesYieldsNothingForAUserWithoutIncidents(Connection $db): void
+    {
+        $this->db = $db;
+
+        $this->seedRole($this->seedIncident(1, ['host' => 'a']), $this->seedContact('jane'), 'manager');
+
+        $this->assertSame([], iterator_to_array((new Incidents([], $db))->getRoles(new User('jdoe'))));
+    }
+
+    #[DataProvider('sharedDatabases')]
+    public function testIteratingAfterHasIncidentYieldsAllMatchesFromTheSameInstance(Connection $db): void
+    {
+        $this->db = $db;
+
         $this->seedIncident(1, ['host' => 'a']);
         $this->seedIncident(2, ['host' => 'b']);
 
-        $incidents = new Incidents([], $this->db);
+        $incidents = new Incidents([], $db);
 
         $this->assertTrue($incidents->hasIncident());
         $this->assertCount(2, iterator_to_array($incidents, false));
     }
 
-    public function testCount(): void
+    #[DataProvider('sharedDatabases')]
+    public function testCount(Connection $db): void
     {
+        $this->db = $db;
+
         $this->seedIncident(1, ['host' => 'a']);
 
-        $this->assertEquals(1, (new Incidents([], $this->db))->count());
+        $this->assertEquals(1, (new Incidents([], $db))->count());
     }
 
-    public function testExcludesClosedIncidents(): void
+    #[DataProvider('sharedDatabases')]
+    public function testExcludesClosedIncidents(Connection $db): void
     {
+        $this->db = $db;
+
         // A recovered (closed) incident must never be yielded — the integration only deals with open
         // incidents (recovered_at IS NULL).
         $this->seedIncident(1, ['host' => 'a']);
         $this->seedIncident(2, ['host' => 'b'], 1_700_000_000_000);
 
-        $incidents = new Incidents([], $this->db);
+        $incidents = new Incidents([], $db);
 
         $this->assertEquals(1, $incidents->count());
         $this->assertCount(1, iterator_to_array($incidents, false));
     }
 
+    #[DataProvider('sharedDatabases')]
+    public function testMatchesTheIncidentsOfObjectsCarryingAllGivenTags(Connection $db): void
+    {
+        $this->db = $db;
+
+        $host = $this->seedIncident(1, ['host' => 'a']);
+        $service = $this->seedIncident(1, ['host' => 'a', 'service' => 'http']);
+        $this->seedIncident(1, ['host' => 'b']);
+
+        // The host's incident and the one of its service, matched by the tag they have in common
+        $this->assertSame(
+            [$host, $service],
+            $this->incidentIds(new Incidents(['host' => 'a'], $db)),
+            'Not all incidents of the objects carrying the given tag were matched'
+        );
+
+        // Only the host's incident, as a null value requires the tag's absence
+        $this->assertSame(
+            [$host],
+            $this->incidentIds(new Incidents(['host' => 'a', 'service' => null], $db)),
+            'A tag given as null did not exclude the objects carrying it'
+        );
+
+        // Only the service's incident, as its object is the only one carrying both tags
+        $this->assertSame(
+            [$service],
+            $this->incidentIds(new Incidents(['host' => 'a', 'service' => 'http'], $db)),
+            'Not only the incidents of the object carrying all given tags were matched'
+        );
+    }
+
     /**
      * Build the query {@see Incidents} would run for the given tags and return its filter
      *
-     * The query is never executed: with tags it compiles to multi-argument COUNT(DISTINCT …) subqueries
-     * that only MySQL and PostgreSQL support, not the sqlite the test database uses. Asserting on the
-     * filter the integration constructs is this unit's responsibility; turning it into SQL is ipl-orm's.
+     * The query is never executed. Asserting on the filter the integration constructs is this unit's
+     * responsibility, turning it into SQL is ipl-orm's, which is why a connection-less test database is
+     * sufficient here.
      *
      * @param array<string, ?string> $tags
      */
     private function builtFilter(array $tags): Chain
     {
-        $incidents = new Incidents($tags, $this->db);
+        $incidents = new Incidents($tags, new TestConnection());
 
         /** @var Query $query */
         $query = (new ReflectionMethod($incidents, 'buildQuery'))->invoke($incidents);
@@ -147,24 +292,33 @@ class IncidentsTest extends TestCase
     }
 
     /**
-     * Stand up an in-memory SQLite database with the incident, object and object_id_tag tables that
-     * {@see Incidents} reads from, and return it so tests can seed it and hand it to the unit under test.
+     * Get the ids of the incidents the given instance yields, sorted for order-independent assertions
+     *
+     * @return list<int>
      */
-    private function createDatabase(): RecordingConnection
+    private function incidentIds(Incidents $incidents): array
     {
-        $db = new RecordingConnection(['db' => 'sqlite', 'dbname' => ':memory:']);
-        $db->exec(
-            'CREATE TABLE object (id BLOB PRIMARY KEY, source_id INTEGER, name VARCHAR, url VARCHAR);'
-        );
-        $db->exec(
-            'CREATE TABLE object_id_tag (object_id BLOB, tag VARCHAR, value VARCHAR, PRIMARY KEY (object_id, tag));'
-        );
-        $db->exec(
-            'CREATE TABLE incident (id INTEGER PRIMARY KEY AUTOINCREMENT, object_id BLOB, started_at INTEGER,'
-            . ' recovered_at INTEGER, severity VARCHAR, mute_reason VARCHAR);'
-        );
+        $ids = [];
+        foreach ($incidents as $incident) {
+            $ids[] = $this->incidentId($incident);
+        }
 
-        return $db;
+        sort($ids);
+
+        return $ids;
+    }
+
+    /**
+     * Get the id of the incident the given wrapper manages
+     *
+     * The wrapper doesn't expose it, but the tests need it to tell the seeded incidents apart.
+     */
+    private function incidentId(Incident $incident): int
+    {
+        /** @var IncidentModel $model */
+        $model = (new ReflectionProperty($incident, 'incident'))->getValue($incident);
+
+        return $model->id;
     }
 
     /**
@@ -173,17 +327,55 @@ class IncidentsTest extends TestCase
      *
      * @param array<string, string> $tags
      * @param ?int $recoveredAt Recovery time in milliseconds; null leaves the incident open
+     *
+     * @return int The id of the inserted incident
      */
-    private function seedIncident(int $sourceId, array $tags, ?int $recoveredAt = null): void
+    private function seedIncident(int $sourceId, array $tags, ?int $recoveredAt = null): int
     {
         $objectId = $this->objectId($sourceId, $tags);
 
         $this->seedObject($sourceId, $tags, $objectId);
 
+        $now = (int) (new DateTime())->format('Uv');
+
         $this->db->insert('incident', [
-            'object_id'    => hex2bin($objectId),
+            'object_id'    => $objectId,
             'severity'     => 'crit',
-            'recovered_at' => $recoveredAt,
+            'started_at'   => ($recoveredAt ?? $now) - 1000,
+            'recovered_at' => $recoveredAt
+        ]);
+
+        return (int) $this->db->lastInsertId();
+    }
+
+    /**
+     * Insert a contact with the given username and return its id
+     */
+    private function seedContact(string $username): int
+    {
+        $this->db->insert('contact', [
+            'external_uuid'      => sprintf('00000000-0000-0000-0000-%012x', crc32($username)),
+            'full_name'          => $username,
+            'username'           => $username,
+            'default_channel_id' => self::$channelId,
+            'changed_at'         => (int) (new DateTime())->format('Uv')
+        ]);
+
+        return (int) $this->db->lastInsertId();
+    }
+
+    /**
+     * Make the given contact a recipient, subscriber or manager of the given incident
+     *
+     * @param string $role One of `recipient`, `subscriber` or `manager`
+     */
+    private function seedRole(int $incidentId, int $contactId, string $role): void
+    {
+        $this->db->insert('incident_contact', [
+            'incident_id' => $incidentId,
+            'contact_id'  => $contactId,
+            'role'        => $role,
+            'changed_at'  => (int) (new DateTime())->format('Uv')
         ]);
     }
 
@@ -194,44 +386,63 @@ class IncidentsTest extends TestCase
      * only has to be deterministic and collision-free across distinct (source, tags) combinations so
      * the seeded incident and object_id_tag rows share one id while distinct objects differ.
      *
+     * The id is returned in the representation the current database expects for a binary literal, as
+     * the tests seed the tables directly, i.e. without the ORM's Binary behavior in between.
+     *
      * @param array<string, string> $tags
      */
     private function objectId(int $sourceId, array $tags): string
     {
         ksort($tags);
 
-        return hash('sha256', $sourceId . "\0" . serialize($tags));
+        $hash = hash('sha256', $sourceId . "\0" . serialize($tags));
+
+        if ($this->db->getAdapter() instanceof Pgsql) {
+            return sprintf('\\x%s', $hash);
+        }
+
+        return hex2bin($hash);
     }
 
     /**
      * Insert the object row and the object_id_tag rows that represent the object for the given tags,
      * unless they already exist — the same object backs every incident sharing its id.
      *
-     * The object id is stored as the raw bytes the Binary behavior compares against.
+     * The source the object belongs to is created as well, once per test and source id.
      *
      * @param array<string, string> $tags
      */
     private function seedObject(int $sourceId, array $tags, string $objectId): void
     {
-        if (isset($this->seededObjects[$objectId])) {
+        if (! isset($this->seededObjects[$sourceId])) {
+            $this->seededObjects[$sourceId] = [];
+
+            $this->db->insert('source', [
+                'id'                => $sourceId,
+                'type'              => 'test',
+                'name'              => 'test',
+                'listener_username' => sprintf('test_%d', $sourceId),
+                'changed_at'        => (int) (new DateTime())->format('Uv')
+            ]);
+        }
+
+        if (isset($this->seededObjects[$sourceId][$objectId])) {
             return;
         }
 
-        $this->seededObjects[$objectId] = true;
-
-        $rawId = hex2bin($objectId);
+        $this->seededObjects[$sourceId][$objectId] = true;
 
         $this->db->insert('object', [
-            'id'        => $rawId,
+            'id'        => $objectId,
             'source_id' => $sourceId,
-            'name'      => implode(', ', $tags),
+            'name'      => implode(', ', $tags)
         ]);
 
         foreach ($tags as $tag => $value) {
             $this->db->insert('object_id_tag', [
-                'object_id' => $rawId,
+                'object_id' => $objectId,
                 'tag'       => $tag,
-                'value'     => $value,
+                'value'     => $value
             ]);
         }
     }


### PR DESCRIPTION
This adds `Incidents::getRoles(\Icinga\User $user): \Generator` that allows to fetch all incidents and roles for the given user. It's a convenience method as it allows to quickly determine the current role of said user and doesn't rely on the previously only available iteration over all incidents.

An additional change, which should amplify the optimization benefit by this in https://github.com/Icinga/icingadb-web/pull/1392 is that `Incidents::hasIncident()` does not always query all incidents now just to answer the question that *any* incident exists.

requires https://github.com/Icinga/ipl-orm/pull/169