### PR TITLE
Fix `Incidents::getRoles()`

### DIFF
--- a/library/Notifications/Integrations/Incidents.php
+++ b/library/Notifications/Integrations/Incidents.php
@@ -117,9 +117,12 @@ class Incidents implements IteratorAggregate, Countable
      */
     public function getRoles(User $user): Generator
     {
+        $filter = Filter::equal('incident_contact.contact.username', $user->getUsername());
+        $filter->metaData()->set('forceOptimization', false);
+
         $incidents = $this->buildQuery()
             ->withColumns(['role' => 'incident_contact.role'])
-            ->filter(Filter::equal('contact.username', $user->getUsername()));
+            ->filter($filter);
         foreach ($incidents as $incident) {
             yield new Incident($incident, $this->db) => $incident->role;
         }

--- a/test/php/library/Notifications/Integrations/IncidentsTest.php
+++ b/test/php/library/Notifications/Integrations/IncidentsTest.php
@@ -186,6 +186,24 @@ class IncidentsTest extends TestCase
     }
 
     #[DataProvider('sharedDatabases')]
+    public function testGetRolesYieldsOnlyTheRoleForTheGivenUser(Connection $db): void
+    {
+        $this->db = $db;
+
+        $incidentId = $this->seedIncident(1, ['host' => 'a']);
+        $this->seedRole($incidentId, $this->seedContact('jane'), 'manager');
+        $this->seedRole($incidentId, $this->seedContact('jdoe'), 'subscriber');
+        $this->seedRole($incidentId, $this->seedContact('bob'), 'recipient');
+
+        $roles = [];
+        foreach ((new Incidents(['host' => 'a'], $db))->getRoles(new User('jdoe')) as $incident => $role) {
+            $roles[] = [$this->incidentId($incident), $role];
+        }
+
+        $this->assertSame([[$incidentId, 'subscriber']], $roles);
+    }
+
+    #[DataProvider('sharedDatabases')]
     public function testIteratingAfterHasIncidentYieldsAllMatchesFromTheSameInstance(Connection $db): void
     {
         $this->db = $db;


### PR DESCRIPTION
`Incidents::getRoles()` can currently return several rows, keyed with `Incident` objects that share the same id, and may assign different roles to the given user.

The problem is that the current filter creates a subquery, that only checks if the given incident has an `incident_contact` row matching the `contact` with the given username. As long as this is the case, all `incident_contact` rows of the incident are contained in the result.

To fix this the `incident_contact.contact` relation is eagerly loaded, so the filter is no longer moved to a subquery and constrains the results.