### PR TITLE
Fix `ViewModeSwitcher` in `IncidentsController`

### DIFF
--- a/application/controllers/IncidentsController.php
+++ b/application/controllers/IncidentsController.php
@@ -5,6 +5,7 @@
 
 namespace Icinga\Module\Notifications\Controllers;
 
+use Icinga\Module\Icingadb\Web\Control\ViewModeSwitcher;
 use Icinga\Module\Notifications\Common\Auth;
 use Icinga\Module\Notifications\Common\Database;
 use Icinga\Module\Notifications\Model\Incident;
@@ -50,6 +51,7 @@ class IncidentsController extends CompatController
         $searchBar = $this->createSearchBar($incidents, [
             $limitControl->getLimitParam(),
             $sortControl->getSortParam(),
+            $viewModeSwitcher->getViewModeParam()
         ]);
 
         $this->handleControls($this->getServerRequest());
@@ -104,6 +106,7 @@ class IncidentsController extends CompatController
         $editor = $this->createSearchEditor(Incident::on(Database::get()), [
             LimitControl::DEFAULT_LIMIT_PARAM,
             SortControl::DEFAULT_SORT_PARAM,
+            ViewModeSwitcher::DEFAULT_VIEW_MODE_PARAM
         ]);
 
         $this->getDocument()->add($editor);


### PR DESCRIPTION
Currently submitting the `SearchEditor` removes a present view-mode param from the Url.

To fix this it is added to the preserve params.