### PR TITLE
Support multiple related sources

### DIFF
--- a/application/controllers/EventRuleController.php
+++ b/application/controllers/EventRuleController.php
@@ -15,7 +15,6 @@ use Icinga\Module\Notifications\Common\SourceHookLocator;
 use Icinga\Module\Notifications\Data\NotificationConfigProvider;
 use Icinga\Module\Notifications\Forms\EventRuleConfigForm;
 use Icinga\Module\Notifications\Forms\EventRuleForm;
-use Icinga\Module\Notifications\Forms\SourceForm;
 use Icinga\Module\Notifications\Hook\V2\SourceHook;
 use Icinga\Module\Notifications\Model\Rule;
 use Icinga\Module\Notifications\Model\Source;
@@ -127,7 +126,7 @@ class EventRuleController extends CompatController
                         $this->addPart($form->prepareObjectFilterUpdate($this->session->get('object_filter')));
                         $this->addPart($form->prepareConfigUpdate(
                             $this->session->get('name'),
-                            $this->session->get('source')
+                            $this->session->get('source_type')
                         ));
                         $this->addPart(Html::tag('div', ['id' => 'event-rule-config-name'], [
                             Html::tag('h2', $this->session->get('name')),
@@ -140,7 +139,7 @@ class EventRuleController extends CompatController
                     } else {
                         $this->addPart($form->prepareConfigUpdate(
                             $this->session->get('name'),
-                            $this->session->get('source')
+                            $this->session->get('source_type')
                         ));
                         $this->addPart($form->prepareObjectFilterUpdate($this->session->get('object_filter')));
                     }
@@ -155,15 +154,15 @@ class EventRuleController extends CompatController
                     $form->setRule($rule);
 
                     $this->session->set('name', $rule->name);
-                    $this->session->set('source', $rule->source_id);
+                    $this->session->set('source_type', $rule->source_type);
                     $this->session->set('object_filter', $rule->object_filter ?? '');
                 } else {
                     $name = $this->params->getRequired('name');
-                    $source = (int) $this->params->getRequired('source');
-                    $form->populate(['name' => $name, 'source' => $source]);
+                    $source = $this->params->getRequired('source_type');
+                    $form->populate(['name' => $name, 'source_type' => $source]);
 
                     $this->session->set('name', $name);
-                    $this->session->set('source', $source);
+                    $this->session->set('source_type', $source);
                     $this->session->set('object_filter', '');
                 }
             })
@@ -204,7 +203,6 @@ class EventRuleController extends CompatController
     {
         $ruleId = (int) $this->params->getRequired('id');
         $filter = $this->params->get('object_filter', $this->session->get('object_filter'));
-        $hook = $this->resolveSourceHook($ruleId);
 
         $parsedFilter = null;
         if ($filter) {
@@ -230,6 +228,8 @@ class EventRuleController extends CompatController
                 ));
             }
         }
+
+        $hook = $this->resolveSourceHook($ruleId, (bool) ($parsedFilter['assisted'] ?? false));
 
         $editor = (new SearchEditor())
             ->addAttributes(Attributes::create(['class' => 'event-rule-filter']))
@@ -317,11 +317,17 @@ class EventRuleController extends CompatController
             };
         }
 
-        $editor->on(Form::ON_SUBMIT, function (SearchEditor $form) use ($ruleId, $getJsonPaths) {
+        $assisted = $hook !== null;
+        $editor->on(Form::ON_SUBMIT, function (SearchEditor $form) use ($ruleId, $getJsonPaths, $assisted) {
             $filter = $form->getFilter();
             $this->session->set(
                 'object_filter',
-                (new RuleSerializer($filter, $getJsonPaths($filter), $form->getValue('filter_name')))->getJson()
+                (new RuleSerializer(
+                    $filter,
+                    $getJsonPaths($filter),
+                    $assisted,
+                    $form->getValue('filter_name')
+                ))->getJson()
             );
             $this->redirectNow(Links::eventRule($ruleId)->setParam('_filterOnly'));
         })->handleRequest($this->getServerRequest());
@@ -349,7 +355,7 @@ class EventRuleController extends CompatController
 
     public function suggestAction(): void
     {
-        $hook = $this->resolveSourceHook((int) $this->params->getRequired('id'));
+        $hook = $this->resolveSourceHook((int) $this->params->getRequired('id'), true);
         $requestData = SearchSuggestions::parseRequest($this->getServerRequest()) ?? [];
 
         $type = $requestData['term']['type'] ?? null;
@@ -382,37 +388,31 @@ class EventRuleController extends CompatController
         $this->getDocument()->addHtml($suggestions);
     }
 
-    protected function resolveSourceHook(int $ruleId): ?SourceHook
+    protected function resolveSourceHook(int $ruleId, bool $required): ?SourceHook
     {
-        $source = null;
-        if ($ruleId !== -1) {
-            $source = Rule::on(Database::get())
-                ->columns(['id' => 'source.id', 'type' => 'source.type'])
+        $type = $this->session->get('source_type');
+        if ($type === null && $ruleId !== -1) {
+            $type = Rule::on(Database::get())
+                ->columns(['source_type'])
                 ->filter(Filter::equal('id', $ruleId))
-                ->first();
-        } elseif (isset($this->session->source)) {
-            /** @var ?Source $source */
-            $source = Source::on(Database::get())
-                ->columns(['id', 'type'])
-                ->filter(Filter::equal('id', $this->session->source))
-                ->first();
+                ->first()?->source_type;
         }
 
-        if ($source === null) {
+        if ($type === null) {
             $this->httpNotFound($this->translate('Rule not found'));
         }
 
-        if ($source->type === SourceForm::TYPE_GENERIC) {
-            return null;
-        }
+        $hook = SourceHookLocator::forType($type);
 
-        $hook = SourceHookLocator::forType($source->type);
+        if (! $required) {
+            return $hook;
+        }
 
         if ($hook === null) {
             $this->httpNotFound(sprintf($this->translate(
                 'No source integration available. Either the module supporting sources of type "%s" is not'
                 . ' enabled or you have insufficient privileges. Please contact your system administrator.'
-            ), $source->type));
+            ), $type));
         }
 
         return $hook;
@@ -424,22 +424,22 @@ class EventRuleController extends CompatController
 
         $eventRuleForm = (new EventRuleForm())
             ->setCsrfCounterMeasureId(Session::getSession()->getId())
-            ->setAvailableSources(
-                Database::get()->fetchPairs(
-                    Source::on(Database::get())->columns(['id', 'name'])->assembleSelect()
+            ->setAvailableSourceTypes(
+                Database::get()->fetchCol(
+                    Source::on(Database::get())->columns(['type'])->assembleSelect()->distinct()
                 )
             )
             ->populate([
                 'name' => $this->session->get('name'),
-                'source' => $this->session->get('source')
+                'source_type' => $this->session->get('source_type')
             ])
             ->setAction(Url::fromRequest()->getAbsoluteUrl())
             ->on(Form::ON_SUBMIT, function ($form) use ($ruleId) {
                 $this->session->set('name', $form->getValue('name'));
 
-                $newSource = (int) $form->getValue('source');
-                if ($newSource !== $this->session->get('source')) {
-                    $this->session->set('source', $newSource);
+                $newSource = $form->getValue('source_type');
+                if ($newSource !== $this->session->get('source_type')) {
+                    $this->session->set('source_type', $newSource);
                     $this->session->set('object_filter', '');
                 }
 

--- a/application/controllers/EventRuleController.php
+++ b/application/controllers/EventRuleController.php
@@ -127,7 +127,7 @@ class EventRuleController extends CompatController
                         $this->addPart($form->prepareObjectFilterUpdate($this->session->get('object_filter')));
                         $this->addPart($form->prepareConfigUpdate(
                             $this->session->get('name'),
-                            $this->session->get('source')
+                            $this->session->get('source_type')
                         ));
                         $this->addPart(Html::tag('div', ['id' => 'event-rule-config-name'], [
                             Html::tag('h2', $this->session->get('name')),
@@ -140,7 +140,7 @@ class EventRuleController extends CompatController
                     } else {
                         $this->addPart($form->prepareConfigUpdate(
                             $this->session->get('name'),
-                            $this->session->get('source')
+                            $this->session->get('source_type')
                         ));
                         $this->addPart($form->prepareObjectFilterUpdate($this->session->get('object_filter')));
                     }
@@ -155,15 +155,15 @@ class EventRuleController extends CompatController
                     $form->setRule($rule);
 
                     $this->session->set('name', $rule->name);
-                    $this->session->set('source', $rule->source_id);
+                    $this->session->set('source_type', $rule->source_type);
                     $this->session->set('object_filter', $rule->object_filter ?? '');
                 } else {
                     $name = $this->params->getRequired('name');
-                    $source = (int) $this->params->getRequired('source');
-                    $form->populate(['name' => $name, 'source' => $source]);
+                    $source = $this->params->getRequired('source_type');
+                    $form->populate(['name' => $name, 'source_type' => $source]);
 
                     $this->session->set('name', $name);
-                    $this->session->set('source', $source);
+                    $this->session->set('source_type', $source);
                     $this->session->set('object_filter', '');
                 }
             })
@@ -384,35 +384,31 @@ class EventRuleController extends CompatController
 
     protected function resolveSourceHook(int $ruleId): ?SourceHook
     {
-        $source = null;
+        $type = null;
         if ($ruleId !== -1) {
-            $source = Rule::on(Database::get())
-                ->columns(['id' => 'source.id', 'type' => 'source.type'])
+            $type = Rule::on(Database::get())
+                ->columns(['source_type'])
                 ->filter(Filter::equal('id', $ruleId))
-                ->first();
-        } elseif (isset($this->session->source)) {
-            /** @var ?Source $source */
-            $source = Source::on(Database::get())
-                ->columns(['id', 'type'])
-                ->filter(Filter::equal('id', $this->session->source))
-                ->first();
+                ->first()?->source_type;
+        } elseif (isset($this->session->source_type)) {
+            $type = $this->session->source_type;
         }
 
-        if ($source === null) {
+        if ($type === null) {
             $this->httpNotFound($this->translate('Rule not found'));
         }
 
-        if ($source->type === SourceForm::TYPE_GENERIC) {
+        if ($type === SourceForm::TYPE_GENERIC) {
             return null;
         }
 
-        $hook = SourceHookLocator::forType($source->type);
+        $hook = SourceHookLocator::forType($type);
 
         if ($hook === null) {
             $this->httpNotFound(sprintf($this->translate(
                 'No source integration available. Either the module supporting sources of type "%s" is not'
                 . ' enabled or you have insufficient privileges. Please contact your system administrator.'
-            ), $source->type));
+            ), $type));
         }
 
         return $hook;
@@ -424,22 +420,26 @@ class EventRuleController extends CompatController
 
         $eventRuleForm = (new EventRuleForm())
             ->setCsrfCounterMeasureId(Session::getSession()->getId())
-            ->setAvailableSources(
-                Database::get()->fetchPairs(
-                    Source::on(Database::get())->columns(['id', 'name'])->assembleSelect()
+            ->setAvailableSourceTypes(
+                array_column(
+                    Database::get()->fetchAll(
+                        Source::on(Database::get())->columns(['type'])->assembleSelect()->distinct()
+                    ),
+                    'type',
+                    'type'
                 )
             )
             ->populate([
                 'name' => $this->session->get('name'),
-                'source' => $this->session->get('source')
+                'source_type' => $this->session->get('source_type')
             ])
             ->setAction(Url::fromRequest()->getAbsoluteUrl())
             ->on(Form::ON_SUBMIT, function ($form) use ($ruleId) {
                 $this->session->set('name', $form->getValue('name'));
 
-                $newSource = (int) $form->getValue('source');
-                if ($newSource !== $this->session->get('source')) {
-                    $this->session->set('source', $newSource);
+                $newSource = $form->getValue('source_type');
+                if ($newSource !== $this->session->get('source_type')) {
+                    $this->session->set('source_type', $newSource);
                     $this->session->set('object_filter', '');
                 }
 

--- a/application/controllers/EventRulesController.php
+++ b/application/controllers/EventRulesController.php
@@ -124,9 +124,9 @@ class EventRulesController extends CompatController
         $eventRuleForm = (new EventRuleForm())
             ->setIsNew()
             ->setCsrfCounterMeasureId(Session::getSession()->getId())
-            ->setAvailableSources(
-                Database::get()->fetchPairs(
-                    Source::on(Database::get())->columns(['id', 'name'])->assembleSelect()
+            ->setAvailableSourceTypes(
+                Database::get()->fetchCol(
+                    Source::on(Database::get())->columns(['type'])->assembleSelect()->distinct()
                 )
             )
             ->setAction(Url::fromRequest()->getAbsoluteUrl())
@@ -134,7 +134,7 @@ class EventRulesController extends CompatController
                 $this->getResponse()->setHeader('X-Icinga-Container', 'col2');
                 $this->redirectNow(Links::eventRule(-1)->addParams([
                     'name' => $form->getValue('name'),
-                    'source' => $form->getValue('source')
+                    'source_type' => $form->getValue('source_type')
                 ]));
             })->handleRequest($this->getServerRequest());
 

--- a/application/controllers/EventRulesController.php
+++ b/application/controllers/EventRulesController.php
@@ -124,9 +124,13 @@ class EventRulesController extends CompatController
         $eventRuleForm = (new EventRuleForm())
             ->setIsNew()
             ->setCsrfCounterMeasureId(Session::getSession()->getId())
-            ->setAvailableSources(
-                Database::get()->fetchPairs(
-                    Source::on(Database::get())->columns(['id', 'name'])->assembleSelect()
+            ->setAvailableSourceTypes(
+                array_column(
+                    Database::get()->fetchAll(
+                        Source::on(Database::get())->columns(['type'])->assembleSelect()->distinct()
+                    ),
+                    'type',
+                    'type'
                 )
             )
             ->setAction(Url::fromRequest()->getAbsoluteUrl())
@@ -134,7 +138,7 @@ class EventRulesController extends CompatController
                 $this->getResponse()->setHeader('X-Icinga-Container', 'col2');
                 $this->redirectNow(Links::eventRule(-1)->addParams([
                     'name' => $form->getValue('name'),
-                    'source' => $form->getValue('source')
+                    'source_type' => $form->getValue('source_type')
                 ]));
             })->handleRequest($this->getServerRequest());
 

--- a/application/controllers/IncidentController.php
+++ b/application/controllers/IncidentController.php
@@ -29,8 +29,8 @@ class IncidentController extends CompatController
         $id = $this->params->getRequired('id');
 
         $query = Incident::on(Database::get())
-            ->with(['object', 'object.source'])
-            ->withColumns('object.id_tags')
+            ->with('object')
+            ->withColumns(['object.id_tags', 'object.sources'])
             ->filter(Filter::equal('incident.id', $id));
 
         $this->applyRestrictions($query);

--- a/application/controllers/IncidentsController.php
+++ b/application/controllers/IncidentsController.php
@@ -33,8 +33,8 @@ class IncidentsController extends CompatController
         $this->addTitleTab(t('Incidents'));
 
         $incidents = Incident::on(Database::get())
-            ->with(['object', 'object.source'])
-            ->withColumns('object.id_tags');
+            ->with(['object'])
+            ->withColumns(['object.sources']);
 
         $limitControl = $this->createLimitControl();
         $sortControl = $this->createSortControl(

--- a/application/controllers/SourceController.php
+++ b/application/controllers/SourceController.php
@@ -8,11 +8,14 @@ namespace Icinga\Module\Notifications\Controllers;
 use Icinga\Module\Notifications\Common\Database;
 use Icinga\Module\Notifications\Forms\DeleteSourceForm;
 use Icinga\Module\Notifications\Forms\SourceForm;
+use Icinga\Module\Notifications\Model\Source;
 use Icinga\Module\Notifications\Repository\SourceRepository;
 use Icinga\Web\Notification;
 use Icinga\Web\Session;
 use ipl\Html\Contract\Form;
 use ipl\Sql\Connection;
+use ipl\Sql\Expression;
+use ipl\Stdlib\Filter;
 use ipl\Web\Compat\CompatController;
 use ipl\Web\Url;
 use RuntimeException;
@@ -70,14 +73,23 @@ class SourceController extends CompatController
             ->setCsrfCounterMeasureId(Session::getSession()->getId())
             ->setAction(Url::fromRequest()->getAbsoluteUrl())
             ->on(Form::ON_REQUEST, function ($_, DeleteSourceForm $form) use ($sourceId) {
-                $source = (new SourceRepository(Database::get()))
-                    ->find($sourceId);
+                $source = (new SourceRepository(Database::get()))->find($sourceId);
                 if ($source === null) {
                     $this->httpNotFound($this->translate('Source not found'));
                 }
 
                 $this->setTitle(sprintf($this->translate('Delete Source: %s'), $source->name));
-                $form->setLocked($source->locked);
+                $form->setLocked($source->locked)
+                    ->setLastOfItsType(
+                        Source::on(Database::get())
+                            ->columns([new Expression('1')])
+                            ->filter(
+                                Filter::all(
+                                    Filter::equal('type', $source->type),
+                                    Filter::unequal('id', $source->id)
+                                )
+                            )->limit(1)->first() === null
+                    );
                 $this->addContent($form);
             })
             ->on(Form::ON_SUBMIT, function () use ($sourceId): never {

--- a/application/controllers/SourceController.php
+++ b/application/controllers/SourceController.php
@@ -70,14 +70,15 @@ class SourceController extends CompatController
             ->setCsrfCounterMeasureId(Session::getSession()->getId())
             ->setAction(Url::fromRequest()->getAbsoluteUrl())
             ->on(Form::ON_REQUEST, function ($_, DeleteSourceForm $form) use ($sourceId) {
-                $source = (new SourceRepository(Database::get()))
-                    ->find($sourceId);
+                $sourceRepository = new SourceRepository(Database::get());
+                $source = $sourceRepository->find($sourceId);
                 if ($source === null) {
                     $this->httpNotFound($this->translate('Source not found'));
                 }
 
                 $this->setTitle(sprintf($this->translate('Delete Source: %s'), $source->name));
-                $form->setLocked($source->locked);
+                $form->setLocked($source->locked)
+                    ->setLastOfItsType($sourceRepository->isLastOfItsType($source));
                 $this->addContent($form);
             })
             ->on(Form::ON_SUBMIT, function () use ($sourceId): never {

--- a/application/forms/DeleteSourceForm.php
+++ b/application/forms/DeleteSourceForm.php
@@ -20,6 +20,9 @@ class DeleteSourceForm extends CompatForm
     /** @var bool Whether the source is locked */
     protected bool $locked = false;
 
+    /** @var bool Whether the source is the last remaining one of its type */
+    protected bool $isLastOfItsType = false;
+
     /**
      * Set whether the source is locked
      *
@@ -30,6 +33,20 @@ class DeleteSourceForm extends CompatForm
     public function setLocked(bool $locked = true): static
     {
         $this->locked = $locked;
+
+        return $this;
+    }
+
+    /**
+     * Set whether the source is the last of its type
+     *
+     * @param bool $lastOfItsType
+     *
+     * @return $this
+     */
+    public function setLastOfItsType(bool $lastOfItsType = true): static
+    {
+        $this->isLastOfItsType = $lastOfItsType;
 
         return $this;
     }
@@ -51,9 +68,17 @@ class DeleteSourceForm extends CompatForm
             new HtmlElement(
                 'li',
                 null,
-                Text::create($this->translate(
-                    'Deleting a source also removes all related event rules and stops event processing for it.'
-                ))
+                Text::create(
+                    $this->isLastOfItsType
+                        ? $this->translate(
+                            'Deleting this source stops event processing for it. As it is the last source of its'
+                            . ' type, all event rules configured for that type are deleted as well.'
+                        )
+                        : $this->translate(
+                            'Deleting this source stops event processing for it. Event rules stay intact,'
+                            . ' as other sources of the same type remain.'
+                        )
+                )
             ),
             new HtmlElement(
                 'li',

--- a/application/forms/EventRuleConfigForm.php
+++ b/application/forms/EventRuleConfigForm.php
@@ -63,7 +63,7 @@ class EventRuleConfigForm extends CompatForm
         $fields = [
             'id' => $rule->id,
             'name' => $rule->name,
-            'source' => $rule->source_id,
+            'source_type' => $rule->source_type,
             'object_filter' => $rule->object_filter
         ];
 
@@ -92,7 +92,7 @@ class EventRuleConfigForm extends CompatForm
         return new EscalationRule(
             $id,
             $this->getValue('name'),
-            (int) $this->getValue('source'),
+            $this->getValue('source_type'),
             $this->getValue('object_filter'),
             $this->getElement('escalations')->getEscalations($id)
         );
@@ -142,7 +142,7 @@ class EventRuleConfigForm extends CompatForm
 
         $name = $this->createElement('hidden', 'name', ['required' => true]);
         $this->registerElement($name);
-        $source = $this->createElement('hidden', 'source', ['required' => true]);
+        $source = $this->createElement('hidden', 'source_type', ['required' => true]);
         $this->registerElement($source);
 
         $this->addHtml(new HtmlElement(
@@ -209,17 +209,17 @@ class EventRuleConfigForm extends CompatForm
      * Get the element to update in case the config of the rule is changed
      *
      * @param string $newName
-     * @param int $newSource
+     * @param string $newSourceType
      *
      * @return ValidHtml
      */
-    public function prepareConfigUpdate(string $newName, int $newSource): ValidHtml
+    public function prepareConfigUpdate(string $newName, string $newSourceType): ValidHtml
     {
         return new HtmlElement(
             'div',
             Attributes::create(['id' => 'event-rule-config-form-name']),
             $this->createElement('hidden', 'name', ['required' => true, 'value' => $newName]),
-            $this->createElement('hidden', 'source', ['required' => true, 'value' => $newSource])
+            $this->createElement('hidden', 'source_type', ['required' => true, 'value' => $newSourceType])
         );
     }
 

--- a/application/forms/EventRuleForm.php
+++ b/application/forms/EventRuleForm.php
@@ -5,6 +5,7 @@
 
 namespace Icinga\Module\Notifications\Forms;
 
+use Icinga\Module\Notifications\Common\SourceHookLocator;
 use ipl\Html\FormDecoration\DescriptionDecorator;
 use ipl\I18n\Translation;
 use ipl\Web\Common\CsrfCounterMeasure;
@@ -15,22 +16,25 @@ class EventRuleForm extends CompatForm
     use CsrfCounterMeasure;
     use Translation;
 
-    /** @var array<int, string> */
-    protected array $sources = [];
+    /** @var array<string, string> */
+    protected array $sourceTypes = [];
 
     /** @var bool Whether this form is for a new rule */
     protected bool $isNew = false;
 
     /**
-     * Set the sources to choose from
+     * Set the source types to choose from
      *
-     * @param array<int, string> $sources
+     * @param string[] $sourceTypes
      *
      * @return $this
      */
-    public function setAvailableSources(array $sources): static
+    public function setAvailableSourceTypes(array $sourceTypes): static
     {
-        $this->sources = $sources;
+        $this->sourceTypes = [];
+        foreach ($sourceTypes as $type) {
+            $this->sourceTypes[$type] = SourceHookLocator::labelFor($type);
+        }
 
         return $this;
     }
@@ -61,17 +65,17 @@ class EventRuleForm extends CompatForm
             ]
         );
 
-        $this->addElement('select', 'source', [
-            'label' => $this->translate('Source'),
+        $this->addElement('select', 'source_type', [
+            'label' => $this->translate('Source Type'),
             'required' => true,
-            'options' => ['' => ' - ' . $this->translate('Please choose') . ' - '] + $this->sources,
+            'options' => ['' => ' - ' . $this->translate('Please choose') . ' - '] + $this->sourceTypes,
             'disabledOptions' => [''],
             'value' => ''
         ]);
         if (! $this->isNew) {
-            $this->getElement('source')
+            $this->getElement('source_type')
                 ->setDescription($this->translate(
-                    'Choosing a different source will reset all filters of the rule'
+                    'Choosing a different source type will reset all filters of the rule'
                 ))
                 ->getDecorators()
                 ->replaceDecorator('Description', DescriptionDecorator::class, ['class' => 'description']);

--- a/application/forms/EventRuleForm.php
+++ b/application/forms/EventRuleForm.php
@@ -15,22 +15,22 @@ class EventRuleForm extends CompatForm
     use CsrfCounterMeasure;
     use Translation;
 
-    /** @var array<int, string> */
-    protected array $sources = [];
+    /** @var array<string, string> */
+    protected array $sourceTypes = [];
 
     /** @var bool Whether this form is for a new rule */
     protected bool $isNew = false;
 
     /**
-     * Set the sources to choose from
+     * Set the source types to choose from
      *
-     * @param array<int, string> $sources
+     * @param array<string, string> $sourceTypes
      *
      * @return $this
      */
-    public function setAvailableSources(array $sources): static
+    public function setAvailableSourceTypes(array $sourceTypes): static
     {
-        $this->sources = $sources;
+        $this->sourceTypes = $sourceTypes;
 
         return $this;
     }
@@ -61,17 +61,17 @@ class EventRuleForm extends CompatForm
             ]
         );
 
-        $this->addElement('select', 'source', [
-            'label' => $this->translate('Source'),
+        $this->addElement('select', 'source_type', [
+            'label' => $this->translate('Source Type'),
             'required' => true,
-            'options' => ['' => ' - ' . $this->translate('Please choose') . ' - '] + $this->sources,
+            'options' => ['' => ' - ' . $this->translate('Please choose') . ' - '] + $this->sourceTypes,
             'disabledOptions' => [''],
             'value' => ''
         ]);
         if (! $this->isNew) {
-            $this->getElement('source')
+            $this->getElement('source_type')
                 ->setDescription($this->translate(
-                    'Choosing a different source will reset all filters of the rule'
+                    'Choosing a different source type will reset all filters of the rule'
                 ))
                 ->getDecorators()
                 ->replaceDecorator('Description', DescriptionDecorator::class, ['class' => 'description']);

--- a/application/forms/SourceForm.php
+++ b/application/forms/SourceForm.php
@@ -26,12 +26,6 @@ class SourceForm extends CompatForm
 {
     use CsrfCounterMeasure;
 
-    /** @var string The generic source type */
-    public const TYPE_GENERIC = 'generic';
-
-    /** @var string The type for sources with an integration */
-    private const TYPE_INTEGRATED = 'integrated';
-
     /**
      * Set the source to populate the form with
      *
@@ -55,7 +49,7 @@ class SourceForm extends CompatForm
     {
         return new SourceData(
             $this->getValue('id'),
-            $this->getValue('type', self::TYPE_GENERIC),
+            $this->getValue('type'),
             $this->getValue('name'),
             $this->getElement('credentials')->getValue('listener_username') ?: null,
             $this->getElement('credentials')->getValue('listener_password') ?: null,
@@ -94,10 +88,10 @@ class SourceForm extends CompatForm
             'p',
             Attributes::create(['class' => 'description']),
             Text::create($this->translate(
-                'Sources are the most vital part of Icinga Notifications. They submit events that will be'
-                . ' processed to notify users about incidents. You can either configure sources that provide an'
-                . ' integration in Icinga Web, or use the generic type for sources that communicate directly with'
-                . ' the Icinga Notifications API.'
+                'Sources are the most vital part of Icinga Notifications.'
+                . ' They submit events that will be processed to notify users about incidents.'
+                . ' You configure here how they relate to event rules and their credentials they will present to'
+                . ' communicate with the Icinga Notifications API.'
             ))
         ));
 
@@ -110,47 +104,30 @@ class SourceForm extends CompatForm
                 'disabled'  => $locked
             ]
         );
-        $this->addElement(
-            'select',
-            'source_type',
-            [
-                'ignore'    => true,
-                'required'  => true,
-                'label'     => $this->translate('Source Type'),
-                'value'     => self::TYPE_GENERIC,
-                'disabled'  => $locked,
-                'class'     => 'autosubmit',
-                'options'   => [
-                    self::TYPE_GENERIC    => $this->translate('Generic', 'notifications.source.type'),
-                    self::TYPE_INTEGRATED => $this->translate('Integrated', 'notifications.source.type')
-                ]
-            ]
-        );
 
-        if ($this->getPopulatedValue('source_type') === self::TYPE_INTEGRATED) {
-            $this->addHtml(
-                new HtmlElement(
-                    'p',
-                    Attributes::create(['class' => 'description']),
-                    Text::create(
-                        $this->translate(
-                            'Enter the source identifier as stated in the integration\'s documentation.'
-                            . ' Note that integrated sources usually provide their own configuration interface for'
-                            . ' notifications, which is the recommended way to set them up.'
-                        )
+        $this->addHtml(
+            new HtmlElement(
+                'p',
+                Attributes::create(['class' => 'description']),
+                Text::create(
+                    $this->translate(
+                        'The source type is used to establish a link to event rules.'
+                        . ' Enter the value as stated in the source\'s documentation.'
+                        . ' Note that integrated sources usually provide their own configuration interface'
+                        . ' for notifications, which is the recommended way to set them up.'
                     )
                 )
-            );
-            $this->addElement(
-                'text',
-                'type',
-                [
-                    'required'  => true,
-                    'label'     => $this->translate('Source Identifier'),
-                    'disabled'  => $locked
-                ]
-            );
-        }
+            )
+        );
+        $this->addElement(
+            'text',
+            'type',
+            [
+                'required'  => true,
+                'label'     => $this->translate('Source Type'),
+                'disabled'  => $locked
+            ]
+        );
 
         $this->addElement(
             'select',
@@ -334,7 +311,6 @@ class SourceForm extends CompatForm
             'locked' => $source->locked ?: null,
             'name' => $source->name,
             'type' => $source->type,
-            'source_type' => $source->type === self::TYPE_GENERIC ? self::TYPE_GENERIC : self::TYPE_INTEGRATED,
             'auth_type' => $source->listener_username === null ? 'certificate' : 'password',
             'credentials' => [
                 'listener_username' => $source->listener_username,

--- a/library/Notifications/Common/SourceHookLocator.php
+++ b/library/Notifications/Common/SourceHookLocator.php
@@ -6,11 +6,16 @@
 namespace Icinga\Module\Notifications\Common;
 
 use Icinga\Application\Hook;
+use Icinga\Application\Logger;
 use Icinga\Module\Notifications\Hook\V2\SourceHook;
 use ipl\Stdlib\Str;
+use Throwable;
 
 class SourceHookLocator
 {
+    /** @var array<string, string> */
+    private static array $labels = [];
+
     /**
      * Get the source hook responsible for the given source type
      *
@@ -34,5 +39,39 @@ class SourceHookLocator
         }
 
         return Hook::first('Notifications\\V2\\' . $name . 'Source');
+    }
+
+    /**
+     * Get the label for the given source type
+     *
+     * @param string $type
+     *
+     * @return string
+     */
+    public static function labelFor(string $type): string
+    {
+        if (array_key_exists($type, self::$labels)) {
+            return self::$labels[$type];
+        }
+
+        $label = $type;
+
+        $hook = static::forType($type);
+        if ($hook !== null) {
+            try {
+                $label = $hook->getSourceLabel();
+            } catch (Throwable $e) {
+                Logger::error(
+                    'Failed to retrieve the label from source hook "%s" for type "%s": %s',
+                    $hook::class,
+                    $type,
+                    $e
+                );
+            }
+        }
+
+        self::$labels[$type] = $label;
+
+        return $label;
     }
 }

--- a/library/Notifications/Daemon/Daemon.php
+++ b/library/Notifications/Daemon/Daemon.php
@@ -249,7 +249,7 @@ class Daemon extends EventEmitter
 
         // grab new notifications and the current connections
         $notifications = IncidentHistory::on(Database::get())
-            ->with(['incident', 'incident.object', 'incident.object.source'])
+            ->with(['incident', 'incident.object'])
             ->withColumns(['incident.object.id_tags'])
             ->filter(Filter::greaterThan('id', $this->lastIncidentId))
             ->filter(Filter::equal('type', 'notified'))

--- a/library/Notifications/Form/Data/EscalationRule.php
+++ b/library/Notifications/Form/Data/EscalationRule.php
@@ -10,14 +10,14 @@ readonly class EscalationRule
     /**
      * @param ?int $id The primary database key value, NULL for new rules
      * @param string $name The name of the rule
-     * @param int $sourceId The source's ID the rule belongs to
+     * @param string $sourceType The source type the rule belongs to
      * @param ?string $objectFilter The object filter of the rule
      * @param Escalation[] $escalations
      */
     public function __construct(
         public ?int $id,
         public string $name,
-        public int $sourceId,
+        public string $sourceType,
         public ?string $objectFilter,
         public array $escalations
     ) {

--- a/library/Notifications/Model/Behavior/SourceAggregator.php
+++ b/library/Notifications/Model/Behavior/SourceAggregator.php
@@ -1,0 +1,108 @@
+<?php
+
+// SPDX-FileCopyrightText: 2026 Icinga GmbH <https://icinga.com>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+namespace Icinga\Module\Notifications\Model\Behavior;
+
+use Icinga\Module\Notifications\Model\Objects;
+use Icinga\Module\Notifications\Model\Source;
+use ipl\Orm\AliasedExpression;
+use ipl\Orm\ColumnDefinition;
+use ipl\Orm\Contract\PropertyBehavior;
+use ipl\Orm\Contract\QueryAwareBehavior;
+use ipl\Orm\Contract\RewriteColumnBehavior;
+use ipl\Orm\Exception\InvalidColumnException;
+use ipl\Orm\Query;
+use ipl\Sql\Adapter\Pgsql;
+use ipl\Sql\Expression;
+use ipl\Stdlib\Filter;
+
+/**
+ * Aggregate all sources an object is linked to into the column `sources`
+ */
+class SourceAggregator extends PropertyBehavior implements RewriteColumnBehavior, QueryAwareBehavior
+{
+    protected ?Query $query = null;
+
+    final public function __construct()
+    {
+        parent::__construct(['sources']);
+    }
+
+    /** @return Source[] */
+    public function fromDb($value, $key, $context): array
+    {
+        $sources = [];
+        foreach (json_decode($value ?? '', true) ?? [] as $row) {
+            $sources[] = (new Source())->setProperties($row);
+        }
+
+        return $sources;
+    }
+
+    public function toDb($value, $key, $context): never
+    {
+        throw new InvalidColumnException($key, new Objects());
+    }
+
+    public function setQuery(Query $query): static
+    {
+        $this->query = $query;
+
+        return $this;
+    }
+
+    public function rewriteColumn($column, ?string $relation = null): ?AliasedExpression
+    {
+        if ($column === 'sources') {
+            $myAlias = $this->query->getResolver()->getAlias(
+                $relation !== null
+                    ? $this->query->getResolver()->resolveRelation($relation)->getTarget()
+                    : $this->query->getModel()
+            );
+
+            $target = new Source();
+            $subQuery = $this->query
+                ->createSubQuery($target, ($relation ?? $this->query->getModel()->getTableAlias()) . '.source')
+                ->disableDefaultSort();
+
+            $subResolver = $subQuery->getResolver();
+            $alias = $subResolver->getAlias($target);
+            $isPgsql = $this->query->getDb()->getAdapter() instanceof Pgsql;
+
+            $row = sprintf(
+                $isPgsql
+                    ? "json_build_object('id', %s, 'type', %s, 'name', %s)"
+                    : "json_object('id', %s, 'type', %s, 'name', %s)",
+                $subResolver->qualifyColumn('id', $alias),
+                $subResolver->qualifyColumn('type', $alias),
+                $subResolver->qualifyColumn('name', $alias)
+            );
+
+            $subQuery->columns([new Expression(($isPgsql ? 'json_agg' : 'json_arrayagg') . "($row)")]);
+
+            [$select, $values] = $this->query->getDb()
+                ->getQueryBuilder()
+                ->assembleSelect($subQuery->assembleSelect());
+
+            return new AliasedExpression($myAlias . '_sources', $select, null, ...$values);
+        }
+
+        return null;
+    }
+
+    public function isSelectableColumn(string $name): bool
+    {
+        return $name === 'sources';
+    }
+
+    public function rewriteColumnDefinition(ColumnDefinition $def, string $relation): void
+    {
+    }
+
+    public function rewriteCondition(Filter\Condition $condition, $relation = null): null
+    {
+        return null;
+    }
+}

--- a/library/Notifications/Model/Behavior/SourceAggregator.php
+++ b/library/Notifications/Model/Behavior/SourceAggregator.php
@@ -1,0 +1,120 @@
+<?php
+
+// SPDX-FileCopyrightText: 2026 Icinga GmbH <https://icinga.com>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+namespace Icinga\Module\Notifications\Model\Behavior;
+
+use Icinga\Module\Notifications\Model\Objects;
+use Icinga\Module\Notifications\Model\Source;
+use InvalidArgumentException;
+use ipl\Orm\AliasedExpression;
+use ipl\Orm\ColumnDefinition;
+use ipl\Orm\Contract\PropertyBehavior;
+use ipl\Orm\Contract\QueryAwareBehavior;
+use ipl\Orm\Contract\RewriteColumnBehavior;
+use ipl\Orm\Exception\InvalidColumnException;
+use ipl\Orm\Query;
+use ipl\Sql\Adapter\Pgsql;
+use ipl\Sql\Expression;
+use ipl\Stdlib\Filter;
+
+use function ipl\Stdlib\get_php_type;
+
+/**
+ * Aggregate all sources an object is linked to into the column `sources`
+ *
+ * The column's value is an array of partially hydrated {@see Source} models each with `id`, `type` and `name` set
+ */
+class SourceAggregator extends PropertyBehavior implements RewriteColumnBehavior, QueryAwareBehavior
+{
+    protected ?Query $query = null;
+
+    final public function __construct()
+    {
+        parent::__construct(['sources']);
+    }
+
+    /**
+     * @return Source[]
+     *
+     * @throws InvalidArgumentException
+     */
+    public function fromDb($value, $key, $context): array
+    {
+        if ($value === null) {
+            return [];
+        }
+
+        if (! is_string($value)) {
+            throw new InvalidArgumentException(
+                sprintf('Expected JSON array or null for %s, got %s', $key, get_php_type($value))
+            );
+        }
+
+        $sources = [];
+        foreach (json_decode($value, true) ?? [] as $row) {
+            $sources[] = new Source($row);
+        }
+
+        return $sources;
+    }
+
+    public function toDb($value, $key, $context): never
+    {
+        throw new InvalidColumnException($key, new Objects());
+    }
+
+    public function setQuery(Query $query): static
+    {
+        $this->query = $query;
+
+        return $this;
+    }
+
+    public function rewriteColumn($column, ?string $relation = null): ?AliasedExpression
+    {
+        if ($column === 'sources') {
+            $myAlias = $this->query->getResolver()->getAlias(
+                $relation !== null
+                    ? $this->query->getResolver()->resolveRelation($relation)->getTarget()
+                    : $this->query->getModel()
+            );
+
+            $target = new Source();
+            $subQuery = $this->query
+                ->createSubQuery($target, ($relation ?? $this->query->getModel()->getTableAlias()) . '.source')
+                ->disableDefaultSort()
+                ->columns([
+                    new Expression(
+                        $this->query->getDb()->getAdapter() instanceof Pgsql
+                            ? "json_agg(json_build_object('id', %s, 'type', %s, 'name', %s))"
+                            : "json_arrayagg(json_object('id', %s, 'type', %s, 'name', %s))",
+                        ['id', 'type', 'name']
+                    ),
+                ]);
+
+            [$select, $values] = $this->query->getDb()
+                ->getQueryBuilder()
+                ->assembleSelect($subQuery->assembleSelect());
+
+            return new AliasedExpression($myAlias . '_sources', $select, null, ...$values);
+        }
+
+        return null;
+    }
+
+    public function isSelectableColumn(string $name): bool
+    {
+        return $name === 'sources';
+    }
+
+    public function rewriteColumnDefinition(ColumnDefinition $def, string $relation): void
+    {
+    }
+
+    public function rewriteCondition(Filter\Condition $condition, $relation = null): null
+    {
+        return null;
+    }
+}

--- a/library/Notifications/Model/Objects.php
+++ b/library/Notifications/Model/Objects.php
@@ -17,14 +17,13 @@ use ipl\Orm\Relations;
  * Object
  *
  * @property string $id
- * @property int $source_id
  * @property string $name
  * @property ?string $url
  *
  * @property Query<Incident>|Collection<Incident> $incident
  * @property Query<ObjectIdTag>|Collection<ObjectIdTag> $object_id_tag
  * @property Query<Tag>|Collection<Tag> $tag
- * @property Query<Source>|Source $source
+ * @property Query<Source>|Collection<Source> $source
  * @property array<string, string> $id_tags
  */
 class Objects extends Model
@@ -42,7 +41,6 @@ class Objects extends Model
     public function getColumns(): array
     {
         return [
-            'source_id',
             'name',
             'url'
         ];
@@ -78,6 +76,8 @@ class Objects extends Model
         $relations->hasMany('object_id_tag', ObjectIdTag::class);
         $relations->hasMany('tag', Tag::class);
 
-        $relations->belongsTo('source', Source::class)->setJoinType('LEFT');
+        $relations->belongsToMany('source', Source::class)
+            ->through('object_source')
+            ->setJoinType('LEFT');
     }
 }

--- a/library/Notifications/Model/Objects.php
+++ b/library/Notifications/Model/Objects.php
@@ -8,6 +8,7 @@ namespace Icinga\Module\Notifications\Model;
 use Icinga\Module\Notifications\Common\Collection;
 use Icinga\Module\Notifications\Common\Model;
 use Icinga\Module\Notifications\Model\Behavior\IdTagAggregator;
+use Icinga\Module\Notifications\Model\Behavior\SourceAggregator;
 use ipl\Orm\Behavior\Binary;
 use ipl\Orm\Behaviors;
 use ipl\Orm\Query;
@@ -17,14 +18,14 @@ use ipl\Orm\Relations;
  * Object
  *
  * @property string $id
- * @property int $source_id
  * @property string $name
  * @property ?string $url
+ * @property Source[] $sources
  *
  * @property Query<Incident>|Collection<Incident> $incident
  * @property Query<ObjectIdTag>|Collection<ObjectIdTag> $object_id_tag
  * @property Query<Tag>|Collection<Tag> $tag
- * @property Query<Source>|Source $source
+ * @property Query<Source>|Collection<Source> $source
  * @property array<string, string> $id_tags
  */
 class Objects extends Model
@@ -42,7 +43,6 @@ class Objects extends Model
     public function getColumns(): array
     {
         return [
-            'source_id',
             'name',
             'url'
         ];
@@ -68,6 +68,7 @@ class Objects extends Model
     {
         $behaviors->add(new Binary(['id']));
         $behaviors->add(new IdTagAggregator());
+        $behaviors->add(new SourceAggregator());
     }
 
     public function createRelations(Relations $relations): void
@@ -78,6 +79,8 @@ class Objects extends Model
         $relations->hasMany('object_id_tag', ObjectIdTag::class);
         $relations->hasMany('tag', Tag::class);
 
-        $relations->belongsTo('source', Source::class)->setJoinType('LEFT');
+        $relations->belongsToMany('source', Source::class)
+            ->through('object_source')
+            ->setJoinType('LEFT');
     }
 }

--- a/library/Notifications/Model/Objects.php
+++ b/library/Notifications/Model/Objects.php
@@ -8,6 +8,7 @@ namespace Icinga\Module\Notifications\Model;
 use Icinga\Module\Notifications\Common\Collection;
 use Icinga\Module\Notifications\Common\Model;
 use Icinga\Module\Notifications\Model\Behavior\IdTagAggregator;
+use Icinga\Module\Notifications\Model\Behavior\SourceAggregator;
 use ipl\Orm\Behavior\Binary;
 use ipl\Orm\Behaviors;
 use ipl\Orm\Query;
@@ -19,6 +20,7 @@ use ipl\Orm\Relations;
  * @property string $id
  * @property string $name
  * @property ?string $url
+ * @property Source[] $sources
  *
  * @property Query<Incident>|Collection<Incident> $incident
  * @property Query<ObjectIdTag>|Collection<ObjectIdTag> $object_id_tag
@@ -66,6 +68,7 @@ class Objects extends Model
     {
         $behaviors->add(new Binary(['id']));
         $behaviors->add(new IdTagAggregator());
+        $behaviors->add(new SourceAggregator());
     }
 
     public function createRelations(Relations $relations): void

--- a/library/Notifications/Model/Rule.php
+++ b/library/Notifications/Model/Rule.php
@@ -18,13 +18,13 @@ use ipl\Stdlib\Filter;
 /**
  * @property int $id
  * @property string $name
- * @property int $source_id
+ * @property string $source_type
  * @property ?int $timeperiod_id
  * @property ?string $object_filter
  * @property DateTime $changed_at
  * @property bool $deleted
  *
- * @property Query<Source>|Source $source
+ * @property Query<Source>|Collection<Source> $source
  * @property Query<RuleEscalation>|Collection<RuleEscalation> $rule_escalation
  * @property Query<Incident>|Collection<Incident> $incident
  * @property Query<IncidentHistory>|Collection<IncidentHistory> $incident_history
@@ -45,7 +45,7 @@ class Rule extends Model
     {
         return [
             'name',
-            'source_id',
+            'source_type',
             'timeperiod_id',
             'object_filter',
             'changed_at',
@@ -57,7 +57,7 @@ class Rule extends Model
     {
         return [
             'name'          => t('Name'),
-            'source_id'     => t('Source ID'),
+            'source_type'   => t('Source Type'),
             'timeperiod_id' => t('Timeperiod ID'),
             'object_filter' => t('Object Filter'),
             'changed_at'    => t('Changed At')
@@ -82,7 +82,9 @@ class Rule extends Model
 
     public function createRelations(Relations $relations): void
     {
-        $relations->belongsTo('source', Source::class);
+        $relations->hasMany('source', Source::class)
+            ->setCandidateKey('source_type')
+            ->setForeignKey('type');
         $relations->hasMany('rule_escalation', RuleEscalation::class)
             ->setJoinType('LEFT');
 

--- a/library/Notifications/Model/Source.php
+++ b/library/Notifications/Model/Source.php
@@ -96,9 +96,12 @@ class Source extends Model
 
     public function createRelations(Relations $relations): void
     {
-        $relations->hasMany('object', Objects::class)
+        $relations->belongsToMany('object', Objects::class)
+            ->through('object_source')
             ->setJoinType('LEFT');
         $relations->hasMany('rule', Rule::class)
+            ->setCandidateKey('type')
+            ->setForeignKey('source_type')
             ->setJoinType('LEFT');
     }
 

--- a/library/Notifications/Repository/EscalationRuleRepository.php
+++ b/library/Notifications/Repository/EscalationRuleRepository.php
@@ -50,7 +50,7 @@ final class EscalationRuleRepository
         $model = (new Rule())->setNew();
 
         $model->name = $rule->name;
-        $model->source_id = $rule->sourceId;
+        $model->source_type = $rule->sourceType;
         $model->object_filter = $rule->objectFilter;
 
         (new EntityManager($this->db))->save($model);
@@ -82,7 +82,7 @@ final class EscalationRuleRepository
         }
 
         $model->name = $rule->name;
-        $model->source_id = $rule->sourceId;
+        $model->source_type = $rule->sourceType;
         $model->object_filter = $rule->objectFilter;
 
         (new EntityManager($this->db))->save($model);

--- a/library/Notifications/Repository/SourceRepository.php
+++ b/library/Notifications/Repository/SourceRepository.php
@@ -10,6 +10,7 @@ use Icinga\Module\Notifications\Form\Data\Source as SourceData;
 use Icinga\Module\Notifications\Model\Source;
 use InvalidArgumentException;
 use ipl\Sql\Connection;
+use ipl\Sql\Expression;
 use ipl\Stdlib\Filter;
 
 class SourceRepository
@@ -56,6 +57,25 @@ class SourceRepository
     }
 
     /**
+     * Get whether the given source is the only remaining one of its type
+     *
+     * @param Source $source
+     *
+     * @return bool
+     */
+    public function isLastOfItsType(Source $source): bool
+    {
+        return Source::on($this->db)
+            ->columns([new Expression('1')])
+            ->filter(
+                Filter::all(
+                    Filter::equal('type', $source->type),
+                    Filter::unequal('id', $source->id)
+                )
+            )->first() === null;
+    }
+
+    /**
      * Create a new source
      *
      * @param SourceData $source
@@ -89,7 +109,7 @@ class SourceRepository
     }
 
     /**
-     * Delete a source and dereference it from any rules
+     * Delete a source, if it is the last of its type all related rules are deleted as well
      *
      * @param int $id
      *
@@ -106,9 +126,10 @@ class SourceRepository
         $source->listener_username = null;
         $source->delete();
 
-        $source->rule->query()->columns('id');
-        foreach ($source->rule as $rule) {
-            (new EscalationRuleRepository($this->db))->delete($rule->id);
+        if ($this->isLastOfItsType($source)) {
+            foreach ($source->rule as $rule) {
+                (new EscalationRuleRepository($this->db))->delete($rule->id);
+            }
         }
 
         (new EntityManager($this->db))->save($source);

--- a/library/Notifications/Repository/SourceRepository.php
+++ b/library/Notifications/Repository/SourceRepository.php
@@ -7,6 +7,7 @@ namespace Icinga\Module\Notifications\Repository;
 
 use Icinga\Module\Notifications\Common\EntityManager;
 use Icinga\Module\Notifications\Form\Data\Source as SourceData;
+use Icinga\Module\Notifications\Model\Rule;
 use Icinga\Module\Notifications\Model\Source;
 use InvalidArgumentException;
 use ipl\Sql\Connection;
@@ -89,7 +90,7 @@ class SourceRepository
     }
 
     /**
-     * Delete a source and dereference it from any rules
+     * Delete a source, if it is the last of its type all related rules are deleted as well
      *
      * @param int $id
      *
@@ -104,14 +105,21 @@ class SourceRepository
 
         $source->client_certificate_subject = null;
         $source->listener_username = null;
-        $source->delete();
 
-        $source->rule->query()->columns('id');
-        foreach ($source->rule as $rule) {
+        (new EntityManager($this->db))->save($source->delete());
+
+        $orphanRules = Rule::on($this->db)
+            ->columns('id')
+            ->filter(
+                Filter::all(
+                    Filter::equal('source_type', $source->type),
+                    Filter::unlike('source.id', '*')
+                )
+            );
+
+        foreach ($orphanRules as $rule) {
             (new EscalationRuleRepository($this->db))->delete($rule->id);
         }
-
-        (new EntityManager($this->db))->save($source);
     }
 
     /**

--- a/library/Notifications/Util/RuleSerializer.php
+++ b/library/Notifications/Util/RuleSerializer.php
@@ -26,17 +26,22 @@ class RuleSerializer
     /** @var array<string, string[]> JSON paths keyed by column name */
     protected array $jsonPaths;
 
+    /** @var bool Whether the filter was created with a source integration */
+    protected bool $assisted;
+
     /**
      * Create an object that can be used to serialize a rule to JSON
      *
      * @param Filter\Rule $filter
      * @param array<string, string[]> $jsonPaths JSON paths keyed by column name
+     * @param bool $assisted Whether the filter was created with a source integration
      * @param ?string $filterName The name of the filter
      */
-    public function __construct(Filter\Rule $filter, array $jsonPaths, ?string $filterName = null)
+    public function __construct(Filter\Rule $filter, array $jsonPaths, bool $assisted, ?string $filterName = null)
     {
         $this->filter = $filter;
         $this->jsonPaths = $jsonPaths;
+        $this->assisted = $assisted;
         $this->filterName = $filterName;
     }
 
@@ -50,8 +55,9 @@ class RuleSerializer
     public function getJson(): ?string
     {
         $result = [
-            'version' => self::VERSION,
-            'qs'      => QueryString::render($this->filter),
+            'version'  => self::VERSION,
+            'qs'       => QueryString::render($this->filter),
+            'assisted' => $this->assisted,
         ];
 
         if ($this->filterName) {

--- a/library/Notifications/View/IncidentRenderer.php
+++ b/library/Notifications/View/IncidentRenderer.php
@@ -8,8 +8,8 @@ namespace Icinga\Module\Notifications\View;
 use Icinga\Module\Notifications\Common\Icons;
 use Icinga\Module\Notifications\Common\Links;
 use Icinga\Module\Notifications\Common\Severity;
+use Icinga\Module\Notifications\Common\SourceHookLocator;
 use Icinga\Module\Notifications\Model\Incident;
-use Icinga\Module\Notifications\Model\Source;
 use ipl\Html\Attributes;
 use ipl\Html\FormattedString;
 use ipl\Html\Html;
@@ -66,18 +66,29 @@ class IncidentRenderer implements ItemRenderer
             $info->addHtml(new Icon(Icons::MUTE, ['title' => $item->mute_reason]));
         }
 
-        /** @var Source $source */
-        $source = $item->object->source;
-        if (isset($source->name)) {
-            $info->addHtml(
-                (new Ball(Ball::SIZE_BIG))
-                    ->addAttributes(Attributes::create(['class' => 'source-icon', 'title' => $source->name]))
-                    ->addHtml($source->getIcon())
-            );
-        } else {
+        if (empty($item->object->sources)) {
             $info->addHtml(new Icon('circle-question', [
                 'title' => $this->translate('No source information available')
             ]));
+        } else {
+            foreach ($item->object->sources as $source) {
+                $info->addHtml(
+                    (new Ball(Ball::SIZE_BIG))
+                        ->addAttributes(
+                            Attributes::create(
+                                [
+                                    'class' => 'source-icon',
+                                    'title' => sprintf(
+                                        '%s (%s)',
+                                        $source->name,
+                                        SourceHookLocator::labelFor($source->type)
+                                    )
+                                ]
+                            )
+                        )
+                        ->addHtml($source->getIcon())
+                );
+            }
         }
 
         if ($item->recovered_at !== null) {

--- a/library/Notifications/View/IncidentRenderer.php
+++ b/library/Notifications/View/IncidentRenderer.php
@@ -9,7 +9,6 @@ use Icinga\Module\Notifications\Common\Icons;
 use Icinga\Module\Notifications\Common\Links;
 use Icinga\Module\Notifications\Common\Severity;
 use Icinga\Module\Notifications\Model\Incident;
-use Icinga\Module\Notifications\Model\Source;
 use ipl\Html\Attributes;
 use ipl\Html\FormattedString;
 use ipl\Html\Html;
@@ -66,14 +65,19 @@ class IncidentRenderer implements ItemRenderer
             $info->addHtml(new Icon(Icons::MUTE, ['title' => $item->mute_reason]));
         }
 
-        /** @var Source $source */
-        $source = $item->object->source;
-        if (isset($source->name)) {
-            $info->addHtml(
-                (new Ball(Ball::SIZE_BIG))
-                    ->addAttributes(Attributes::create(['class' => 'source-icon', 'title' => $source->name]))
-                    ->addHtml($source->getIcon())
-            );
+        if (! empty($item->object->sources)) {
+            $sourceTypes = [];
+            foreach ($item->object->sources as $source) {
+                $sourceTypes[$source->type] = $source->getIcon();
+            }
+
+            foreach ($sourceTypes as $type => $icon) {
+                $info->addHtml(
+                    (new Ball(Ball::SIZE_BIG))
+                        ->addAttributes(Attributes::create(['class' => 'source-icon', 'title' => $type]))
+                        ->addHtml($icon)
+                );
+            }
         } else {
             $info->addHtml(new Icon('circle-question', [
                 'title' => $this->translate('No source information available')

--- a/library/Notifications/Widget/Detail/IncidentDetail.php
+++ b/library/Notifications/Widget/Detail/IncidentDetail.php
@@ -78,9 +78,13 @@ class IncidentDetail extends BaseHtmlElement
     protected function createRelatedObject(): array
     {
         $object = $this->incident->object;
-        $hook = isset($object->source->type)
-            ? SourceHookLocator::forType($object->source->type)
-            : null;
+        $hook = null;
+        foreach ($object->sources as $source) {
+            $hook = SourceHookLocator::forType($source->type);
+            if ($hook !== null) {
+                break;
+            }
+        }
 
         $objectUrl = $hook?->createObjectLink($object->id_tags);
         if ($objectUrl === null) {
@@ -160,9 +164,9 @@ class IncidentDetail extends BaseHtmlElement
     }
 
     /** @return ValidHtml[] */
-    protected function createSource(): array
+    protected function createSources(): array
     {
-        if (! isset($this->incident->object->source->name)) {
+        if (empty($this->incident->object->sources)) {
             return [
                 Html::tag('h2', $this->translate('Event Source')),
                 new EmptyState($this->translate('No source information available'))
@@ -170,10 +174,12 @@ class IncidentDetail extends BaseHtmlElement
         }
 
         $list = new HtmlElement('ul', Attributes::create(['class' => 'source-list']));
-        $list->addHtml(new HtmlElement('li', null, new EventSourceBadge($this->incident->object->source)));
+        foreach ($this->incident->object->sources as $source) {
+            $list->addHtml(new HtmlElement('li', null, new EventSourceBadge($source)));
+        }
 
         return [
-            Html::tag('h2', $this->translate('Event Source')),
+            Html::tag('h2', $this->translate('Event Sources')),
             $list
         ];
     }
@@ -185,7 +191,7 @@ class IncidentDetail extends BaseHtmlElement
             $this->createHistory(),
             $this->createRelatedObject(),
             $this->createMessage(),
-            $this->createSource(),
+            $this->createSources(),
         ]);
     }
 }

--- a/library/Notifications/Widget/EventSourceBadge.php
+++ b/library/Notifications/Widget/EventSourceBadge.php
@@ -5,6 +5,7 @@
 
 namespace Icinga\Module\Notifications\Widget;
 
+use Icinga\Module\Notifications\Common\SourceHookLocator;
 use Icinga\Module\Notifications\Model\Source;
 use ipl\Html\Attributes;
 use ipl\Html\BaseHtmlElement;
@@ -34,7 +35,7 @@ class EventSourceBadge extends BaseHtmlElement
     {
         $this
             ->addAttributes(Attributes::create([
-                'title' => sprintf('%s (%s)', $this->source->name, $this->source->type)
+                'title' => sprintf('%s (%s)', $this->source->name, SourceHookLocator::labelFor($this->source->type))
             ]))
             ->addHtml(
                 (new Ball(Ball::SIZE_LARGE))

--- a/test/php/application/forms/EventRuleConfigFormTest.php
+++ b/test/php/application/forms/EventRuleConfigFormTest.php
@@ -48,7 +48,7 @@ class EventRuleConfigFormTest extends TestCase
         $requestStub->method('getUploadedFiles')->willReturn([]);
         $requestStub->method('getParsedBody')->willReturn([
             'id' => 1337,
-            'source' => 1338,
+            'source_type' => 'icinga2',
             'name' => 'Test'
         ]);
 

--- a/test/php/library/Notifications/Behavior/SourceAggregatorTest.php
+++ b/test/php/library/Notifications/Behavior/SourceAggregatorTest.php
@@ -1,0 +1,297 @@
+<?php
+
+// SPDX-FileCopyrightText: 2026 Icinga GmbH <https://icinga.com>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+namespace Tests\Icinga\Module\Notifications\Behavior;
+
+use DateTime;
+use Icinga\Module\Notifications\Model\Behavior\SourceAggregator;
+use Icinga\Module\Notifications\Model\Incident;
+use Icinga\Module\Notifications\Model\Objects;
+use Icinga\Module\Notifications\Model\Source;
+use Icinga\Module\Notifications\Test\DbTestBackends;
+use ipl\Orm\Exception\InvalidColumnException;
+use ipl\Sql\Adapter\Pgsql;
+use ipl\Sql\Connection;
+use ipl\Sql\Test\SharedDatabases\TransactionIsolation;
+use ipl\Stdlib\Filter;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+#[TransactionIsolation]
+class SourceAggregatorTest extends TestCase
+{
+    use DbTestBackends;
+
+    /** @var Connection The database of the current test, set by every test using the shared databases */
+    private Connection $db;
+
+    /** @var int Number of sources seeded so far, keeps `source.listener_username` unique across all tests */
+    private static int $sourceCount = 0;
+
+    protected static function initializeNotificationsDb(Connection $db): void
+    {
+        // Neither objects nor sources have prerequisites of their own
+    }
+
+    #[DataProvider('sharedDatabases')]
+    public function testAggregatesEverySourceAnObjectIsLinkedTo(Connection $db): void
+    {
+        $this->db = $db;
+
+        $objectId = $this->seedObject('host-a');
+        $this->linkSource($objectId, $this->seedSource('icingadb', 'Icinga 2'));
+        $this->linkSource($objectId, $this->seedSource('gitlab', 'GitLab'));
+        $this->seedIncident($objectId);
+
+        $object = $this->loadObject('host-a');
+
+        $this->assertIsArray(
+            $object->sources,
+            'The sources should be aggregated up front, not left as a lazily loaded relation query'
+        );
+        $this->assertSame(
+            [['gitlab', 'GitLab'], ['icingadb', 'Icinga 2']],
+            $this->sortedSourceTuples($object),
+            'An object should be given every source it is linked to'
+        );
+    }
+
+    #[DataProvider('sharedDatabases')]
+    public function testKeepsSourcesSharingATypeApart(Connection $db): void
+    {
+        $this->db = $db;
+
+        $objectId = $this->seedObject('host-a');
+        $this->linkSource($objectId, $this->seedSource('icingadb', 'Datacenter A'));
+        $this->linkSource($objectId, $this->seedSource('icingadb', 'Datacenter B'));
+        $this->seedIncident($objectId);
+
+        $this->assertSame(
+            [['icingadb', 'Datacenter A'], ['icingadb', 'Datacenter B']],
+            $this->sortedSourceTuples($this->loadObject('host-a')),
+            'Sources sharing a type should be kept apart, deduplicating them is up to the consumer'
+        );
+    }
+
+    #[DataProvider('sharedDatabases')]
+    public function testOmitsSoftDeletedSources(Connection $db): void
+    {
+        $this->db = $db;
+
+        $objectId = $this->seedObject('host-a');
+        $this->linkSource($objectId, $this->seedSource('icingadb', 'Icinga 2'));
+        $this->linkSource($objectId, $this->seedSource('gitlab', 'GitLab', true));
+        $this->seedIncident($objectId);
+
+        $this->assertSame(
+            [['icingadb', 'Icinga 2']],
+            $this->sortedSourceTuples($this->loadObject('host-a')),
+            'A soft-deleted source should be omitted, even if a link still exists'
+        );
+    }
+
+    #[DataProvider('sharedDatabases')]
+    public function testYieldsNoSourcesForAnObjectWithoutAny(Connection $db): void
+    {
+        $this->db = $db;
+
+        $this->seedIncident($this->seedObject('host-a'));
+
+        $this->assertSame(
+            [],
+            $this->loadObject('host-a')->sources,
+            'An object without sources should be given an empty array, not the aggregate\'s NULL'
+        );
+    }
+
+    #[DataProvider('sharedDatabases')]
+    public function testYieldsEachObjectOnlyItsOwnSources(Connection $db): void
+    {
+        $this->db = $db;
+
+        $hostA = $this->seedObject('host-a');
+        $this->linkSource($hostA, $this->seedSource('icingadb', 'Icinga 2'));
+        $this->seedIncident($hostA);
+
+        $hostB = $this->seedObject('host-b');
+        $this->linkSource($hostB, $this->seedSource('gitlab', 'GitLab'));
+        $this->seedIncident($hostB);
+
+        $this->assertSame(
+            [['icingadb', 'Icinga 2']],
+            $this->sortedSourceTuples($this->loadObject('host-a')),
+            'An object should only be given the sources it is linked to itself'
+        );
+        $this->assertSame(
+            [['gitlab', 'GitLab']],
+            $this->sortedSourceTuples($this->loadObject('host-b')),
+            'An object should only be given the sources it is linked to itself'
+        );
+    }
+
+    #[DataProvider('sharedDatabases')]
+    public function testDoesNotMultiplyTheRowsOfTheOuterQuery(Connection $db): void
+    {
+        $this->db = $db;
+
+        $objectId = $this->seedObject('host-a');
+        $this->linkSource($objectId, $this->seedSource('icingadb', 'Icinga 2'));
+        $this->linkSource($objectId, $this->seedSource('gitlab', 'GitLab'));
+        $this->seedIncident($objectId);
+
+        $incidents = Incident::on($db)->with('object')->withColumns(['object.sources']);
+
+        $this->assertCount(
+            1,
+            iterator_to_array($incidents, false),
+            'An incident should stay a single row, its object\'s sources should be aggregated, not joined'
+        );
+    }
+
+    #[DataProvider('sharedDatabases')]
+    public function testAggregatesOnlyTheColumnsASourceIsRenderedFrom(Connection $db): void
+    {
+        $this->db = $db;
+
+        $objectId = $this->seedObject('host-a');
+        $sourceId = $this->seedSource('icingadb', 'Icinga 2');
+        $this->linkSource($objectId, $sourceId);
+        $this->seedIncident($objectId);
+
+        $sources = $this->loadObject('host-a')->sources;
+        $this->assertCount(1, $sources, 'The object\'s only source should be aggregated');
+
+        $source = $sources[0];
+        $this->assertInstanceOf(Source::class, $source, 'An aggregated source should be hydrated into a model');
+        $this->assertEquals($sourceId, $source->id, 'A source\'s id should be aggregated');
+        $this->assertSame('icingadb', $source->type, 'A source\'s type should be aggregated');
+        $this->assertSame('Icinga 2', $source->name, 'A source\'s name should be aggregated');
+
+        $this->assertFalse(
+            $source->hasProperty('listener_username'),
+            'A source model should be partial, it should not carry columns no consumer requires'
+        );
+    }
+
+    #[DataProvider('sharedDatabases')]
+    public function testAggregatesSourcesWithTheObjectAsBaseModel(Connection $db): void
+    {
+        $this->db = $db;
+
+        $objectId = $this->seedObject('host-a');
+        $this->linkSource($objectId, $this->seedSource('icingadb', 'Icinga 2'));
+
+        $object = Objects::on($db)
+            ->withColumns(['sources'])
+            ->filter(Filter::equal('name', 'host-a'))
+            ->first();
+
+        $this->assertNotNull($object, 'The seeded object should be found');
+        $this->assertSame(
+            [['icingadb', 'Icinga 2']],
+            $this->sortedSourceTuples($object),
+            'Sources should be aggregated with the object as the query\'s base model too, i.e. without a relation'
+        );
+    }
+
+    public function testCannotBeUsedToPersistSources(): void
+    {
+        // `sources` is read-only, it doesn't exist as a column and hence can't be written to
+        $this->expectException(InvalidColumnException::class);
+
+        (new SourceAggregator())->toDb([], 'sources', new Objects());
+    }
+
+    /**
+     * Load the object of the given name through an incident query with its sources aggregated
+     */
+    private function loadObject(string $name): Objects
+    {
+        $incident = Incident::on($this->db)
+            ->with('object')
+            ->withColumns(['object.sources'])
+            ->filter(Filter::equal('object.name', $name))
+            ->first();
+
+        $this->assertNotNull($incident, "The incident seeded for object '$name' should be found");
+
+        return $incident->object;
+    }
+
+    /**
+     * Reduce the sources of the given object to a sorted list of type and name pairs
+     *
+     * The subquery the behavior builds is unordered, so assertions must not depend on
+     * the order in which the sources are aggregated.
+     *
+     * @return list<array{string, string}>
+     */
+    private function sortedSourceTuples(Objects $object): array
+    {
+        $sources = [];
+        foreach ($object->sources as $source) {
+            $sources[] = [$source->type, $source->name];
+        }
+
+        sort($sources);
+
+        return $sources;
+    }
+
+    /**
+     * Insert an object row and return its id in the representation the current database expects
+     */
+    private function seedObject(string $name): string
+    {
+        // The tables are seeded directly, i.e. without the ORM's Binary behavior in between,
+        // which is why PostgreSQL requires the hex literal notation
+        $hash = hash('sha256', $name);
+        $id = $this->db->getAdapter() instanceof Pgsql ? sprintf('\\x%s', $hash) : hex2bin($hash);
+
+        $this->db->insert('object', ['id' => $id, 'name' => $name]);
+
+        return $id;
+    }
+
+    /**
+     * Insert a source row and return its id
+     */
+    private function seedSource(string $type, string $name, bool $deleted = false): int
+    {
+        // A soft-deleted source gets no listener_username, both because the repository frees it upon
+        // deletion and because the source table's check constraint only permits its absence for those
+        $this->db->insert('source', [
+            'type'              => $type,
+            'name'              => $name,
+            'listener_username' => $deleted ? null : 'listener-' . ++self::$sourceCount,
+            'changed_at'        => (int) (new DateTime())->format('Uv'),
+            'deleted'           => $deleted ? 'y' : 'n'
+        ]);
+
+        return (int) $this->db->lastInsertId();
+    }
+
+    /**
+     * Link the given object with the given source
+     */
+    private function linkSource(string $objectId, int $sourceId): void
+    {
+        $this->db->insert('object_source', ['object_id' => $objectId, 'source_id' => $sourceId]);
+    }
+
+    /**
+     * Insert an open incident for the given object and return its id
+     */
+    private function seedIncident(string $objectId): int
+    {
+        $this->db->insert('incident', [
+            'object_id'  => $objectId,
+            'severity'   => 'crit',
+            'started_at' => (int) (new DateTime())->format('Uv')
+        ]);
+
+        return (int) $this->db->lastInsertId();
+    }
+}

--- a/test/php/library/Notifications/Integrations/IncidentsTest.php
+++ b/test/php/library/Notifications/Integrations/IncidentsTest.php
@@ -30,7 +30,7 @@ use ReflectionProperty;
  *
  * The tests that execute a query run against real databases — once for MySQL and once for PostgreSQL (see
  * {@see DbTestBackends} / `#[DataProvider('sharedDatabases')]`). Each of them runs inside its own transaction which is
- * rolled back afterwards, so the incidents, objects and sources it seeds don't leak into the next test. The
+ * rolled back afterwards, so the incidents, objects it seeds don't leak into the next test. The
  * prerequisite channel a contact requires is seeded once per driver in {@see self::initializeNotificationsDb()} and
  * its id captured into {@see self::$channelId} (the id can't be assumed as rolled-back transactions still advance
  * the auto-increment).
@@ -47,7 +47,7 @@ class IncidentsTest extends TestCase
     private static int $channelId;
 
     /**
-     * Object ids seeded into the current test's database, keyed by source id and object id
+     * Object ids seeded into the current test's database, keyed by object id
      *
      * @var array<int, array<string, true>>
      */
@@ -114,8 +114,8 @@ class IncidentsTest extends TestCase
     {
         $this->db = $db;
 
-        $this->seedIncident(1, ['host' => 'a']);
-        $this->seedIncident(2, ['host' => 'b']);
+        $this->seedIncident(['host' => 'a']);
+        $this->seedIncident(['host' => 'b']);
 
         $incidents = iterator_to_array(new Incidents([], $db), false);
 
@@ -132,7 +132,7 @@ class IncidentsTest extends TestCase
 
         $this->assertFalse((new Incidents([], $db))->hasIncident());
 
-        $this->seedIncident(1, ['host' => 'a']);
+        $this->seedIncident(['host' => 'a']);
 
         $this->assertTrue((new Incidents([], $db))->hasIncident());
     }
@@ -142,9 +142,9 @@ class IncidentsTest extends TestCase
     {
         $this->db = $db;
 
-        $managed = $this->seedIncident(1, ['host' => 'a']);
-        $subscribed = $this->seedIncident(2, ['host' => 'b']);
-        $foreign = $this->seedIncident(3, ['host' => 'c']);
+        $managed = $this->seedIncident(['host' => 'a']);
+        $subscribed = $this->seedIncident(['host' => 'b']);
+        $foreign = $this->seedIncident(['host' => 'c']);
 
         $jdoe = $this->seedContact('jdoe');
         $this->seedRole($managed, $jdoe, 'manager');
@@ -169,7 +169,7 @@ class IncidentsTest extends TestCase
     {
         $this->db = $db;
 
-        $recovered = $this->seedIncident(1, ['host' => 'a'], 1_700_000_000_000);
+        $recovered = $this->seedIncident(['host' => 'a'], 1_700_000_000_000);
         $this->seedRole($recovered, $this->seedContact('jdoe'), 'manager');
 
         $this->assertSame([], iterator_to_array((new Incidents([], $db))->getRoles(new User('jdoe'))));
@@ -180,7 +180,7 @@ class IncidentsTest extends TestCase
     {
         $this->db = $db;
 
-        $this->seedRole($this->seedIncident(1, ['host' => 'a']), $this->seedContact('jane'), 'manager');
+        $this->seedRole($this->seedIncident(['host' => 'a']), $this->seedContact('jane'), 'manager');
 
         $this->assertSame([], iterator_to_array((new Incidents([], $db))->getRoles(new User('jdoe'))));
     }
@@ -190,7 +190,7 @@ class IncidentsTest extends TestCase
     {
         $this->db = $db;
 
-        $incidentId = $this->seedIncident(1, ['host' => 'a']);
+        $incidentId = $this->seedIncident(['host' => 'a']);
         $this->seedRole($incidentId, $this->seedContact('jane'), 'manager');
         $this->seedRole($incidentId, $this->seedContact('jdoe'), 'subscriber');
         $this->seedRole($incidentId, $this->seedContact('bob'), 'recipient');
@@ -208,8 +208,8 @@ class IncidentsTest extends TestCase
     {
         $this->db = $db;
 
-        $this->seedIncident(1, ['host' => 'a']);
-        $this->seedIncident(2, ['host' => 'b']);
+        $this->seedIncident(['host' => 'a']);
+        $this->seedIncident(['host' => 'b']);
 
         $incidents = new Incidents([], $db);
 
@@ -222,7 +222,7 @@ class IncidentsTest extends TestCase
     {
         $this->db = $db;
 
-        $this->seedIncident(1, ['host' => 'a']);
+        $this->seedIncident(['host' => 'a']);
 
         $this->assertEquals(1, (new Incidents([], $db))->count());
     }
@@ -234,8 +234,8 @@ class IncidentsTest extends TestCase
 
         // A recovered (closed) incident must never be yielded — the integration only deals with open
         // incidents (recovered_at IS NULL).
-        $this->seedIncident(1, ['host' => 'a']);
-        $this->seedIncident(2, ['host' => 'b'], 1_700_000_000_000);
+        $this->seedIncident(['host' => 'a']);
+        $this->seedIncident(['host' => 'b'], 1_700_000_000_000);
 
         $incidents = new Incidents([], $db);
 
@@ -248,9 +248,9 @@ class IncidentsTest extends TestCase
     {
         $this->db = $db;
 
-        $host = $this->seedIncident(1, ['host' => 'a']);
-        $service = $this->seedIncident(1, ['host' => 'a', 'service' => 'http']);
-        $this->seedIncident(1, ['host' => 'b']);
+        $host = $this->seedIncident(['host' => 'a']);
+        $service = $this->seedIncident(['host' => 'a', 'service' => 'http']);
+        $this->seedIncident(['host' => 'b']);
 
         // The host's incident and the one of its service, matched by the tag they have in common
         $this->assertSame(
@@ -340,7 +340,7 @@ class IncidentsTest extends TestCase
     }
 
     /**
-     * Insert an incident for the object identified by the given source and tags, creating the
+     * Insert an incident for the object identified by the given tags, creating the
      * object and object_id_tag rows it relates to so the joins in {@see Incidents::buildQuery()} resolve.
      *
      * @param array<string, string> $tags
@@ -348,11 +348,11 @@ class IncidentsTest extends TestCase
      *
      * @return int The id of the inserted incident
      */
-    private function seedIncident(int $sourceId, array $tags, ?int $recoveredAt = null): int
+    private function seedIncident(array $tags, ?int $recoveredAt = null): int
     {
-        $objectId = $this->objectId($sourceId, $tags);
+        $objectId = $this->objectId($tags);
 
-        $this->seedObject($sourceId, $tags, $objectId);
+        $this->seedObject($tags, $objectId);
 
         $now = (int) (new DateTime())->format('Uv');
 
@@ -398,10 +398,10 @@ class IncidentsTest extends TestCase
     }
 
     /**
-     * Derive a stable, unique object id for the given source and tags
+     * Derive a stable, unique object id for the given tags
      *
      * Stands in for the daemon's object hashing: the exact algorithm is irrelevant to these tests, it
-     * only has to be deterministic and collision-free across distinct (source, tags) combinations so
+     * only has to be deterministic and collision-free for distinct tags so
      * the seeded incident and object_id_tag rows share one id while distinct objects differ.
      *
      * The id is returned in the representation the current database expects for a binary literal, as
@@ -409,11 +409,11 @@ class IncidentsTest extends TestCase
      *
      * @param array<string, string> $tags
      */
-    private function objectId(int $sourceId, array $tags): string
+    private function objectId(array $tags): string
     {
         ksort($tags);
 
-        $hash = hash('sha256', $sourceId . "\0" . serialize($tags));
+        $hash = hash('sha256', serialize($tags));
 
         if ($this->db->getAdapter() instanceof Pgsql) {
             return sprintf('\\x%s', $hash);
@@ -426,33 +426,18 @@ class IncidentsTest extends TestCase
      * Insert the object row and the object_id_tag rows that represent the object for the given tags,
      * unless they already exist — the same object backs every incident sharing its id.
      *
-     * The source the object belongs to is created as well, once per test and source id.
-     *
      * @param array<string, string> $tags
      */
-    private function seedObject(int $sourceId, array $tags, string $objectId): void
+    private function seedObject(array $tags, string $objectId): void
     {
-        if (! isset($this->seededObjects[$sourceId])) {
-            $this->seededObjects[$sourceId] = [];
-
-            $this->db->insert('source', [
-                'id'                => $sourceId,
-                'type'              => 'test',
-                'name'              => 'test',
-                'listener_username' => sprintf('test_%d', $sourceId),
-                'changed_at'        => (int) (new DateTime())->format('Uv')
-            ]);
-        }
-
-        if (isset($this->seededObjects[$sourceId][$objectId])) {
+        if (isset($this->seededObjects[$objectId])) {
             return;
         }
 
-        $this->seededObjects[$sourceId][$objectId] = true;
+        $this->seededObjects[$objectId] = true;
 
         $this->db->insert('object', [
             'id'        => $objectId,
-            'source_id' => $sourceId,
             'name'      => implode(', ', $tags)
         ]);
 

--- a/test/php/library/Notifications/Integrations/IncidentsTest.php
+++ b/test/php/library/Notifications/Integrations/IncidentsTest.php
@@ -30,7 +30,7 @@ use ReflectionProperty;
  *
  * The tests that execute a query run against real databases — once for MySQL and once for PostgreSQL (see
  * {@see DbTestBackends} / `#[DataProvider('sharedDatabases')]`). Each of them runs inside its own transaction which is
- * rolled back afterwards, so the incidents, objects and sources it seeds don't leak into the next test. The
+ * rolled back afterwards, so the incidents, objects it seeds don't leak into the next test. The
  * prerequisite channel a contact requires is seeded once per driver in {@see self::initializeNotificationsDb()} and
  * its id captured into {@see self::$channelId} (the id can't be assumed as rolled-back transactions still advance
  * the auto-increment).
@@ -47,7 +47,7 @@ class IncidentsTest extends TestCase
     private static int $channelId;
 
     /**
-     * Object ids seeded into the current test's database, keyed by source id and object id
+     * Object ids seeded into the current test's database, keyed by object id
      *
      * @var array<int, array<string, true>>
      */
@@ -114,8 +114,8 @@ class IncidentsTest extends TestCase
     {
         $this->db = $db;
 
-        $this->seedIncident(1, ['host' => 'a']);
-        $this->seedIncident(2, ['host' => 'b']);
+        $this->seedIncident(['host' => 'a']);
+        $this->seedIncident(['host' => 'b']);
 
         $incidents = iterator_to_array(new Incidents([], $db), false);
 
@@ -132,7 +132,7 @@ class IncidentsTest extends TestCase
 
         $this->assertFalse((new Incidents([], $db))->hasIncident());
 
-        $this->seedIncident(1, ['host' => 'a']);
+        $this->seedIncident(['host' => 'a']);
 
         $this->assertTrue((new Incidents([], $db))->hasIncident());
     }
@@ -142,9 +142,9 @@ class IncidentsTest extends TestCase
     {
         $this->db = $db;
 
-        $managed = $this->seedIncident(1, ['host' => 'a']);
-        $subscribed = $this->seedIncident(2, ['host' => 'b']);
-        $foreign = $this->seedIncident(3, ['host' => 'c']);
+        $managed = $this->seedIncident(['host' => 'a']);
+        $subscribed = $this->seedIncident(['host' => 'b']);
+        $foreign = $this->seedIncident(['host' => 'c']);
 
         $jdoe = $this->seedContact('jdoe');
         $this->seedRole($managed, $jdoe, 'manager');
@@ -169,7 +169,7 @@ class IncidentsTest extends TestCase
     {
         $this->db = $db;
 
-        $recovered = $this->seedIncident(1, ['host' => 'a'], 1_700_000_000_000);
+        $recovered = $this->seedIncident(['host' => 'a'], 1_700_000_000_000);
         $this->seedRole($recovered, $this->seedContact('jdoe'), 'manager');
 
         $this->assertSame([], iterator_to_array((new Incidents([], $db))->getRoles(new User('jdoe'))));
@@ -180,7 +180,7 @@ class IncidentsTest extends TestCase
     {
         $this->db = $db;
 
-        $this->seedRole($this->seedIncident(1, ['host' => 'a']), $this->seedContact('jane'), 'manager');
+        $this->seedRole($this->seedIncident(['host' => 'a']), $this->seedContact('jane'), 'manager');
 
         $this->assertSame([], iterator_to_array((new Incidents([], $db))->getRoles(new User('jdoe'))));
     }
@@ -190,7 +190,7 @@ class IncidentsTest extends TestCase
     {
         $this->db = $db;
 
-        $incidentId = $this->seedIncident(1, ['host' => 'a']);
+        $incidentId = $this->seedIncident(['host' => 'a']);
         $this->seedRole($incidentId, $this->seedContact('jane'), 'manager');
         $this->seedRole($incidentId, $this->seedContact('jdoe'), 'subscriber');
         $this->seedRole($incidentId, $this->seedContact('bob'), 'recipient');
@@ -208,8 +208,8 @@ class IncidentsTest extends TestCase
     {
         $this->db = $db;
 
-        $this->seedIncident(1, ['host' => 'a']);
-        $this->seedIncident(2, ['host' => 'b']);
+        $this->seedIncident(['host' => 'a']);
+        $this->seedIncident(['host' => 'b']);
 
         $incidents = new Incidents([], $db);
 
@@ -222,7 +222,7 @@ class IncidentsTest extends TestCase
     {
         $this->db = $db;
 
-        $this->seedIncident(1, ['host' => 'a']);
+        $this->seedIncident(['host' => 'a']);
 
         $this->assertEquals(1, (new Incidents([], $db))->count());
     }
@@ -234,8 +234,8 @@ class IncidentsTest extends TestCase
 
         // A recovered (closed) incident must never be yielded — the integration only deals with open
         // incidents (recovered_at IS NULL).
-        $this->seedIncident(1, ['host' => 'a']);
-        $this->seedIncident(2, ['host' => 'b'], 1_700_000_000_000);
+        $this->seedIncident(['host' => 'a']);
+        $this->seedIncident(['host' => 'b'], 1_700_000_000_000);
 
         $incidents = new Incidents([], $db);
 
@@ -248,9 +248,9 @@ class IncidentsTest extends TestCase
     {
         $this->db = $db;
 
-        $host = $this->seedIncident(1, ['host' => 'a']);
-        $service = $this->seedIncident(1, ['host' => 'a', 'service' => 'http']);
-        $this->seedIncident(1, ['host' => 'b']);
+        $host = $this->seedIncident(['host' => 'a']);
+        $service = $this->seedIncident(['host' => 'a', 'service' => 'http']);
+        $this->seedIncident(['host' => 'b']);
 
         // The host's incident and the one of its service, matched by the tag they have in common
         $this->assertSame(
@@ -340,7 +340,7 @@ class IncidentsTest extends TestCase
     }
 
     /**
-     * Insert an incident for the object identified by the given source and tags, creating the
+     * Insert an incident for the object identified by the given tags, creating the
      * object and object_id_tag rows it relates to so the joins in {@see Incidents::buildQuery()} resolve.
      *
      * @param array<string, string> $tags
@@ -348,11 +348,11 @@ class IncidentsTest extends TestCase
      *
      * @return int The id of the inserted incident
      */
-    private function seedIncident(int $sourceId, array $tags, ?int $recoveredAt = null): int
+    private function seedIncident(array $tags, ?int $recoveredAt = null): int
     {
-        $objectId = $this->objectId($sourceId, $tags);
+        $objectId = $this->objectId($tags);
 
-        $this->seedObject($sourceId, $tags, $objectId);
+        $this->seedObject($tags, $objectId);
 
         $now = (int) (new DateTime())->format('Uv');
 
@@ -401,10 +401,10 @@ class IncidentsTest extends TestCase
     }
 
     /**
-     * Derive a stable, unique object id for the given source and tags
+     * Derive a stable, unique object id for the given tags
      *
      * Stands in for the daemon's object hashing: the exact algorithm is irrelevant to these tests, it
-     * only has to be deterministic and collision-free across distinct (source, tags) combinations so
+     * only has to be deterministic and collision-free for distinct tags so
      * the seeded incident and object_id_tag rows share one id while distinct objects differ.
      *
      * The id is returned in the representation the current database expects for a binary literal, as
@@ -412,11 +412,11 @@ class IncidentsTest extends TestCase
      *
      * @param array<string, string> $tags
      */
-    private function objectId(int $sourceId, array $tags): string
+    private function objectId(array $tags): string
     {
         ksort($tags);
 
-        $hash = hash('sha256', $sourceId . "\0" . serialize($tags));
+        $hash = hash('sha256', serialize($tags));
 
         if ($this->db->getAdapter() instanceof Pgsql) {
             return sprintf('\\x%s', $hash);
@@ -429,33 +429,18 @@ class IncidentsTest extends TestCase
      * Insert the object row and the object_id_tag rows that represent the object for the given tags,
      * unless they already exist — the same object backs every incident sharing its id.
      *
-     * The source the object belongs to is created as well, once per test and source id.
-     *
      * @param array<string, string> $tags
      */
-    private function seedObject(int $sourceId, array $tags, string $objectId): void
+    private function seedObject(array $tags, string $objectId): void
     {
-        if (! isset($this->seededObjects[$sourceId])) {
-            $this->seededObjects[$sourceId] = [];
-
-            $this->db->insert('source', [
-                'id'                => $sourceId,
-                'type'              => 'test',
-                'name'              => 'test',
-                'listener_username' => sprintf('test_%d', $sourceId),
-                'changed_at'        => (int) (new DateTime())->format('Uv')
-            ]);
-        }
-
-        if (isset($this->seededObjects[$sourceId][$objectId])) {
+        if (isset($this->seededObjects[$objectId])) {
             return;
         }
 
-        $this->seededObjects[$sourceId][$objectId] = true;
+        $this->seededObjects[$objectId] = true;
 
         $this->db->insert('object', [
             'id'        => $objectId,
-            'source_id' => $sourceId,
             'name'      => implode(', ', $tags)
         ]);
 

--- a/test/php/library/Notifications/Repository/ContactGroupRepositoryTest.php
+++ b/test/php/library/Notifications/Repository/ContactGroupRepositoryTest.php
@@ -334,8 +334,7 @@ class ContactGroupRepositoryTest extends TestCase
     {
         $now = (int) (new DateTime())->format('Uv');
         $db->insert('source', ['type' => 'icinga2', 'name' => 'S', 'listener_username' => 'ls', 'changed_at' => $now]);
-        $sourceId = (int) $db->lastInsertId();
-        $db->insert('rule', ['name' => 'R', 'source_id' => $sourceId, 'changed_at' => $now]);
+        $db->insert('rule', ['name' => 'R', 'source_type' => 'icinga2', 'changed_at' => $now]);
         $ruleId = (int) $db->lastInsertId();
 
         return (new EscalationRepository($db))->create(new Escalation(

--- a/test/php/library/Notifications/Repository/ContactGroupRepositoryTest.php
+++ b/test/php/library/Notifications/Repository/ContactGroupRepositoryTest.php
@@ -336,8 +336,7 @@ class ContactGroupRepositoryTest extends TestCase
     {
         $now = (int) (new DateTime())->format('Uv');
         $db->insert('source', ['type' => 'icinga2', 'name' => 'S', 'listener_username' => 'ls', 'changed_at' => $now]);
-        $sourceId = (int) $db->lastInsertId();
-        $db->insert('rule', ['name' => 'R', 'source_id' => $sourceId, 'changed_at' => $now]);
+        $db->insert('rule', ['name' => 'R', 'source_type' => 'icinga2', 'changed_at' => $now]);
         $ruleId = (int) $db->lastInsertId();
 
         return (new EscalationRepository($db))->create(new Escalation(

--- a/test/php/library/Notifications/Repository/EscalationRepositoryTest.php
+++ b/test/php/library/Notifications/Repository/EscalationRepositoryTest.php
@@ -28,7 +28,7 @@ use Tests\Icinga\Module\Notifications\Lib\DatabaseUtils;
  * `#[DataProvider('sharedDatabases')]`). Each test runs inside its own transaction which is rolled back afterwards,
  * so its writes don't leak into the next test. A source, channel and contact are seeded per test in
  * {@see self::initializeNotificationsDb()} to satisfy the rule's and the recipients' foreign keys, and their ids
- * captured into {@see self::$sourceId}, {@see self::$channelId} and {@see self::$contactId} (the ids can't be assumed
+ * captured into {@see self::$channelId} and {@see self::$contactId} (the ids can't be assumed
  * as rolled-back transactions still advance the auto-increment).
  *
  * Escalations are unique by `(rule_id, position)`, so each test creates its own throwaway rule and puts its
@@ -45,9 +45,6 @@ class EscalationRepositoryTest extends TestCase
 
     /** @var int Id of the channel seeded per test */
     private static int $channelId;
-
-    /** @var int Id of the source seeded per test, referenced by the rule */
-    private static int $sourceId;
 
     /** @var int Id of the contact group seeded per test, used as a recipient */
     private static int $contactgroupId;
@@ -71,7 +68,6 @@ class EscalationRepositoryTest extends TestCase
         $db->insert('source', [
             'type' => 'icinga2', 'name' => 'Test Source', 'listener_username' => 'test-source', 'changed_at' => $now
         ]);
-        self::$sourceId = (int) $db->lastInsertId();
         $db->insert('contact', [
             'full_name' => 'Test', 'username' => 'test', 'default_channel_id' => self::$channelId,
             'external_uuid' => static::transformUUIDForDB($db, '00000000-0000-0000-0000-0000000000a1'),
@@ -98,7 +94,7 @@ class EscalationRepositoryTest extends TestCase
     private function createRule(Connection $db): int
     {
         $db->insert('rule', [
-            'name' => 'Rule', 'source_id' => self::$sourceId, 'changed_at' => (int) (new DateTime())->format('Uv')
+            'name' => 'Rule', 'source_type' => 'icinga2', 'changed_at' => (int) (new DateTime())->format('Uv')
         ]);
 
         return (int) $db->lastInsertId();

--- a/test/php/library/Notifications/Repository/EscalationRepositoryTest.php
+++ b/test/php/library/Notifications/Repository/EscalationRepositoryTest.php
@@ -28,7 +28,7 @@ use Tests\Icinga\Module\Notifications\Lib\DatabaseUtils;
  * `#[DataProvider('sharedDatabases')]`). Each test runs inside its own transaction which is rolled back afterwards,
  * so its writes don't leak into the next test. A source, channel and contact are seeded per test in
  * {@see self::initializeNotificationsDb()} to satisfy the rule's and the recipients' foreign keys, and their ids
- * captured into {@see self::$sourceId}, {@see self::$channelId} and {@see self::$contactId} (the ids can't be assumed
+ * captured into {@see self::$channelId} and {@see self::$contactId} (the ids can't be assumed
  * as rolled-back transactions still advance the auto-increment).
  *
  * Escalations are unique by `(rule_id, position)`, so each test creates its own throwaway rule and puts its
@@ -45,9 +45,6 @@ class EscalationRepositoryTest extends TestCase
 
     /** @var int Id of the channel seeded per test */
     private static int $channelId;
-
-    /** @var int Id of the source seeded per test, referenced by the rule */
-    private static int $sourceId;
 
     /** @var int Id of the contact group seeded per test, used as a recipient */
     private static int $contactgroupId;
@@ -70,7 +67,6 @@ class EscalationRepositoryTest extends TestCase
         $db->insert('source', [
             'type' => 'icinga2', 'name' => 'Test Source', 'listener_username' => 'test-source', 'changed_at' => $now
         ]);
-        self::$sourceId = (int) $db->lastInsertId();
         $db->insert('contact', [
             'full_name' => 'Test', 'username' => 'test', 'default_channel_id' => self::$channelId,
             'external_uuid' => '00000000-0000-0000-0000-0000000000a1', 'changed_at' => $now
@@ -94,7 +90,7 @@ class EscalationRepositoryTest extends TestCase
     private function createRule(Connection $db): int
     {
         $db->insert('rule', [
-            'name' => 'Rule', 'source_id' => self::$sourceId, 'changed_at' => (int) (new DateTime())->format('Uv')
+            'name' => 'Rule', 'source_type' => 'icinga2', 'changed_at' => (int) (new DateTime())->format('Uv')
         ]);
 
         return (int) $db->lastInsertId();

--- a/test/php/library/Notifications/Repository/EscalationRuleRepositoryTest.php
+++ b/test/php/library/Notifications/Repository/EscalationRuleRepositoryTest.php
@@ -34,7 +34,7 @@ use Tests\Icinga\Module\Notifications\Lib\DatabaseUtils;
  *
  * Each test runs inside its own transaction which is rolled back afterwards, so its writes don't leak into the next
  * test. A source, channel and contact are seeded per test in {@see self::initializeNotificationsDb()} and their ids
- * captured into {@see self::$sourceId}, {@see self::$channelId} and {@see self::$contactId} (the ids can't be assumed
+ * captured into {@see self::$channelId} and {@see self::$contactId} (the ids can't be assumed
  * as rolled-back transactions still advance the auto-increment).
  */
 #[TransactionIsolation]
@@ -42,9 +42,6 @@ class EscalationRuleRepositoryTest extends TestCase
 {
     use DatabaseUtils;
     use DbTestBackends;
-
-    /** @var int Id of the source seeded per test, referenced by the rule */
-    private static int $sourceId;
 
     /** @var int Id of the channel seeded per test */
     private static int $channelId;
@@ -67,7 +64,6 @@ class EscalationRuleRepositoryTest extends TestCase
         $db->insert('source', [
             'type' => 'icinga2', 'name' => 'Test Source', 'listener_username' => 'test-source', 'changed_at' => $now
         ]);
-        self::$sourceId = (int) $db->lastInsertId();
         $db->insert('contact', [
             'full_name' => 'Test', 'username' => 'test', 'default_channel_id' => self::$channelId,
             'external_uuid' => '00000000-0000-0000-0000-0000000000a1', 'changed_at' => $now
@@ -125,7 +121,7 @@ class EscalationRuleRepositoryTest extends TestCase
         $id = $repository->create(new EscalationRule(
             null,
             'Create Rule',
-            self::$sourceId,
+            'icinga2',
             'host.name=foo',
             [
                 $this->escalation(null, 0, null),
@@ -136,7 +132,7 @@ class EscalationRuleRepositoryTest extends TestCase
         $rule = $repository->find($id);
         $this->assertNotNull($rule, 'The created rule was not found');
         $this->assertSame('Create Rule', $rule->name);
-        $this->assertEquals(self::$sourceId, $rule->source_id);
+        $this->assertEquals('icinga2', $rule->source_type);
         $this->assertSame('host.name=foo', $rule->object_filter);
         $this->assertFalse($rule->deleted);
 
@@ -163,7 +159,7 @@ class EscalationRuleRepositoryTest extends TestCase
         $id = $repository->create(new EscalationRule(
             null,
             'Update Rule',
-            self::$sourceId,
+            'icinga2',
             null,
             [
                 $this->escalation(null, 0, null),
@@ -179,7 +175,7 @@ class EscalationRuleRepositoryTest extends TestCase
         $repository->update(new EscalationRule(
             $id,
             'Renamed Rule',
-            self::$sourceId,
+            'icinga2',
             'service.name=bar',
             [
                 $this->escalation($keptId, 0, 'incident_severity>=warning'),
@@ -212,7 +208,7 @@ class EscalationRuleRepositoryTest extends TestCase
     {
         $this->expectException(InvalidArgumentException::class);
 
-        (new EscalationRuleRepository($db))->update(new EscalationRule(999, 'Nope', self::$sourceId, null, []));
+        (new EscalationRuleRepository($db))->update(new EscalationRule(999, 'Nope', 'icinga2', null, []));
     }
 
     #[DataProvider('sharedDatabases')]
@@ -223,7 +219,7 @@ class EscalationRuleRepositoryTest extends TestCase
         $id = $repository->create(new EscalationRule(
             null,
             'Delete Rule',
-            self::$sourceId,
+            'icinga2',
             null,
             [$this->escalation(null, 0, null)]
         ));
@@ -258,7 +254,7 @@ class EscalationRuleRepositoryTest extends TestCase
         $id = $repository->create(new EscalationRule(
             null,
             'Rule',
-            self::$sourceId,
+            'icinga2',
             null,
             [
                 $this->escalation(null, 0, 'first'),
@@ -276,7 +272,7 @@ class EscalationRuleRepositoryTest extends TestCase
         $repository->update(new EscalationRule(
             $id,
             'Rule',
-            self::$sourceId,
+            'icinga2',
             null,
             [$this->escalation($survivorId, 0, 'second')]
         ));

--- a/test/php/library/Notifications/Repository/EscalationRuleRepositoryTest.php
+++ b/test/php/library/Notifications/Repository/EscalationRuleRepositoryTest.php
@@ -34,7 +34,7 @@ use Tests\Icinga\Module\Notifications\Lib\DatabaseUtils;
  *
  * Each test runs inside its own transaction which is rolled back afterwards, so its writes don't leak into the next
  * test. A source, channel and contact are seeded per test in {@see self::initializeNotificationsDb()} and their ids
- * captured into {@see self::$sourceId}, {@see self::$channelId} and {@see self::$contactId} (the ids can't be assumed
+ * captured into {@see self::$channelId} and {@see self::$contactId} (the ids can't be assumed
  * as rolled-back transactions still advance the auto-increment).
  */
 #[TransactionIsolation]
@@ -42,9 +42,6 @@ class EscalationRuleRepositoryTest extends TestCase
 {
     use DatabaseUtils;
     use DbTestBackends;
-
-    /** @var int Id of the source seeded per test, referenced by the rule */
-    private static int $sourceId;
 
     /** @var int Id of the channel seeded per test */
     private static int $channelId;
@@ -68,7 +65,6 @@ class EscalationRuleRepositoryTest extends TestCase
         $db->insert('source', [
             'type' => 'icinga2', 'name' => 'Test Source', 'listener_username' => 'test-source', 'changed_at' => $now
         ]);
-        self::$sourceId = (int) $db->lastInsertId();
         $db->insert('contact', [
             'full_name' => 'Test', 'username' => 'test', 'default_channel_id' => self::$channelId,
             'external_uuid' => static::transformUUIDForDB($db, '00000000-0000-0000-0000-0000000000a1'),
@@ -127,7 +123,7 @@ class EscalationRuleRepositoryTest extends TestCase
         $id = $repository->create(new EscalationRule(
             null,
             'Create Rule',
-            self::$sourceId,
+            'icinga2',
             'host.name=foo',
             [
                 $this->escalation(null, 0, null),
@@ -138,7 +134,7 @@ class EscalationRuleRepositoryTest extends TestCase
         $rule = $repository->find($id);
         $this->assertNotNull($rule, 'The created rule was not found');
         $this->assertSame('Create Rule', $rule->name);
-        $this->assertEquals(self::$sourceId, $rule->source_id);
+        $this->assertEquals('icinga2', $rule->source_type);
         $this->assertSame('host.name=foo', $rule->object_filter);
         $this->assertFalse($rule->deleted);
 
@@ -165,7 +161,7 @@ class EscalationRuleRepositoryTest extends TestCase
         $id = $repository->create(new EscalationRule(
             null,
             'Update Rule',
-            self::$sourceId,
+            'icinga2',
             null,
             [
                 $this->escalation(null, 0, null),
@@ -181,7 +177,7 @@ class EscalationRuleRepositoryTest extends TestCase
         $repository->update(new EscalationRule(
             $id,
             'Renamed Rule',
-            self::$sourceId,
+            'icinga2',
             'service.name=bar',
             [
                 $this->escalation($keptId, 0, 'incident_severity>=warning'),
@@ -214,7 +210,7 @@ class EscalationRuleRepositoryTest extends TestCase
     {
         $this->expectException(InvalidArgumentException::class);
 
-        (new EscalationRuleRepository($db))->update(new EscalationRule(999, 'Nope', self::$sourceId, null, []));
+        (new EscalationRuleRepository($db))->update(new EscalationRule(999, 'Nope', 'icinga2', null, []));
     }
 
     #[DataProvider('sharedDatabases')]
@@ -225,7 +221,7 @@ class EscalationRuleRepositoryTest extends TestCase
         $id = $repository->create(new EscalationRule(
             null,
             'Delete Rule',
-            self::$sourceId,
+            'icinga2',
             null,
             [$this->escalation(null, 0, null)]
         ));
@@ -260,7 +256,7 @@ class EscalationRuleRepositoryTest extends TestCase
         $id = $repository->create(new EscalationRule(
             null,
             'Rule',
-            self::$sourceId,
+            'icinga2',
             null,
             [
                 $this->escalation(null, 0, 'first'),
@@ -278,7 +274,7 @@ class EscalationRuleRepositoryTest extends TestCase
         $repository->update(new EscalationRule(
             $id,
             'Rule',
-            self::$sourceId,
+            'icinga2',
             null,
             [$this->escalation($survivorId, 0, 'second')]
         ));

--- a/test/php/library/Notifications/Repository/ScheduleRepositoryTest.php
+++ b/test/php/library/Notifications/Repository/ScheduleRepositoryTest.php
@@ -153,8 +153,7 @@ class ScheduleRepositoryTest extends TestCase
     {
         $now = (int) (new DateTime())->format('Uv');
         $db->insert('source', ['type' => 'icinga2', 'name' => 'S', 'listener_username' => 'ls', 'changed_at' => $now]);
-        $sourceId = (int) $db->lastInsertId();
-        $db->insert('rule', ['name' => 'R', 'source_id' => $sourceId, 'changed_at' => $now]);
+        $db->insert('rule', ['name' => 'R', 'source_type' => 'icinga2', 'changed_at' => $now]);
         $ruleId = (int) $db->lastInsertId();
 
         return (new EscalationRepository($db))->create(new Escalation(

--- a/test/php/library/Notifications/Repository/ScheduleRepositoryTest.php
+++ b/test/php/library/Notifications/Repository/ScheduleRepositoryTest.php
@@ -149,8 +149,7 @@ class ScheduleRepositoryTest extends TestCase
     {
         $now = (int) (new DateTime())->format('Uv');
         $db->insert('source', ['type' => 'icinga2', 'name' => 'S', 'listener_username' => 'ls', 'changed_at' => $now]);
-        $sourceId = (int) $db->lastInsertId();
-        $db->insert('rule', ['name' => 'R', 'source_id' => $sourceId, 'changed_at' => $now]);
+        $db->insert('rule', ['name' => 'R', 'source_type' => 'icinga2', 'changed_at' => $now]);
         $ruleId = (int) $db->lastInsertId();
 
         return (new EscalationRepository($db))->create(new Escalation(

--- a/test/php/library/Notifications/Repository/SourceRepositoryTest.php
+++ b/test/php/library/Notifications/Repository/SourceRepositoryTest.php
@@ -317,20 +317,40 @@ class SourceRepositoryTest extends TestCase
     }
 
     #[DataProvider('sharedDatabases')]
-    public function testDeleteSoftDeletesLinkedRules(Connection $db): void
+    public function testDeleteSoftDeletesLinkedRulesOnlyIfTheSourceIsTheLastOfItsType(Connection $db): void
     {
-        $sourceId = $this->insertSource($db, 'with-rule');
+        $sourceId = $this->insertSource($db, 'icingadb1');
+        $sourceId2 = $this->insertSource($db, 'icingadb2');
         $db->insert('rule', [
-            'name' => 'Linked Rule', 'source_id' => $sourceId, 'changed_at' => (int) (new DateTime())->format('Uv')
+            'name' => 'Linked Rule', 'source_type' => 'icingadb', 'changed_at' => (int) (new DateTime())->format('Uv')
         ]);
         $ruleId = (int) $db->lastInsertId();
+        $db->insert('rule', [
+            'name' => 'Unaffected Rule', 'source_type' => 'test', 'changed_at' => (int) (new DateTime())->format('Uv')
+        ]);
+        $unaffectedRuleId = (int) $db->lastInsertId();
 
         (new SourceRepository($db))->delete($sourceId);
 
-        // The linked rule is soft-deleted along with the source
+        $rule = $this->loadRawEntity($db, $ruleId, Rule::class);
+        $this->assertSame('n', $rule->deleted, 'The rule must not be deleted if a source of its type still exists');
+
+        (new SourceRepository($db))->delete($sourceId2);
+
+        // The linked rule is soft-deleted along with last source of its type
         $rule = $this->loadRawEntity($db, $ruleId, Rule::class);
         $this->assertNotNull($rule, 'The rule row should still exist');
-        $this->assertSame('y', $rule->deleted, 'The linked rule must be soft-deleted with the source');
+        $this->assertSame(
+            'y',
+            $rule->deleted,
+            'The rule must be soft-deleted when the last source of its type is deleted'
+        );
+
+        $this->assertSame(
+            'n',
+            $this->loadRawEntity($db, $unaffectedRuleId, Rule::class)->deleted,
+            'Rules of other sources must not be affected'
+        );
 
         $this->assertSame(
             'y',

--- a/test/php/library/Notifications/Util/RuleSerializerTest.php
+++ b/test/php/library/Notifications/Util/RuleSerializerTest.php
@@ -12,14 +12,15 @@ use RuntimeException;
 
 class RuleSerializerTest extends TestCase
 {
-    public function testGetJsonIncludesVersionAndQueryString()
+    public function testGetJsonIncludesVersionQueryStringAndAssisted()
     {
         $filter = Filter::equal('a', 'x');
 
-        $result = json_decode((new RuleSerializer($filter, ['a' => ['$.a']]))->getJson(), true);
+        $result = json_decode((new RuleSerializer($filter, ['a' => ['$.a']], true))->getJson(), true);
 
         $this->assertSame(RuleSerializer::VERSION, $result['version']);
         $this->assertSame('a=x', $result['qs']);
+        $this->assertTrue($result['assisted']);
     }
 
     public function testGetJsonSerializesAllChainWithOperatorAndAttributeMapping()
@@ -38,7 +39,7 @@ class RuleSerializerTest extends TestCase
             'column4' => ['$.d'],
         ];
 
-        $result = json_decode((new RuleSerializer($filter, $jsonPaths))->getJson(), true);
+        $result = json_decode((new RuleSerializer($filter, $jsonPaths, false))->getJson(), true);
 
         $this->assertSame('&', $result['ast']['op']);
         $this->assertSame(
@@ -50,6 +51,7 @@ class RuleSerializerTest extends TestCase
             ],
             $result['ast']['rules']
         );
+        $this->assertFalse($result['assisted']);
     }
 
     public function testGetJsonSerializesNoneAndAnyChainsRecursively()
@@ -62,7 +64,7 @@ class RuleSerializerTest extends TestCase
             ),
         );
 
-        $result = json_decode((new RuleSerializer($filter, ['a' => ['$.a']]))->getJson(), true);
+        $result = json_decode((new RuleSerializer($filter, ['a' => ['$.a']], true))->getJson(), true);
 
         $this->assertSame('!', $result['ast']['rules'][0]['op']);
         $this->assertSame('|', $result['ast']['rules'][1]['op']);
@@ -76,7 +78,7 @@ class RuleSerializerTest extends TestCase
             Filter::unlike('a', '*bar[foo]'),
         );
 
-        $result = json_decode((new RuleSerializer($filter, ['a' => ['$.a']]))->getJson(), true);
+        $result = json_decode((new RuleSerializer($filter, ['a' => ['$.a']], true))->getJson(), true);
 
         $this->assertArrayNotHasKey('value', $result['ast']);
         $this->assertSame('^.*foo\\.bar.*$', $result['ast']['rules'][0]['regex']);
@@ -90,12 +92,12 @@ class RuleSerializerTest extends TestCase
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Source hook did not provide a JSON path for column "absent"');
 
-        (new RuleSerializer($filter, []))->getJson();
+        (new RuleSerializer($filter, [], true))->getJson();
     }
 
     public function testGetJsonReturnsNullForEmptyChain()
     {
-        $result = (new RuleSerializer(Filter::all(), []))->getJson();
+        $result = (new RuleSerializer(Filter::all(), [], true))->getJson();
 
         $this->assertNull($result);
     }
@@ -104,7 +106,7 @@ class RuleSerializerTest extends TestCase
     {
         $filter = Filter::equal('a', 'x');
 
-        $result = json_decode((new RuleSerializer($filter, ['a' => ['$.a']], 'my filter'))->getJson(), true);
+        $result = json_decode((new RuleSerializer($filter, ['a' => ['$.a']], true, 'my filter'))->getJson(), true);
 
         $this->assertSame('my filter', $result['filter_name']);
     }
@@ -113,7 +115,7 @@ class RuleSerializerTest extends TestCase
     {
         $filter = Filter::equal('a', 'x');
 
-        $result = json_decode((new RuleSerializer($filter, ['a' => ['$.a']]))->getJson(), true);
+        $result = json_decode((new RuleSerializer($filter, ['a' => ['$.a']], true))->getJson(), true);
 
         $this->assertNotContains('filter_name', $result);
     }


### PR DESCRIPTION
resolve #519 
requires https://github.com/Icinga/icinga-notifications/pull/494

This PR allows escalation rules to be configured for a source type instead of an individual source and allows to display incidents that have more than one related source.

### Rules
For rules the configuration now asks for a source type instead of a source, and the database interaction is adjusted accordingly.
Deleting a source will now check if the source is the last remaining one of its type, and only then delete all escalation rules configured for it. The warning in `DeleteSourceForm` is adjusted to reflect this.

### Incidents
The `IncidentsController` previously eager loaded the `object.source` relation on its incidents, since an object can now be linked to several sources via `object_source`, this is no longer possible as it would duplicate incidents in the list.
To avoid having to lazy load sources for each incident the `SourceAggregator` behavior is added alongside a claude written test for it.

The incidents view now shows the icons of all related source types, and uses the source type as title rather than the name.

The detail view lists all related sources, the object link is created by the first source for which a hook is found.

Similar to the incident queries `Daemon.php` eager loaded the `object.source` relation, but it was unused by the subsequent code so I removed it in that case.

Tests pass locally on mysql with the schema changes introduced in https://github.com/Icinga/icinga-notifications/pull/494