### PR TITLE
Handle UUID's correctly for both DBMs

### DIFF
--- a/library/Notifications/Api/V1/ApiV1.php
+++ b/library/Notifications/Api/V1/ApiV1.php
@@ -15,13 +15,16 @@ use Icinga\Module\Notifications\Api\Exception\InvalidFilterParameterException;
 use Icinga\Module\Notifications\Common\Database;
 use Icinga\Module\Notifications\Common\HttpMethod;
 use Icinga\Util\Json;
+use ipl\Sql\Adapter\Pgsql;
 use ipl\Sql\Compat\FilterProcessor;
+use ipl\Sql\Connection;
 use ipl\Sql\Select;
 use ipl\Stdlib\Filter\Condition;
 use ipl\Web\Filter\QueryString;
 use OpenApi\Attributes as OA;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
+use Ramsey\Uuid\Exception\InvalidArgumentException;
 use Ramsey\Uuid\Uuid;
 use stdClass;
 
@@ -101,6 +104,35 @@ abstract class ApiV1 extends ApiCore
     }
 
     /**
+     * Returns a valid UUID string representation of the given value.
+     *
+     * If the provided value conforms to the UUID string format, it is returned unchanged. Otherwise, it's
+     * treated as the UUID's binary representation and converted into an Uuid instance via Uuid::fromBytes,
+     * it then returns its string format.
+     *
+     * @param string $value
+     *
+     * @return string
+     */
+    protected static function getUUIDString(string $value): string
+    {
+        if (! UUID::isValid($value)) {
+            return Uuid::fromBytes($value)->toString();
+        }
+
+        return $value;
+    }
+
+    protected static function transformUUIDForDB(Connection $db, string $uuid): string
+    {
+        if (! $db->getAdapter() instanceof Pgsql) {
+            return Uuid::fromString($uuid)->getBytes();
+        }
+
+        return $uuid;
+    }
+
+    /**
      * Create a filter from the filter string.
      *
      * @param string $queryFilter
@@ -128,7 +160,11 @@ abstract class ApiV1 extends ApiCore
                         }
 
                         if ($column === 'id') {
-                            if (! Uuid::isValid($condition->getValue())) {
+                            try {
+                                $condition->setValue(
+                                    static::transformUUIDForDB(Database::get(), $condition->getValue())
+                                );
+                            } catch (InvalidArgumentException $_) {
                                 throw new HttpBadRequestException('The given filter id is not a valid UUID');
                             }
 

--- a/library/Notifications/Api/V1/Channels.php
+++ b/library/Notifications/Api/V1/Channels.php
@@ -115,7 +115,7 @@ class Channels extends ApiV1 implements RequestHandlerInterface, EndpointInterfa
             return $this->getPlural($queryFilter, $stmt);
         }
 
-        $stmt->where(['external_uuid = ?' => $identifier]);
+        $stmt->where(['external_uuid = ?' => static::transformUUIDForDB(Database::get(), $identifier)]);
 
         /** @var stdClass|false $result */
         $result = Database::get()->fetchOne($stmt);
@@ -194,7 +194,7 @@ class Channels extends ApiV1 implements RequestHandlerInterface, EndpointInterfa
                 ->from('channel')
                 ->columns('id')
                 ->where([
-                    'external_uuid = ?' => $channelIdentifier,
+                    'external_uuid = ?' => static::transformUUIDForDB(Database::get(), $channelIdentifier),
                     'deleted = ?' => 'n'
                 ])
         );
@@ -227,6 +227,7 @@ class Channels extends ApiV1 implements RequestHandlerInterface, EndpointInterfa
 
     public function prepareRow(stdClass $row): void
     {
+        $row->id = static::getUUIDString($row->id);
         $row->config = Json::decode($row->config, true);
         unset($row->channel_id);
     }

--- a/library/Notifications/Api/V1/ContactGroups.php
+++ b/library/Notifications/Api/V1/ContactGroups.php
@@ -142,7 +142,7 @@ class ContactGroups extends ApiV1 implements RequestHandlerInterface, EndpointIn
             return $this->getPlural($queryFilter, $stmt);
         }
 
-        $stmt->where(['external_uuid = ?' => $identifier]);
+        $stmt->where(['external_uuid = ?' => static::transformUUIDForDB(Database::get(), $identifier)]);
 
         /** @var stdClass|false $result */
         $result = Database::get()->fetchOne($stmt);
@@ -419,7 +419,7 @@ class ContactGroups extends ApiV1 implements RequestHandlerInterface, EndpointIn
      */
     public static function fetchGroupIdentifiers(int $contactId): array
     {
-        return Database::get()->fetchCol(
+        $groupsUUIDs = Database::get()->fetchCol(
             (new Select())
                 ->from('contactgroup_member cgm')
                 ->columns('cg.external_uuid')
@@ -427,6 +427,8 @@ class ContactGroups extends ApiV1 implements RequestHandlerInterface, EndpointIn
                 ->where(['cgm.contact_id = ?' => $contactId, 'cgm.deleted = ?' => 'n'])
                 ->groupBy('cg.external_uuid')
         );
+
+        return array_map(static::getUUIDString(...), $groupsUUIDs);
     }
 
     /**
@@ -444,7 +446,7 @@ class ContactGroups extends ApiV1 implements RequestHandlerInterface, EndpointIn
                 ->from('contactgroup')
                 ->columns('id')
                 ->where([
-                    'external_uuid = ?' => $identifier,
+                    'external_uuid = ?' => static::transformUUIDForDB(Database::get(), $identifier),
                     'deleted = ?' => 'n'
                 ])
         );
@@ -582,6 +584,7 @@ class ContactGroups extends ApiV1 implements RequestHandlerInterface, EndpointIn
 
     public function prepareRow(stdClass $row): void
     {
+        $row->id = static::getUUIDString($row->id);
         $row->users = Contacts::fetchUserIdentifiers($row->contactgroup_id);
 
         unset($row->contactgroup_id);

--- a/library/Notifications/Api/V1/Contacts.php
+++ b/library/Notifications/Api/V1/Contacts.php
@@ -213,7 +213,7 @@ class Contacts extends ApiV1 implements RequestHandlerInterface, EndpointInterfa
             return $this->getPlural($queryFilter, $stmt);
         }
 
-        $stmt->where(['co.external_uuid = ?' => $identifier]);
+        $stmt->where(['co.external_uuid = ?' => static::transformUUIDForDB(Database::get(), $identifier)]);
 
         /** @var stdClass|false $result */
         $result = Database::get()->fetchOne($stmt);
@@ -504,6 +504,8 @@ class Contacts extends ApiV1 implements RequestHandlerInterface, EndpointInterfa
 
     public function prepareRow(stdClass $row): void
     {
+        $row->id = static::getUUIDString($row->id);
+        $row->default_channel = static::getUUIDString($row->default_channel);
         $row->groups = ContactGroups::fetchGroupIdentifiers($row->contact_id);
         $row->addresses = self::fetchContactAddresses($row->contact_id) ?: new stdClass();
 
@@ -548,7 +550,7 @@ class Contacts extends ApiV1 implements RequestHandlerInterface, EndpointInterfa
                 ->from('contact')
                 ->columns('id')
                 ->where([
-                    'external_uuid = ?' => $identifier,
+                    'external_uuid = ?' => static::transformUUIDForDB(Database::get(), $identifier),
                     'deleted = ?' => 'n'
                 ])
         );
@@ -780,7 +782,7 @@ class Contacts extends ApiV1 implements RequestHandlerInterface, EndpointInterfa
      */
     public static function fetchUserIdentifiers(int $contactgroupId): array
     {
-        return Database::get()->fetchCol(
+        $contactsUUIDs = Database::get()->fetchCol(
             (new Select())
                 ->from('contactgroup_member cgm')
                 ->columns('co.external_uuid')
@@ -788,5 +790,7 @@ class Contacts extends ApiV1 implements RequestHandlerInterface, EndpointInterfa
                 ->where(['cgm.contactgroup_id = ?' => $contactgroupId, 'cgm.deleted = ?' => 'n'])
                 ->groupBy('co.external_uuid')
         );
+
+        return array_map(static::getUUIDString(...), $contactsUUIDs);
     }
 }

--- a/library/Notifications/Model/Channel.php
+++ b/library/Notifications/Model/Channel.php
@@ -10,15 +10,17 @@ use Icinga\Module\Notifications\Common\Collection;
 use Icinga\Module\Notifications\Common\Model;
 use ipl\Orm\Behavior\BoolCast;
 use ipl\Orm\Behavior\MillisecondTimestamp;
+use ipl\Orm\Behavior\UUID;
 use ipl\Orm\Behaviors;
 use ipl\Orm\Query;
 use ipl\Orm\Relations;
 use ipl\Stdlib\Filter;
 use ipl\Web\Widget\Icon;
+use Ramsey\Uuid\UuidInterface;
 
 /**
  * @property int $id
- * @property ?string $external_uuid
+ * @property ?UuidInterface $external_uuid
  * @property string $name
  * @property string $type
  * @property ?string $config
@@ -79,6 +81,7 @@ class Channel extends Model
     {
         $behaviors->add(new MillisecondTimestamp(['changed_at']));
         $behaviors->add(new BoolCast(['deleted']));
+        $behaviors->add(new UUID(['external_uuid']));
     }
 
     public function createRelations(Relations $relations): void

--- a/library/Notifications/Model/Contact.php
+++ b/library/Notifications/Model/Contact.php
@@ -10,10 +10,12 @@ use Icinga\Module\Notifications\Common\Collection;
 use Icinga\Module\Notifications\Common\Model;
 use ipl\Orm\Behavior\BoolCast;
 use ipl\Orm\Behavior\MillisecondTimestamp;
+use ipl\Orm\Behavior\UUID;
 use ipl\Orm\Behaviors;
 use ipl\Orm\Query;
 use ipl\Orm\Relations;
 use ipl\Stdlib\Filter;
+use Ramsey\Uuid\UuidInterface;
 
 /**
  * @property int $id
@@ -22,7 +24,7 @@ use ipl\Stdlib\Filter;
  * @property int $default_channel_id
  * @property DateTime $changed_at
  * @property bool $deleted
- * @property ?string $external_uuid
+ * @property ?UuidInterface $external_uuid
  *
  * @property Query<Channel>|Channel $channel
  * @property Query<Incident>|Collection<Incident> $incident
@@ -79,6 +81,7 @@ class Contact extends Model
     {
         $behaviors->add(new MillisecondTimestamp(['changed_at']));
         $behaviors->add(new BoolCast(['deleted']));
+        $behaviors->add(new UUID(['external_uuid']));
     }
 
     public function getDefaultSort(): array

--- a/library/Notifications/Model/Contactgroup.php
+++ b/library/Notifications/Model/Contactgroup.php
@@ -10,10 +10,12 @@ use Icinga\Module\Notifications\Common\Collection;
 use Icinga\Module\Notifications\Common\Model;
 use ipl\Orm\Behavior\BoolCast;
 use ipl\Orm\Behavior\MillisecondTimestamp;
+use ipl\Orm\Behavior\UUID;
 use ipl\Orm\Behaviors;
 use ipl\Orm\Query;
 use ipl\Orm\Relations;
 use ipl\Stdlib\Filter;
+use Ramsey\Uuid\UuidInterface;
 
 /**
  * Contact group
@@ -22,7 +24,7 @@ use ipl\Stdlib\Filter;
  * @property string $name
  * @property DateTime $changed_at
  * @property bool $deleted
- * @property ?string $external_uuid
+ * @property ?UuidInterface $external_uuid
  *
  * @property Query<Contact>|Collection<Contact> $contact
  * @property Query<Rotation>|Collection<Rotation> $rotation
@@ -71,6 +73,7 @@ class Contactgroup extends Model
     {
         $behaviors->add(new MillisecondTimestamp(['changed_at']));
         $behaviors->add(new BoolCast(['deleted']));
+        $behaviors->add(new UUID(['external_uuid']));
     }
 
     public function createRelations(Relations $relations): void

--- a/library/Notifications/Test/BaseApiV1TestCase.php
+++ b/library/Notifications/Test/BaseApiV1TestCase.php
@@ -9,10 +9,12 @@ use DateTime;
 use GuzzleHttp\Client;
 use Icinga\Util\Json;
 use Icinga\Web\Url;
+use ipl\Sql\Adapter\Pgsql;
 use ipl\Sql\Connection;
 use ipl\Sql\Select;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseInterface;
+use Ramsey\Uuid\Uuid;
 
 class BaseApiV1TestCase extends TestCase
 {
@@ -66,14 +68,14 @@ class BaseApiV1TestCase extends TestCase
     protected static function createChannels(Connection $db): void
     {
         $db->insert('channel', [
-            'external_uuid' => self::CHANNEL_UUID,
+            'external_uuid' => static::transformUUIDForDB($db, self::CHANNEL_UUID),
             'name' => 'Test',
             'type' => 'email',
             'changed_at' => (int) (new DateTime())->format("Uv"),
         ]);
 
         $db->insert('channel', [
-            'external_uuid' => self::CHANNEL_UUID_2,
+            'external_uuid' => static::transformUUIDForDB($db, self::CHANNEL_UUID_2),
             'name' => 'Test2',
             'type' => 'webhook',
             'changed_at' => (int) (new DateTime())->format("Uv"),
@@ -82,7 +84,12 @@ class BaseApiV1TestCase extends TestCase
 
     protected static function deleteChannels(Connection $db): void
     {
-        $db->delete('channel', "external_uuid in ('" . self::CHANNEL_UUID . "', '" . self::CHANNEL_UUID_2 . "')");
+        $db->delete('channel', [
+            'external_uuid IN (?)' => [
+                static::transformUUIDForDB($db, self::CHANNEL_UUID),
+                static::transformUUIDForDB($db, self::CHANNEL_UUID_2),
+            ],
+        ]);
     }
 
     protected static function createContacts(Connection $db): void
@@ -91,7 +98,7 @@ class BaseApiV1TestCase extends TestCase
             (new Select())
                 ->from('channel')
                 ->columns(['id'])
-                ->where('external_uuid = ?', self::CHANNEL_UUID)
+                ->where('external_uuid = ?', static::transformUUIDForDB($db, self::CHANNEL_UUID))
                 ->limit(1)
         )->fetchColumn();
 
@@ -99,7 +106,7 @@ class BaseApiV1TestCase extends TestCase
             (new Select())
                 ->from('channel')
                 ->columns(['type'])
-                ->where('external_uuid = ?', self::CHANNEL_UUID)
+                ->where('external_uuid = ?', static::transformUUIDForDB($db, self::CHANNEL_UUID))
                 ->limit(1)
         )->fetchColumn();
 
@@ -107,14 +114,14 @@ class BaseApiV1TestCase extends TestCase
             'full_name' => 'Test',
             'username' => 'test',
             'default_channel_id' => $channelId,
-            'external_uuid' => self::CONTACT_UUID,
+            'external_uuid' => static::transformUUIDForDB($db, self::CONTACT_UUID),
             'changed_at' => (int) (new DateTime())->format("Uv"),
         ]);
         $db->insert('contact', [
             'full_name' => 'Test2',
             'username' => 'test2',
             'default_channel_id' => $channelId,
-            'external_uuid' => self::CONTACT_UUID_2,
+            'external_uuid' => static::transformUUIDForDB($db, self::CONTACT_UUID_2),
             'changed_at' => (int) (new DateTime())->format("Uv"),
         ]);
 
@@ -122,7 +129,12 @@ class BaseApiV1TestCase extends TestCase
             (new Select())
                 ->from('contact')
                 ->columns('id')
-                ->where(['external_uuid IN (?)' => [self::CONTACT_UUID, self::CONTACT_UUID_2]])
+                ->where([
+                    'external_uuid IN (?)' => [
+                        static::transformUUIDForDB($db, self::CONTACT_UUID),
+                        static::transformUUIDForDB($db, self::CONTACT_UUID_2),
+                    ]
+                ])
         )->fetchAll(\PDO::FETCH_COLUMN);
 
         foreach ($contactIds as $contactId) {
@@ -138,26 +150,36 @@ class BaseApiV1TestCase extends TestCase
     protected static function deleteContacts(Connection $db): void
     {
         $db->delete('contact_address');
-        $db->delete('contact', "external_uuid in ('" . self::CONTACT_UUID . "', '" . self::CONTACT_UUID_2 . "')");
+        $db->delete('contact', [
+            'external_uuid IN (?)' => [
+                static::transformUUIDForDB($db, self::CONTACT_UUID),
+                static::transformUUIDForDB($db, self::CONTACT_UUID_2),
+            ]
+        ]);
     }
 
     protected static function createContactGroups(Connection $db): void
     {
         $db->insert('contactgroup', [
             'name' => 'Test',
-            'external_uuid' => self::GROUP_UUID,
+            'external_uuid' => static::transformUUIDForDB($db, self::GROUP_UUID),
             'changed_at' => (int) (new DateTime())->format("Uv"),
         ]);
         $db->insert('contactgroup', [
             'name' => 'Test2',
-            'external_uuid' => self::GROUP_UUID_2,
+            'external_uuid' => static::transformUUIDForDB($db, self::GROUP_UUID_2),
             'changed_at' => (int) (new DateTime())->format("Uv"),
         ]);
     }
 
     protected static function deleteContactGroups(Connection $db): void
     {
-        $db->delete('contactgroup', "external_uuid in ('" . self::GROUP_UUID . "', '" . self::GROUP_UUID_2 . "')");
+        $db->delete('contactgroup', [
+            'external_uuid IN (?)' => [
+                static::transformUUIDForDB($db, self::GROUP_UUID),
+                static::transformUUIDForDB($db, self::GROUP_UUID_2),
+            ],
+        ]);
     }
 
     protected function sendRequest(

--- a/library/Notifications/Test/DbTestBackends.php
+++ b/library/Notifications/Test/DbTestBackends.php
@@ -5,8 +5,10 @@
 
 namespace Icinga\Module\Notifications\Test;
 
+use ipl\Sql\Adapter\Pgsql;
 use ipl\Sql\Connection;
 use ipl\Sql\Test\SharedDatabases;
+use Ramsey\Uuid\Uuid;
 use RuntimeException;
 
 /**
@@ -61,6 +63,15 @@ SQL;
      * @return void
      */
     abstract protected static function initializeNotificationsDb(Connection $db): void;
+
+    protected static function transformUUIDForDB(Connection $db, string $uuid): string
+    {
+        if (! $db->getAdapter() instanceof Pgsql) {
+            return Uuid::fromString($uuid)->getBytes();
+        }
+
+        return $uuid;
+    }
 
     public static function setUpSchema(Connection $db, string $driver): void
     {

--- a/library/Notifications/Util/ObjectSuggestionsCursor.php
+++ b/library/Notifications/Util/ObjectSuggestionsCursor.php
@@ -5,18 +5,47 @@
 
 namespace Icinga\Module\Notifications\Util;
 
+use BackedEnum;
+use DateTime;
+use DateTimeInterface;
+use ipl\Orm\Behaviors;
+use ipl\Sql\Connection;
 use ipl\Sql\Cursor;
+use ipl\Sql\Select;
+use Ramsey\Uuid\UuidInterface;
 
 class ObjectSuggestionsCursor extends Cursor
 {
+    /** @var Behaviors The registered behaviors of the model which we're going to yield results for. */
+    protected Behaviors $behaviors;
+
+    /** @var string The actual property name of the model we're going to yield results for. */
+    protected string $column;
+
+    public function __construct(Connection $db, Select $select, Behaviors $behaviors, string $column)
+    {
+        parent::__construct($db, $select);
+
+        $this->behaviors = $behaviors;
+        $this->column = $column;
+    }
+
     public function getIterator(): \Traversable
     {
         foreach (parent::getIterator() as $key => $value) {
-            // TODO(lippserd): This is a quick and dirty fix for PostgreSQL binary datatypes for which PDO returns
-            // PHP resources that would cause exceptions since resources are not a valid type for attribute values.
-            // We need to do it this way as the suggestion implementation bypasses ORM behaviors here and there.
-            if (is_resource($value)) {
-                $value = stream_get_contents($value);
+            $value = $this->behaviors->retrieveProperty($value, $this->column);
+            if ($value instanceof DateTime) {
+                // The search bar can't handle date time objects, so convert it back to milliseconds again.
+                $value = $value->format(DateTimeInterface::RFC3339_EXTENDED);
+            } elseif ($value instanceof UuidInterface) {
+                $value = (string) $value;
+            } elseif ($value instanceof BackedEnum) {
+                $value = $value->value;
+            } elseif (is_bool($value)) {
+                // Same goes with booleans, the search bar can't render boolean values either.
+                $value = $value ? 'y' : 'n';
+            } elseif (is_string($value) && str_ends_with($this->column, 'id')) {
+                $value = bin2hex($value);
             }
 
             yield $key => $value;

--- a/library/Notifications/Web/Control/SearchBar/ObjectSuggestions.php
+++ b/library/Notifications/Web/Control/SearchBar/ObjectSuggestions.php
@@ -167,7 +167,9 @@ class ObjectSuggestions extends Suggestions
         $this->applyRestrictions($query);
 
         try {
-            return (new ObjectSuggestionsCursor($query->getDb(), $query->assembleSelect()->distinct()))
+            $modelBehaviors = $query->getResolver()->getBehaviors($model);
+            $select = $query->assembleSelect()->distinct();
+            return (new ObjectSuggestionsCursor($query->getDb(), $select, $modelBehaviors, $columnName))
                 ->setFetchMode(PDO::FETCH_COLUMN);
         } catch (InvalidColumnException $e) {
             throw new SearchException(sprintf(t('"%s" is not a valid column'), $e->getColumn()));

--- a/test/php/application/controllers/ApiV1ContactGroupsTest.php
+++ b/test/php/application/controllers/ApiV1ContactGroupsTest.php
@@ -1273,10 +1273,12 @@ YAML;
         $db = $this->getConnection();
 
         $db->delete('contactgroup_member');
-        $db->delete(
-            'contact',
-            "external_uuid NOT IN ('" . self::CONTACT_UUID . "', '" . self::CONTACT_UUID_2 . "')"
-        );
+        $db->delete('contact', [
+            'external_uuid NOT IN (?)' => [
+                static::transformUUIDForDB($db, self::CONTACT_UUID),
+                static::transformUUIDForDB($db, self::CONTACT_UUID_2),
+            ]
+        ]);
         $db->delete('contactgroup');
 
         self::createContactGroups($db);

--- a/test/php/application/controllers/ApiV1ContactsTest.php
+++ b/test/php/application/controllers/ApiV1ContactsTest.php
@@ -2090,7 +2090,7 @@ YAML;
                 ->from('contact_address ca')
                 ->columns(['ca.id', 'ca.changed_at'])
                 ->joinLeft('contact co', 'co.id = ca.contact_id')
-                ->where(['co.external_uuid = ?' => BaseApiV1TestCase::CONTACT_UUID])
+                ->where(['co.external_uuid = ?' => static::transformUUIDForDB($db, BaseApiV1TestCase::CONTACT_UUID)])
         );
         $this->assertCount(1, $addresses, 'The contact should have exactly one seeded address');
 
@@ -2161,10 +2161,12 @@ YAML;
 
         $db->delete('contact_address');
         $db->delete('contactgroup_member');
-        $db->delete(
-            'contactgroup',
-            "external_uuid NOT IN ('" . self::GROUP_UUID . "', '" . self::GROUP_UUID_2 . "')"
-        );
+        $db->delete('contactgroup', [
+            'external_uuid NOT IN (?)' => [
+                static::transformUUIDForDB($db, self::GROUP_UUID),
+                static::transformUUIDForDB($db, self::GROUP_UUID_2),
+            ]
+        ]);
         $db->delete('contact');
 
         self::createContacts($db);

--- a/test/php/library/Notifications/Integrations/IncidentsTest.php
+++ b/test/php/library/Notifications/Integrations/IncidentsTest.php
@@ -62,7 +62,7 @@ class IncidentsTest extends TestCase
             'type' => 'email', 'name' => 'Email', 'version' => '1', 'author' => 'Test', 'config_attrs' => ''
         ]);
         $db->insert('channel', [
-            'external_uuid' => '00000000-0000-0000-0000-0000000000c1',
+            'external_uuid' => static::transformUUIDForDB($db, '00000000-0000-0000-0000-0000000000c1'),
             'name'          => 'Test',
             'type'          => 'email',
             'changed_at'    => (int) (new DateTime())->format('Uv')
@@ -372,7 +372,10 @@ class IncidentsTest extends TestCase
     private function seedContact(string $username): int
     {
         $this->db->insert('contact', [
-            'external_uuid'      => sprintf('00000000-0000-0000-0000-%012x', crc32($username)),
+            'external_uuid'      => static::transformUUIDForDB(
+                $this->db,
+                sprintf('00000000-0000-0000-0000-%012x', crc32($username)),
+            ),
             'full_name'          => $username,
             'username'           => $username,
             'default_channel_id' => self::$channelId,

--- a/test/php/library/Notifications/Repository/ChannelRepositoryTest.php
+++ b/test/php/library/Notifications/Repository/ChannelRepositoryTest.php
@@ -59,7 +59,7 @@ class ChannelRepositoryTest extends TestCase
     private function insertChannel(Connection $db, string $uuid, array $overrides = []): int
     {
         $db->insert('channel', array_merge([
-            'external_uuid'  => $uuid,
+            'external_uuid'  => static::transformUUIDForDB($db, $uuid),
             'name'           => 'Mail',
             'type'           => 'email',
             'changed_at'     => (int) (new DateTime())->format('Uv')

--- a/test/php/library/Notifications/Repository/ContactGroupRepositoryTest.php
+++ b/test/php/library/Notifications/Repository/ContactGroupRepositoryTest.php
@@ -55,7 +55,8 @@ class ContactGroupRepositoryTest extends TestCase
             'type' => 'email', 'name' => 'Email', 'version' => '1', 'author' => 'Test', 'config_attrs' => ''
         ]);
         $db->insert('channel', [
-            'external_uuid' => '00000000-0000-0000-0000-0000000000c1', 'name' => 'Test', 'type' => 'email',
+            'external_uuid' => static::transformUUIDForDB($db, '00000000-0000-0000-0000-0000000000c1'),
+            'name' => 'Test', 'type' => 'email',
             'changed_at' => $now
         ]);
         $channelId = (int) $db->lastInsertId();
@@ -65,7 +66,8 @@ class ContactGroupRepositoryTest extends TestCase
         foreach ([1, 2, 3] as $i) {
             $db->insert('contact', [
                 'full_name' => "Contact $i", 'username' => "contact$i", 'default_channel_id' => $channelId,
-                'external_uuid' => sprintf('00000000-0000-0000-0000-00000000000%d', $i), 'changed_at' => $now
+                'external_uuid' => static::transformUUIDForDB($db, '00000000-0000-0000-0000-00000000000' . $i),
+                'changed_at' => $now
             ]);
             self::$contactIds[] = (int) $db->lastInsertId();
         }
@@ -122,7 +124,7 @@ class ContactGroupRepositoryTest extends TestCase
         $uuid = '00000000-0000-4000-8000-0000000000e1';
         $id = (new ContactGroupRepository($db))->create(new ContactGroupData(null, 'Group A', [], $uuid));
 
-        $this->assertSame($uuid, (new ContactGroupRepository($db))->find($id)->external_uuid);
+        $this->assertSame($uuid, (string) (new ContactGroupRepository($db))->find($id)->external_uuid);
     }
 
     #[DataProvider('sharedDatabases')]

--- a/test/php/library/Notifications/Repository/ContactRepositoryTest.php
+++ b/test/php/library/Notifications/Repository/ContactRepositoryTest.php
@@ -59,7 +59,8 @@ class ContactRepositoryTest extends TestCase
             'type' => 'email', 'name' => 'Email', 'version' => '1', 'author' => 'Test', 'config_attrs' => ''
         ]);
         $db->insert('channel', [
-            'external_uuid' => '00000000-0000-0000-0000-0000000000c1', 'name' => 'Test', 'type' => 'email',
+            'external_uuid' => static::transformUUIDForDB($db, '00000000-0000-0000-0000-0000000000c1'),
+            'name' => 'Test', 'type' => 'email',
             'changed_at' => $now
         ]);
         self::$channelId = (int) $db->lastInsertId();
@@ -196,7 +197,7 @@ class ContactRepositoryTest extends TestCase
             externalUuid: $uuid
         ));
 
-        $this->assertSame($uuid, (new ContactRepository($db))->find($id)->external_uuid);
+        $this->assertSame($uuid, (string) (new ContactRepository($db))->find($id)->external_uuid);
     }
 
     #[DataProvider('sharedDatabases')]

--- a/test/php/library/Notifications/Repository/EscalationRepositoryTest.php
+++ b/test/php/library/Notifications/Repository/EscalationRepositoryTest.php
@@ -63,7 +63,8 @@ class EscalationRepositoryTest extends TestCase
             'type' => 'email', 'name' => 'Email', 'version' => '1', 'author' => 'Test', 'config_attrs' => ''
         ]);
         $db->insert('channel', [
-            'external_uuid' => '00000000-0000-0000-0000-0000000000c1', 'name' => 'Test', 'type' => 'email',
+            'external_uuid' => static::transformUUIDForDB($db, '00000000-0000-0000-0000-0000000000c1'),
+            'name' => 'Test', 'type' => 'email',
             'changed_at' => $now
         ]);
         self::$channelId = (int) $db->lastInsertId();
@@ -73,11 +74,14 @@ class EscalationRepositoryTest extends TestCase
         self::$sourceId = (int) $db->lastInsertId();
         $db->insert('contact', [
             'full_name' => 'Test', 'username' => 'test', 'default_channel_id' => self::$channelId,
-            'external_uuid' => '00000000-0000-0000-0000-0000000000a1', 'changed_at' => $now
+            'external_uuid' => static::transformUUIDForDB($db, '00000000-0000-0000-0000-0000000000a1'),
+            'changed_at' => $now
         ]);
         self::$contactId = (int) $db->lastInsertId();
         $db->insert('contactgroup', [
-            'name' => 'Test Group', 'external_uuid' => '00000000-0000-0000-0000-0000000000b1', 'changed_at' => $now
+            'name' => 'Test Group',
+            'external_uuid' => static::transformUUIDForDB($db, '00000000-0000-0000-0000-0000000000b1'),
+            'changed_at' => $now
         ]);
         self::$contactgroupId = (int) $db->lastInsertId();
         $db->insert('schedule', ['name' => 'Test Schedule', 'timezone' => 'Europe/Berlin', 'changed_at' => $now]);

--- a/test/php/library/Notifications/Repository/EscalationRuleRepositoryTest.php
+++ b/test/php/library/Notifications/Repository/EscalationRuleRepositoryTest.php
@@ -60,7 +60,8 @@ class EscalationRuleRepositoryTest extends TestCase
             'type' => 'email', 'name' => 'Email', 'version' => '1', 'author' => 'Test', 'config_attrs' => ''
         ]);
         $db->insert('channel', [
-            'external_uuid' => '00000000-0000-0000-0000-0000000000c1', 'name' => 'Test', 'type' => 'email',
+            'external_uuid' => static::transformUUIDForDB($db, '00000000-0000-0000-0000-0000000000c1'),
+            'name' => 'Test', 'type' => 'email',
             'changed_at' => $now
         ]);
         self::$channelId = (int) $db->lastInsertId();
@@ -70,7 +71,8 @@ class EscalationRuleRepositoryTest extends TestCase
         self::$sourceId = (int) $db->lastInsertId();
         $db->insert('contact', [
             'full_name' => 'Test', 'username' => 'test', 'default_channel_id' => self::$channelId,
-            'external_uuid' => '00000000-0000-0000-0000-0000000000a1', 'changed_at' => $now
+            'external_uuid' => static::transformUUIDForDB($db, '00000000-0000-0000-0000-0000000000a1'),
+            'changed_at' => $now
         ]);
         self::$contactId = (int) $db->lastInsertId();
     }

--- a/test/php/library/Notifications/Repository/RotationRepositoryTest.php
+++ b/test/php/library/Notifications/Repository/RotationRepositoryTest.php
@@ -52,13 +52,15 @@ class RotationRepositoryTest extends TestCase
             'type' => 'email', 'name' => 'Email', 'version' => '1', 'author' => 'Test', 'config_attrs' => ''
         ]);
         $db->insert('channel', [
-            'external_uuid' => '00000000-0000-0000-0000-0000000000c1', 'name' => 'Test', 'type' => 'email',
+            'external_uuid' => static::transformUUIDForDB($db, '00000000-0000-0000-0000-0000000000c1'),
+            'name' => 'Test', 'type' => 'email',
             'changed_at' => $now
         ]);
         $channelId = (int) $db->lastInsertId();
         $db->insert('contact', [
             'full_name' => 'Test', 'username' => 'test', 'default_channel_id' => $channelId,
-            'external_uuid' => '00000000-0000-0000-0000-0000000000a1', 'changed_at' => $now
+            'external_uuid' => static::transformUUIDForDB($db, '00000000-0000-0000-0000-0000000000a1'),
+            'changed_at' => $now
         ]);
         self::$contactId = (int) $db->lastInsertId();
     }

--- a/test/php/library/Notifications/Repository/ScheduleRepositoryTest.php
+++ b/test/php/library/Notifications/Repository/ScheduleRepositoryTest.php
@@ -57,17 +57,21 @@ class ScheduleRepositoryTest extends TestCase
             'type' => 'email', 'name' => 'Email', 'version' => '1', 'author' => 'Test', 'config_attrs' => ''
         ]);
         $db->insert('channel', [
-            'external_uuid' => '00000000-0000-0000-0000-0000000000c1', 'name' => 'Test', 'type' => 'email',
+            'external_uuid' => static::transformUUIDForDB($db, '00000000-0000-0000-0000-0000000000c1'),
+            'name' => 'Test', 'type' => 'email',
             'changed_at' => $now
         ]);
         $channelId = (int) $db->lastInsertId();
         $db->insert('contact', [
             'full_name' => 'Test', 'username' => 'test', 'default_channel_id' => $channelId,
-            'external_uuid' => '00000000-0000-0000-0000-0000000000a1', 'changed_at' => $now
+            'external_uuid' => static::transformUUIDForDB($db, '00000000-0000-0000-0000-0000000000a1'),
+            'changed_at' => $now
         ]);
         self::$contactId = (int) $db->lastInsertId();
         $db->insert('contactgroup', [
-            'name' => 'Test Group', 'external_uuid' => '00000000-0000-0000-0000-0000000000b1', 'changed_at' => $now
+            'name' => 'Test Group',
+            'external_uuid' => static::transformUUIDForDB($db, '00000000-0000-0000-0000-0000000000b1'),
+            'changed_at' => $now
         ]);
         self::$contactgroupId = (int) $db->lastInsertId();
     }


### PR DESCRIPTION
This PR adds support for UUID binary and text format in all UI activities involving UUIDs. For this to work, I've introduced a new `UUID` behavior in IPL orm that is used to automatically convert UUIDs between binary and text formats for MySQL but is a no-op for PostgreSQL as PDO treats the binary format as a string when not explicitly told otherwise via the `PDO::PARAM_LOB` parameter. Since I've no way to do that parameter binding in all possible cases, I've decided to leave PostgreSQL as-is.

I've also updated the API handlers to partially use the Models instead of raw SQL queries via ipl SQL, so that the UUID can be used in those cases as well. The API handlers are still using raw SQL queries in some places, but I've added an explicit conversion to binary format for those cases, so that the UUIDTransformer is not needed there.

Lastly, I've extended the `ObjectSuggestionsCursor` class to require the column name for which the suggestions are being generated, and the registered model behaviors the column belongs to, so that it also applies the behaviors, including the UUID behavior to the suggestions.

## Context

- https://github.com/Icinga/icinga-notifications/pull/496